### PR TITLE
add a test to ensure inst/lintr/linters.csv is up to date

### DIFF
--- a/R/object_name_linters.R
+++ b/R/object_name_linters.R
@@ -144,7 +144,7 @@ object_lint2 <- function(expr, source_file, message) {
   )
 }
 
-make_object_linter <- function(fun, name = linter_auto_name()) {
+object_linter_factory <- function(fun, name = linter_auto_name()) {
   force(name)
   Linter(function(source_file) {
 
@@ -330,7 +330,7 @@ regexes_rd <- toString(paste0("\\sQuote{", names(style_regexes), "}"))
 #' @seealso [linters] for a complete list of linters available in lintr.
 #' @export
 object_length_linter <- function(length = 30L) {
-  make_object_linter(function(source_file, token) {
+  object_linter_factory(function(source_file, token) {
     if (nchar(token$text) > length) {
         object_lint(
           source_file,

--- a/R/path_linters.R
+++ b/R/path_linters.R
@@ -139,7 +139,7 @@ split_path <- function(path, sep="/|\\\\") {
 }
 
 #' @include utils.R
-make_path_linter <- function(path_function, message, linter, name = linter_auto_name()) {
+path_linter_factory <- function(path_function, message, linter, name = linter_auto_name()) {
   force(name)
   Linter(function(source_file) {
     lapply(
@@ -184,7 +184,7 @@ make_path_linter <- function(path_function, message, linter, name = linter_auto_
 #' @seealso [linters] for a complete list of linters available in lintr.
 #' @export
 absolute_path_linter <- function(lax = TRUE) {
-  make_path_linter(
+  path_linter_factory(
     path_function = function(path) {
       is_absolute_path(path) && is_valid_long_path(path, lax)
     },
@@ -201,7 +201,7 @@ absolute_path_linter <- function(lax = TRUE) {
 #' @seealso [linters] for a complete list of linters available in lintr.
 #' @export
 nonportable_path_linter <- function(lax = TRUE) {
-  make_path_linter(
+  path_linter_factory(
     path_function = function(path) {
       is_path(path) && is_valid_long_path(path, lax) && path != "/" &&
         re_matches(path, rex(one_of("/", "\\")))

--- a/tests/testthat/test-linter_tags.R
+++ b/tests/testthat/test-linter_tags.R
@@ -18,3 +18,8 @@ test_that("default_linters and default tag match up", {
   tagged_default <- avail[["linter"]][vapply(avail[["tags"]], function(tags) "default" %in% tags, logical(1L))]
   expect_setequal(tagged_default, names(default_linters))
 })
+
+test_that("available_linters matches the set of linters available from lintr", {
+  lintr_db <- available_linters()
+  expect_setequal(lintr_db$linter, ls(asNamespace("lintr"), pattern = "_linter$"))
+})

--- a/tests/testthat/test-linter_tags.R
+++ b/tests/testthat/test-linter_tags.R
@@ -21,5 +21,9 @@ test_that("default_linters and default tag match up", {
 
 test_that("available_linters matches the set of linters available from lintr", {
   lintr_db <- available_linters()
-  expect_setequal(lintr_db$linter, ls(asNamespace("lintr"), pattern = "_linter$"))
+  all_linters <- ls(asNamespace("lintr"), pattern = "_linter$")
+  # ensure that the contents of inst/lintr/linters.csv covers all _linter objects in our namespace
+  expect_setequal(lintr_db$linter, all_linters)
+  # ensure that all _linter objects in our namespace are also exported
+  expect_setequal(all_linters, grep("_linter$", getNamespaceExports("lintr"), value = TRUE))
 })


### PR DESCRIPTION
Part of #916

This has been the biggest pain point thus far -- making sure to remember the .csv is in sync as we make edits/rename things. Having this test will at least make it so we fail early.

Renamed the only two `_linter` objects in our namespace that aren't linters; thankfully neither is exported so we don't have to worry much.