### PR TITLE
missing_argument_linter ignores comments

### DIFF
--- a/R/missing_argument_linter.R
+++ b/R/missing_argument_linter.R
@@ -9,9 +9,9 @@ missing_argument_linter <- function(except = c("switch", "alist")) {
     xml <- source_file$full_xml_parsed_content
 
     xpath <- "//expr[expr[SYMBOL_FUNCTION_CALL]]/*[
-      self::OP-COMMA[preceding-sibling::*[1][self::OP-LEFT-PAREN or self::OP-COMMA]] or
-      self::OP-COMMA[following-sibling::*[1][self::OP-RIGHT-PAREN]] or
-      self::EQ_SUB[following-sibling::*[1][self::OP-RIGHT-PAREN or self::OP-COMMA]]
+      self::OP-COMMA[preceding-sibling::*[not(self::COMMENT)][1][self::OP-LEFT-PAREN or self::OP-COMMA]] or
+      self::OP-COMMA[following-sibling::*[not(self::COMMENT)][1][self::OP-RIGHT-PAREN]] or
+      self::EQ_SUB[following-sibling::*[not(self::COMMENT)][1][self::OP-RIGHT-PAREN or self::OP-COMMA]]
     ]"
 
     missing_args <- xml2::xml_find_all(xml, xpath)

--- a/tests/testthat/test-missing_argument_linter.R
+++ b/tests/testthat/test-missing_argument_linter.R
@@ -78,6 +78,9 @@ test_that("returns the correct linting", {
     list(message = rex("Missing argument in function call.")),
     missing_argument_linter(c()))
 
+  # Fixes https://github.com/r-lib/lintr/issues/906
+  # Comments should be ignored so that missing arguments could be
+  # properly identified in these cases.
   expect_lint("fun(
     1,
     2,

--- a/tests/testthat/test-missing_argument_linter.R
+++ b/tests/testthat/test-missing_argument_linter.R
@@ -77,4 +77,28 @@ test_that("returns the correct linting", {
   expect_lint("alist(a =)",
     list(message = rex("Missing argument in function call.")),
     missing_argument_linter(c()))
+
+  expect_lint("fun(
+    1,
+    2,
+    # comment
+    )",
+    list(message = rex("Missing argument in function call.")),
+    missing_argument_linter())
+
+  expect_lint("fun(
+    # comment
+    ,
+    1
+    )",
+    list(message = rex("Missing argument in function call.")),
+    missing_argument_linter())
+
+  expect_lint("fun(
+    a = # comment
+    ,
+    1
+    )",
+    list(message = rex("Missing argument in function call.")),
+    missing_argument_linter())
 })


### PR DESCRIPTION
Closes #906 

This PR makes `missing_argument_linter` ignores `COMMENT` nodes.