### PR TITLE
fix-up R parser bug in get_source_expressions

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -143,6 +143,7 @@ function calls. (#850, #851, @renkun-ken)
 * `object_name_linter()` now correctly detects assignment generics (#843, @jonkeane)
 * `trailing_whitespace_linter()` now also lints completely blank lines by default. This can be disabled by setting the
   new argument `allow_empty_lines = TRUE` (#1044, @AshesITR)
+* `get_source_expressions()` fixes the `text` value for `STR_CONST` nodes involving 1- or 2-width octal escapes (e.g. `"\1"`) to account for an R parser bug (https://bugs.r-project.org/show_bug.cgi?id=18323)
 
 # lintr 2.0.1
 

--- a/tests/testthat/test-get_source_expressions.R
+++ b/tests/testthat/test-get_source_expressions.R
@@ -168,3 +168,27 @@ test_that("Can extract line number from parser errors", {
     expect_equal(error$line_number, 1L)
   })
 })
+
+test_that("1- or 2-width octal expressions give the right STR_CONST values", {
+  with_content_to_parse("'\\1'", expect_identical(pc[[1L]][2L, "text"], "'\\1'"))
+  with_content_to_parse('"\\1"', expect_identical(pc[[1L]][2L, "text"], '"\\1"'))
+
+  # multiple literals
+  with_content_to_parse("'\\1'\n'\\2'", {
+    expect_identical(pc[[1L]][2L, "text"], "'\\1'")
+    expect_identical(pc[[2L]][2L, "text"], "'\\2'")
+  })
+
+  # multiple escapes
+  with_content_to_parse("'\\1\\2'", expect_identical(pc[[1L]][2L, "text"], "'\\1\\2'"))
+
+  # multi-line strings
+  with_content_to_parse("'\n\\1\n'", expect_identical(pc[[1L]][2L, "text"], "'\n\\1\n'"))
+  with_content_to_parse("a <- '\\1\n\\2'", expect_identical(pc[[1L]][5L, "text"], "'\\1\n\\2'"))
+
+  # mixed-length strings
+  with_content_to_parse("foo('\\1',\n  '\n\\2\n')", {
+    expect_identical(pc[[1L]][5L, "text"], "'\\1'")
+    expect_identical(pc[[1L]][8L, "text"], "'\n\\2\n'")
+  })
+})


### PR DESCRIPTION
Split off from #1032 because in principle it could affect the logic whenever `STR_CONST` is involved (especially, it's probably needed as part of #1034)