### PR TITLE
add style guide links for default linters

### DIFF
--- a/R/T_and_F_symbol_linter.R
+++ b/R/T_and_F_symbol_linter.R
@@ -3,7 +3,9 @@
 #' Avoid the symbols `T` and `F` (for `TRUE` and `FALSE`).
 #'
 #' @evalRd rd_tags("T_and_F_symbol_linter")
-#' @seealso [linters] for a complete list of linters available in lintr.
+#' @seealso
+#'   [linters] for a complete list of linters available in lintr. \cr
+#'   <https://style.tidyverse.org/syntax.html#logical-vectors>
 #' @export
 T_and_F_symbol_linter <- function() { # nolint: object_name_linter.
   Linter(function(source_file) {

--- a/R/assignment_linter.R
+++ b/R/assignment_linter.R
@@ -1,6 +1,7 @@
 #' Assignment linter
 #'
 #' Check that `<-` is always used for assignment.
+#'   See <https://style.tidyverse.org/syntax.html#assignment-1>
 #'
 #' @param allow_cascading_assign Logical, default `TRUE`.
 #'   If `FALSE`, [`<<-`][base::assignOps] and `->>` are not allowed.

--- a/R/assignment_linter.R
+++ b/R/assignment_linter.R
@@ -1,13 +1,14 @@
 #' Assignment linter
 #'
 #' Check that `<-` is always used for assignment.
-#'   See <https://style.tidyverse.org/syntax.html#assignment-1>
 #'
 #' @param allow_cascading_assign Logical, default `TRUE`.
 #'   If `FALSE`, [`<<-`][base::assignOps] and `->>` are not allowed.
 #' @param allow_right_assign Logical, default `FALSE`. If `TRUE`, `->` and `->>` are allowed.
 #' @evalRd rd_tags("assignment_linter")
-#' @seealso [linters] for a complete list of linters available in lintr.
+#' @seealso
+#'   [linters] for a complete list of linters available in lintr. \cr
+#'   <https://style.tidyverse.org/syntax.html#assignment-1>
 #' @export
 assignment_linter <- function(allow_cascading_assign = TRUE, allow_right_assign = FALSE) {
   Linter(function(source_file) {

--- a/R/closed_curly_linter.R
+++ b/R/closed_curly_linter.R
@@ -4,7 +4,9 @@
 #'
 #' @param allow_single_line if `TRUE`, allow an open and closed curly pair on the same line.
 #' @evalRd rd_tags("closed_curly_linter")
-#' @seealso [linters] for a complete list of linters available in lintr.
+#' @seealso
+#'   [linters] for a complete list of linters available in lintr. \cr
+#'   <https://style.tidyverse.org/syntax.html#indenting>
 #' @export
 closed_curly_linter <- function(allow_single_line = FALSE) {
   Linter(function(source_file) {
@@ -15,12 +17,14 @@ closed_curly_linter <- function(allow_single_line = FALSE) {
         parsed_content <- source_file[["parsed_content"]]
 
         tokens_before <- parsed_content$token[
-                                              parsed_content$line1 == parsed$line1 &
-                                              parsed_content$col1 < parsed$col1]
+          parsed_content$line1 == parsed$line1 &
+            parsed_content$col1 < parsed$col1
+        ]
 
         tokens_after <- parsed_content$token[
-                                             parsed_content$line1 == parsed$line1 &
-                                             parsed_content$col1 > parsed$col1]
+          parsed_content$line1 == parsed$line1 &
+            parsed_content$col1 > parsed$col1
+        ]
         if (isTRUE(allow_single_line) &&
             "'{'" %in% tokens_before) {
           return()

--- a/R/commas_linter.R
+++ b/R/commas_linter.R
@@ -3,7 +3,9 @@
 #' Check that all commas are followed by spaces, but do not have spaces before them.
 #'
 #' @evalRd rd_tags("commas_linter")
-#' @seealso [linters] for a complete list of linters available in lintr.
+#' @seealso
+#'   [linters] for a complete list of linters available in lintr. \cr
+#'   <https://style.tidyverse.org/syntax.html#commas>
 #' @importFrom utils head
 #' @export
 commas_linter <- function() {

--- a/R/function_brace_linter.R
+++ b/R/function_brace_linter.R
@@ -4,7 +4,9 @@
 #'   that aren't wrapped in braces
 #'
 #' @evalRd rd_tags("function_brace_linter")
-#' @seealso [linters] for a complete list of linters available in lintr.
+#' @seealso
+#'   [linters] for a complete list of linters available in lintr. \cr
+#'   <https://style.tidyverse.org/syntax.html#indenting>
 #' @export
 function_brace_linter <- function() {
   Linter(function(source_file) {

--- a/R/function_left_parentheses.R
+++ b/R/function_left_parentheses.R
@@ -3,7 +3,9 @@
 #' Check that all left parentheses in a function call do not have spaces before them.
 #'
 #' @evalRd rd_tags("function_left_parentheses_linter")
-#' @seealso [linters] for a complete list of linters available in lintr.
+#' @seealso
+#'   [linters] for a complete list of linters available in lintr. \cr
+#'   <https://style.tidyverse.org/syntax.html#parentheses>
 #' @export
 function_left_parentheses_linter <- function() { # nolint: object_length_linter.
   Linter(function(source_file) {

--- a/R/if_else_match_braces_linter.R
+++ b/R/if_else_match_braces_linter.R
@@ -5,7 +5,9 @@
 #'   that either both branches use `{...}` or neither does.
 #'
 #' @evalRd rd_tags("if_else_match_braces_linter")
-#' @seealso [linters] for a complete list of linters available in lintr.
+#' @seealso
+#'   [linters] for a complete list of linters available in lintr. \cr
+#'   <https://style.tidyverse.org/syntax.html#if-statements>
 #' @export
 if_else_match_braces_linter <- function() {
   Linter(function(source_file) {

--- a/R/infix_spaces_linter.R
+++ b/R/infix_spaces_linter.R
@@ -70,7 +70,9 @@ infix_metadata$comparator <- infix_metadata$string_value %in% c("<", "<=", ">", 
 #'   are included/excluded as a group (indicated by passing `"<-"`), as are `->` and `->>` (_viz_, `"->"`),
 #'   and that `=` for assignment and for setting arguments in calls are treated the same.
 #' @evalRd rd_tags("infix_spaces_linter")
-#' @seealso [linters] for a complete list of linters available in lintr.
+#' @seealso
+#'   [linters] for a complete list of linters available in lintr. \cr
+#'   <https://style.tidyverse.org/syntax.html#infix-operators>
 #' @export
 infix_spaces_linter <- function(exclude_operators = NULL) {
   Linter(function(source_file) {

--- a/R/line_length_linter.R
+++ b/R/line_length_linter.R
@@ -4,7 +4,9 @@
 #'
 #' @param length maximum line length allowed.
 #' @evalRd rd_tags("line_length_linter")
-#' @seealso [linters] for a complete list of linters available in lintr.
+#' @seealso
+#'   [linters] for a complete list of linters available in lintr. \cr
+#'   <https://style.tidyverse.org/syntax.html#long-lines>
 #' @export
 line_length_linter <- function(length = 80L) {
   Linter(function(source_file) {

--- a/R/open_curly_linter.R
+++ b/R/open_curly_linter.R
@@ -4,7 +4,9 @@
 #'
 #' @param allow_single_line if `TRUE`, allow an open and closed curly pair on the same line.
 #' @evalRd rd_tags("open_curly_linter")
-#' @seealso [linters] for a complete list of linters available in lintr.
+#' @seealso
+#'   [linters] for a complete list of linters available in lintr. \cr
+#'   <https://style.tidyverse.org/syntax.html#indenting>
 #' @export
 open_curly_linter <- function(allow_single_line = FALSE) {
   Linter(function(source_file) {

--- a/R/paren_body_linter.R
+++ b/R/paren_body_linter.R
@@ -3,7 +3,9 @@
 #' Check that there is a space between right parenthesis and a body expression.
 #'
 #' @evalRd rd_tags("paren_body_linter")
-#' @seealso [linters] for a complete list of linters available in lintr.
+#' @seealso
+#'   [linters] for a complete list of linters available in lintr. \cr
+#'   <https://style.tidyverse.org/syntax.html#parentheses>
 #' @export
 paren_body_linter <- function() {
   Linter(function(source_file) {

--- a/R/pipe_continuation_linter.R
+++ b/R/pipe_continuation_linter.R
@@ -3,7 +3,9 @@
 #' Check that each step in a pipeline is on a new line, or the entire pipe fits on one line.
 #'
 #' @evalRd rd_tags("pipe_continuation_linter")
-#' @seealso [linters] for a complete list of linters available in lintr.
+#' @seealso
+#'   [linters] for a complete list of linters available in lintr. \cr
+#'   <https://style.tidyverse.org/pipes.html#long-lines-2>
 #' @importFrom xml2 xml_find_all as_list
 #' @export
 pipe_continuation_linter <- function() {

--- a/R/semicolon_terminator_linter.R
+++ b/R/semicolon_terminator_linter.R
@@ -8,7 +8,9 @@
 #'   \item{trailing}{Semicolons following the last statement on the line.}
 #' }
 #' @evalRd rd_tags("semicolon_terminator_linter")
-#' @seealso [linters] for a complete list of linters available in lintr.
+#' @seealso
+#'   [linters] for a complete list of linters available in lintr. \cr
+#'   <https://style.tidyverse.org/syntax.html#semicolons>
 #' @export
 semicolon_terminator_linter <- function(semicolon = c("compound", "trailing")) {
   Linter(function(source_file) {

--- a/R/single_quotes_linter.R
+++ b/R/single_quotes_linter.R
@@ -3,7 +3,9 @@
 #' Check that only double quotes are used to delimit string constants.
 #'
 #' @evalRd rd_tags("single_quotes_linter")
-#' @seealso [linters] for a complete list of linters available in lintr.
+#' @seealso
+#'   [linters] for a complete list of linters available in lintr. \cr
+#'   <https://style.tidyverse.org/syntax.html#character-vectors>
 #' @export
 single_quotes_linter <- function() {
   Linter(function(source_file) {

--- a/R/spaces_inside_linter.R
+++ b/R/spaces_inside_linter.R
@@ -4,7 +4,9 @@
 #' opening delimiter or directly preceding a closing delimiter.
 #'
 #' @evalRd rd_tags("spaces_inside_linter")
-#' @seealso [linters] for a complete list of linters available in lintr.
+#' @seealso
+#'   [linters] for a complete list of linters available in lintr. \cr
+#'   <https://style.tidyverse.org/syntax.html#parentheses>
 #' @export
 spaces_inside_linter <- function() {
   Linter(function(source_file) {

--- a/R/spaces_left_parentheses_linter.R
+++ b/R/spaces_left_parentheses_linter.R
@@ -3,7 +3,9 @@
 #' Check that all left parentheses have a space before them unless they are in a function call.
 #'
 #' @evalRd rd_tags("spaces_left_parentheses_linter")
-#' @seealso [linters] for a complete list of linters available in lintr.
+#' @seealso
+#'   [linters] for a complete list of linters available in lintr. \cr
+#'   <https://style.tidyverse.org/syntax.html#parentheses>
 #' @export
 spaces_left_parentheses_linter <- function() {
   Linter(function(source_file) {

--- a/R/vector_logic_linter.R
+++ b/R/vector_logic_linter.R
@@ -8,7 +8,7 @@
 #'   [testthat::expect_true()] and [testthat::expect_false()].
 #' @evalRd rd_tags("vector_logic_linter")
 #' @seealso
-#'   [linters] for a complete list of linters available in lintr.
+#'   [linters] for a complete list of linters available in lintr. \cr
 #'   <https://style.tidyverse.org/syntax.html#if-statements>
 #' @export
 vector_logic_linter <- function() {

--- a/man/T_and_F_symbol_linter.Rd
+++ b/man/T_and_F_symbol_linter.Rd
@@ -10,7 +10,8 @@ T_and_F_symbol_linter()
 Avoid the symbols \code{T} and \code{F} (for \code{TRUE} and \code{FALSE}).
 }
 \seealso{
-\link{linters} for a complete list of linters available in lintr.
+\link{linters} for a complete list of linters available in lintr. \cr
+\url{https://style.tidyverse.org/syntax.html#logical-vectors}
 }
 \section{Tags}{
 \link[=best_practices_linters]{best_practices}, \link[=consistency_linters]{consistency}, \link[=default_linters]{default}, \link[=readability_linters]{readability}, \link[=robustness_linters]{robustness}, \link[=style_linters]{style}

--- a/man/assignment_linter.Rd
+++ b/man/assignment_linter.Rd
@@ -16,7 +16,8 @@ If \code{FALSE}, \code{\link[base:assignOps]{<<-}} and \verb{->>} are not allowe
 Check that \verb{<-} is always used for assignment.
 }
 \seealso{
-\link{linters} for a complete list of linters available in lintr.
+\link{linters} for a complete list of linters available in lintr. \cr
+\url{https://style.tidyverse.org/syntax.html#assignment-1}
 }
 \section{Tags}{
 \link[=consistency_linters]{consistency}, \link[=default_linters]{default}, \link[=style_linters]{style}

--- a/man/closed_curly_linter.Rd
+++ b/man/closed_curly_linter.Rd
@@ -13,7 +13,8 @@ closed_curly_linter(allow_single_line = FALSE)
 Check that closed curly braces are on their own line unless they follow an else.
 }
 \seealso{
-\link{linters} for a complete list of linters available in lintr.
+\link{linters} for a complete list of linters available in lintr. \cr
+\url{https://style.tidyverse.org/syntax.html#indenting}
 }
 \section{Tags}{
 \link[=configurable_linters]{configurable}, \link[=default_linters]{default}, \link[=readability_linters]{readability}, \link[=style_linters]{style}

--- a/man/commas_linter.Rd
+++ b/man/commas_linter.Rd
@@ -10,7 +10,8 @@ commas_linter()
 Check that all commas are followed by spaces, but do not have spaces before them.
 }
 \seealso{
-\link{linters} for a complete list of linters available in lintr.
+\link{linters} for a complete list of linters available in lintr. \cr
+\url{https://style.tidyverse.org/syntax.html#commas}
 }
 \section{Tags}{
 \link[=default_linters]{default}, \link[=readability_linters]{readability}, \link[=style_linters]{style}

--- a/man/function_brace_linter.Rd
+++ b/man/function_brace_linter.Rd
@@ -11,7 +11,8 @@ This linter catches function definitions spanning multiple lines of code
 that aren't wrapped in braces
 }
 \seealso{
-\link{linters} for a complete list of linters available in lintr.
+\link{linters} for a complete list of linters available in lintr. \cr
+\url{https://style.tidyverse.org/syntax.html#indenting}
 }
 \section{Tags}{
 \link[=default_linters]{default}, \link[=readability_linters]{readability}, \link[=style_linters]{style}

--- a/man/function_left_parentheses_linter.Rd
+++ b/man/function_left_parentheses_linter.Rd
@@ -10,7 +10,8 @@ function_left_parentheses_linter()
 Check that all left parentheses in a function call do not have spaces before them.
 }
 \seealso{
-\link{linters} for a complete list of linters available in lintr.
+\link{linters} for a complete list of linters available in lintr. \cr
+\url{https://style.tidyverse.org/syntax.html#parentheses}
 }
 \section{Tags}{
 \link[=default_linters]{default}, \link[=readability_linters]{readability}, \link[=style_linters]{style}

--- a/man/if_else_match_braces_linter.Rd
+++ b/man/if_else_match_braces_linter.Rd
@@ -12,7 +12,8 @@ in \code{{...}} but the \verb{else} branch is not, or vice versa, i.e., it ensur
 that either both branches use \code{{...}} or neither does.
 }
 \seealso{
-\link{linters} for a complete list of linters available in lintr.
+\link{linters} for a complete list of linters available in lintr. \cr
+\url{https://style.tidyverse.org/syntax.html#if-statements}
 }
 \section{Tags}{
 \link[=default_linters]{default}, \link[=readability_linters]{readability}, \link[=style_linters]{style}

--- a/man/infix_spaces_linter.Rd
+++ b/man/infix_spaces_linter.Rd
@@ -19,7 +19,8 @@ Check that infix operators are surrounded by spaces. Enforces the corresponding 
 see \url{https://style.tidyverse.org/syntax.html#infix-operators}.
 }
 \seealso{
-\link{linters} for a complete list of linters available in lintr.
+\link{linters} for a complete list of linters available in lintr. \cr
+\url{https://style.tidyverse.org/syntax.html#infix-operators}
 }
 \section{Tags}{
 \link[=default_linters]{default}, \link[=readability_linters]{readability}, \link[=style_linters]{style}

--- a/man/line_length_linter.Rd
+++ b/man/line_length_linter.Rd
@@ -13,7 +13,8 @@ line_length_linter(length = 80L)
 Check that the line length of both comments and code is less than \code{length}.
 }
 \seealso{
-\link{linters} for a complete list of linters available in lintr.
+\link{linters} for a complete list of linters available in lintr. \cr
+\url{https://style.tidyverse.org/syntax.html#long-lines}
 }
 \section{Tags}{
 \link[=configurable_linters]{configurable}, \link[=default_linters]{default}, \link[=readability_linters]{readability}, \link[=style_linters]{style}

--- a/man/open_curly_linter.Rd
+++ b/man/open_curly_linter.Rd
@@ -13,7 +13,8 @@ open_curly_linter(allow_single_line = FALSE)
 Check that opening curly braces are never on their own line and are always followed by a newline.
 }
 \seealso{
-\link{linters} for a complete list of linters available in lintr.
+\link{linters} for a complete list of linters available in lintr. \cr
+\url{https://style.tidyverse.org/syntax.html#indenting}
 }
 \section{Tags}{
 \link[=configurable_linters]{configurable}, \link[=default_linters]{default}, \link[=readability_linters]{readability}, \link[=style_linters]{style}

--- a/man/paren_body_linter.Rd
+++ b/man/paren_body_linter.Rd
@@ -10,7 +10,8 @@ paren_body_linter()
 Check that there is a space between right parenthesis and a body expression.
 }
 \seealso{
-\link{linters} for a complete list of linters available in lintr.
+\link{linters} for a complete list of linters available in lintr. \cr
+\url{https://style.tidyverse.org/syntax.html#parentheses}
 }
 \section{Tags}{
 \link[=default_linters]{default}, \link[=readability_linters]{readability}, \link[=style_linters]{style}

--- a/man/pipe_continuation_linter.Rd
+++ b/man/pipe_continuation_linter.Rd
@@ -10,7 +10,8 @@ pipe_continuation_linter()
 Check that each step in a pipeline is on a new line, or the entire pipe fits on one line.
 }
 \seealso{
-\link{linters} for a complete list of linters available in lintr.
+\link{linters} for a complete list of linters available in lintr. \cr
+\url{https://style.tidyverse.org/pipes.html#long-lines-2}
 }
 \section{Tags}{
 \link[=default_linters]{default}, \link[=readability_linters]{readability}, \link[=style_linters]{style}

--- a/man/semicolon_terminator_linter.Rd
+++ b/man/semicolon_terminator_linter.Rd
@@ -17,7 +17,8 @@ semicolon_terminator_linter(semicolon = c("compound", "trailing"))
 Check that no semicolons terminate expressions.
 }
 \seealso{
-\link{linters} for a complete list of linters available in lintr.
+\link{linters} for a complete list of linters available in lintr. \cr
+\url{https://style.tidyverse.org/syntax.html#semicolons}
 }
 \section{Tags}{
 \link[=configurable_linters]{configurable}, \link[=default_linters]{default}, \link[=readability_linters]{readability}, \link[=style_linters]{style}

--- a/man/single_quotes_linter.Rd
+++ b/man/single_quotes_linter.Rd
@@ -10,7 +10,8 @@ single_quotes_linter()
 Check that only double quotes are used to delimit string constants.
 }
 \seealso{
-\link{linters} for a complete list of linters available in lintr.
+\link{linters} for a complete list of linters available in lintr. \cr
+\url{https://style.tidyverse.org/syntax.html#character-vectors}
 }
 \section{Tags}{
 \link[=consistency_linters]{consistency}, \link[=default_linters]{default}, \link[=readability_linters]{readability}, \link[=style_linters]{style}

--- a/man/spaces_inside_linter.Rd
+++ b/man/spaces_inside_linter.Rd
@@ -11,7 +11,8 @@ Check that parentheses and square brackets do not have spaces directly inside th
 opening delimiter or directly preceding a closing delimiter.
 }
 \seealso{
-\link{linters} for a complete list of linters available in lintr.
+\link{linters} for a complete list of linters available in lintr. \cr
+\url{https://style.tidyverse.org/syntax.html#parentheses}
 }
 \section{Tags}{
 \link[=default_linters]{default}, \link[=readability_linters]{readability}, \link[=style_linters]{style}

--- a/man/spaces_left_parentheses_linter.Rd
+++ b/man/spaces_left_parentheses_linter.Rd
@@ -10,7 +10,8 @@ spaces_left_parentheses_linter()
 Check that all left parentheses have a space before them unless they are in a function call.
 }
 \seealso{
-\link{linters} for a complete list of linters available in lintr.
+\link{linters} for a complete list of linters available in lintr. \cr
+\url{https://style.tidyverse.org/syntax.html#parentheses}
 }
 \section{Tags}{
 \link[=default_linters]{default}, \link[=readability_linters]{readability}, \link[=style_linters]{style}

--- a/man/vector_logic_linter.Rd
+++ b/man/vector_logic_linter.Rd
@@ -16,7 +16,7 @@ This linter covers inputs to \verb{if()} and \verb{while()} conditions and to
 \code{\link[testthat:logical-expectations]{testthat::expect_true()}} and \code{\link[testthat:logical-expectations]{testthat::expect_false()}}.
 }
 \seealso{
-\link{linters} for a complete list of linters available in lintr.
+\link{linters} for a complete list of linters available in lintr. \cr
 \url{https://style.tidyverse.org/syntax.html#if-statements}
 }
 \section{Tags}{


### PR DESCRIPTION
Closes #911

Any idea how fragile these links are? I guess the CRAN release checklist does URL checking, so we should be able to update stale links at release?

Is it better to add the links in the details (as done here), or to put the link in `@seealso`?