### PR TITLE
add a skip for when the test might fail

### DIFF
--- a/tests/testthat/test-object_usage_linter.R
+++ b/tests/testthat/test-object_usage_linter.R
@@ -82,12 +82,12 @@ test_that("returns the correct linting", {
     linter
   )
 
-  # e.g. if the test suite is run after library(dplyr)
-  skip_if(exists("n"))
+  # earlier we used n(1) but this might conflict with dplyr::n(),
+  #   so switch to use an obscure symbol
   expect_lint(
     trim_some("
       fun <- function(x) {
-        n(1)
+        `__lintr_obj`(1)
       }
     "),
     rex("no visible global function definition for ", anything),
@@ -99,7 +99,7 @@ test_that("replace_functions_stripped", {
   expect_lint(
     trim_some("
       fun <- function(x) {
-        n(x) = 1
+        `__lintr_obj`(x) = 1
       }
     "),
     rex("no visible global function definition for ", anything),
@@ -109,7 +109,7 @@ test_that("replace_functions_stripped", {
   expect_lint(
     trim_some("
       fun <- function(x) {
-        n(x) <- 1
+        `__lintr_obj`(x) <- 1
       }
     "),
     rex("no visible global function definition for ", anything),

--- a/tests/testthat/test-object_usage_linter.R
+++ b/tests/testthat/test-object_usage_linter.R
@@ -82,6 +82,8 @@ test_that("returns the correct linting", {
     linter
   )
 
+  # e.g. if the test suite is run after library(dplyr)
+  skip_if(exists("n"))
   expect_lint(
     trim_some("
       fun <- function(x) {


### PR DESCRIPTION
Alternatively we could (1) pick a more obscure function name like `__lintr_missing_fun` (2) loop over the letters and pick the first one that fails `exists()`