### PR TITLE
extend xml_nodes_to_lint for custom messages

### DIFF
--- a/R/T_and_F_symbol_linter.R
+++ b/R/T_and_F_symbol_linter.R
@@ -43,7 +43,7 @@ T_and_F_symbol_linter <- function() { # nolint: object_name_linter.
       xml_nodes_to_lint(
         xml = expr,
         source_file = source_file,
-        message = message,
+        lint_message = message,
         type = "style",
         offset = 1L
       )

--- a/R/equals_na_linter.R
+++ b/R/equals_na_linter.R
@@ -23,7 +23,7 @@ equals_na_linter <- function() {
     bad_expr <- xml2::xml_find_all(xml, xpath)
 
     lapply(bad_expr, xml_nodes_to_lint, source_file,
-           message = "Use is.na for comparisons to NA (not == or !=)",
+           lint_message = "Use is.na for comparisons to NA (not == or !=)",
            type = "warning")
   })
 }

--- a/R/expect_not_linter.R
+++ b/R/expect_not_linter.R
@@ -28,7 +28,7 @@ expect_not_linter <- function() {
       bad_expr,
       xml_nodes_to_lint,
       source_file = source_file,
-      message = "expect_false(x) is better than expect_true(!x), and vice versa.",
+      lint_message = "expect_false(x) is better than expect_true(!x), and vice versa.",
       type = "warning"
     ))
   })

--- a/R/expect_s3_class_linter.R
+++ b/R/expect_s3_class_linter.R
@@ -98,7 +98,7 @@ expect_s4_class_linter <- function() {
       bad_expr,
       xml_nodes_to_lint,
       source_file = source_file,
-      message = paste(
+      lint_message = paste(
         "expect_s4_class(x, k) is better than expect_true(is(x, k)).",
         "Note also expect_s3_class() available for testing S3 objects."
       ),

--- a/R/paren_body_linter.R
+++ b/R/paren_body_linter.R
@@ -34,7 +34,7 @@ paren_body_linter <- function() {
       matched_expressions,
       xml_nodes_to_lint,
       source_file = source_file,
-      message = "There should be a space between right parenthesis and a body expression."
+      lint_message = "There should be a space between right parenthesis and a body expression."
     )
   })
 }

--- a/R/pipe_call_linter.R
+++ b/R/pipe_call_linter.R
@@ -24,7 +24,7 @@ pipe_call_linter <- function() {
       bad_expr,
       xml_nodes_to_lint,
       source_file = source_file,
-      message = "Use explicit calls in magrittr pipes, i.e., `a %>% foo` should be `a %>% foo()`.",
+      lint_message = "Use explicit calls in magrittr pipes, i.e., `a %>% foo` should be `a %>% foo()`.",
       type = "warning"
     ))
   })

--- a/R/spaces_left_parentheses_linter.R
+++ b/R/spaces_left_parentheses_linter.R
@@ -53,7 +53,7 @@ spaces_left_parentheses_linter <- function() {
     bad_paren <- xml2::xml_find_all(xml, xpath)
 
     lapply(bad_paren, xml_nodes_to_lint, source_file,
-           message = "Place a space before left parenthesis, except in a function call.",
+           lint_message = "Place a space before left parenthesis, except in a function call.",
            type = "style", global = global)
   })
 }

--- a/R/xp_utils.R
+++ b/R/xp_utils.R
@@ -4,7 +4,7 @@
 xp_text_in_table <- function(table) paste("text() = ", quote_wrap(table, "'"), collapse = " or ")
 
 # convert an XML match into a Lint
-xml_nodes_to_lint <- function(xml, source_file, message,
+xml_nodes_to_lint <- function(xml, source_file, lint_message,
                               type = c("style", "warning", "error"),
                               offset = 0L,
                               global = FALSE) {
@@ -19,12 +19,13 @@ xml_nodes_to_lint <- function(xml, source_file, message,
   } else {
     col2 <- unname(nchar(source_file[[line_elt]][line1]))
   }
+  if (is.function(lint_message)) lint_message <- lint_message(xml)
   return(Lint(
     filename = source_file$filename,
     line_number = as.integer(line1),
     column_number = as.integer(col1),
     type = type,
-    message = message,
+    message = lint_message,
     line = source_file[[line_elt]][line1],
     ranges = list(c(col1 - offset, col2))
   ))


### PR DESCRIPTION
Part 1 split off from #956 

This way we don't keep accumulating little helper functions to pull out a lint message to pass on to `xml_nodes_to_lint()`

Rename the argument `message=` ➡️ `lint_message=` to avoid writing `message <- message(expr)` which looks like `base::message()`