### PR TITLE
deprecate open_curly_linter and merge it into brace_linter

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -11,6 +11,7 @@
 * Rename `semicolon_terminator_linter` to `semicolon_linter` for better consistency. `semicolon_terminator_linter` survives but is marked for deprecation. The new linter also has a new signature, taking arguments `allow_compound` and `allow_trailing` to replace the old single argument `semicolon=`, again for signature consistency with other linters.
 * Combined several curly brace related linters into a new `brace_linter` (#1041, @AshesITR):
   + `closed_curly_linter()`
+  + `open_curly_linter()`, no longer linting unnecessary trailing whitespace
   + Require `else` to come on the same line as the preceding `}`, if present (#884, @michaelchirico)
   + Require functions spanning multiple lines to use curly braces (@michaelchirico)
   + Require balanced usage of `{}` in `if`/`else` conditions (@michaelchirico)

--- a/NEWS.md
+++ b/NEWS.md
@@ -12,6 +12,7 @@
 * Combined several curly brace related linters into a new `brace_linter` (#1041, @AshesITR):
   + `closed_curly_linter()`
   + `open_curly_linter()`, no longer linting unnecessary trailing whitespace
+  + `paren_brace_linter()`, also linting `if`/`else` and `repeat` with missing whitespace
   + Require `else` to come on the same line as the preceding `}`, if present (#884, @michaelchirico)
   + Require functions spanning multiple lines to use curly braces (@michaelchirico)
   + Require balanced usage of `{}` in `if`/`else` conditions (@michaelchirico)

--- a/R/brace_linter.R
+++ b/R/brace_linter.R
@@ -2,7 +2,8 @@
 #'
 #' Perform various style checks related to placement and spacing of curly braces:
 #'
-#'  - Curly braces are on their own line unless they are followed by an `else`.
+#'  - Opening curly braces are never on their own line and are always followed by a newline.
+#'  - Closing curly braces are on their own line unless they are followed by an `else`.
 #'  - Closing curly braces in `if` conditions are on the same line as the corresponding `else`.
 #'  - Either both or neither branch in `if`/`else` use curly braces, i.e., either both branches use `{...}` or neither
 #'    does.
@@ -22,6 +23,36 @@ brace_linter <- function(allow_single_line = FALSE) {
     }
 
     lints <- list()
+
+    xp_cond_open <- xp_and(c(
+      # matching } is on same line
+      if (isTRUE(allow_single_line)) {
+        "(@line1 != following-sibling::OP-LEFT-BRACE/@line1)"
+      },
+      # double curly
+      "not(
+        (@line1 = parent::expr/preceding-sibling::OP-LEFT-BRACE/@line1) or
+        (@line1 = following-sibling::expr/OP-LEFT-BRACE/@line1)
+      )"
+    ))
+
+    # TODO (AshesITR): if c_style_braces is TRUE, invert the preceding-sibling condition
+    xp_open_curly <- glue::glue("//OP-LEFT-BRACE[
+      { xp_cond_open } and (
+        not(@line1 = parent::expr/preceding-sibling::*/@line2) or
+        @line1 = following-sibling::*[1][not(self::COMMENT)]/@line1
+      )
+    ]")
+
+    lints <- c(lints, lapply(
+      xml2::xml_find_all(source_expression$xml_parsed_content, xp_open_curly),
+      xml_nodes_to_lint,
+      source_file = source_expression,
+      lint_message = paste(
+        "Opening curly braces should never go on their own line and",
+        "should always be followed by a new line."
+      )
+    ))
 
     xp_cond_closed <- xp_and(c(
       # matching { is on same line

--- a/R/open_curly_linter.R
+++ b/R/open_curly_linter.R
@@ -9,6 +9,7 @@
 #'   <https://style.tidyverse.org/syntax.html#indenting>
 #' @export
 open_curly_linter <- function(allow_single_line = FALSE) {
+  lintr_deprecated("open_curly_linter", new = "brace_linter", version = "2.0.1.9001", type = "Linter")
   Linter(function(source_file) {
     lapply(
       ids_with_token(source_file, "'{'"),

--- a/R/paren_brace_linter.R
+++ b/R/paren_brace_linter.R
@@ -6,6 +6,7 @@
 #' @seealso [linters] for a complete list of linters available in lintr.
 #' @export
 paren_brace_linter <- function() {
+  lintr_deprecated("paren_brace_linter", new = "brace_linter", version = "2.0.1.9001", type = "Linter")
   Linter(function(source_file) {
     if (is.null(source_file$xml_parsed_content)) {
       return(NULL)

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -25,7 +25,6 @@ default_linters <- with_defaults(
   object_length_linter(),
   object_name_linter(),
   object_usage_linter(),
-  open_curly_linter(),
   paren_body_linter(),
   paren_brace_linter(),
   pipe_continuation_linter(),

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -26,7 +26,6 @@ default_linters <- with_defaults(
   object_name_linter(),
   object_usage_linter(),
   paren_body_linter(),
-  paren_brace_linter(),
   pipe_continuation_linter(),
   semicolon_linter(),
   seq_linter(),

--- a/inst/lintr/linters.csv
+++ b/inst/lintr/linters.csv
@@ -43,7 +43,7 @@ numeric_leading_zero_linter,style consistency readability
 object_length_linter,style readability default configurable
 object_name_linter,style consistency default configurable
 object_usage_linter,style readability correctness default
-open_curly_linter,style readability default configurable
+open_curly_linter,style readability configurable
 outer_negation_linter,readability efficiency best_practices
 package_hooks_linter,style correctness package_development
 paren_body_linter,style readability default

--- a/inst/lintr/linters.csv
+++ b/inst/lintr/linters.csv
@@ -47,7 +47,7 @@ open_curly_linter,style readability configurable
 outer_negation_linter,readability efficiency best_practices
 package_hooks_linter,style correctness package_development
 paren_body_linter,style readability default
-paren_brace_linter,style readability default
+paren_brace_linter,style readability
 paste_linter,best_practices consistency
 pipe_call_linter,style readability
 pipe_continuation_linter,style readability default

--- a/man/brace_linter.Rd
+++ b/man/brace_linter.Rd
@@ -15,6 +15,7 @@ Perform various style checks related to placement and spacing of curly braces:
 \details{
 \itemize{
 \item Opening curly braces are never on their own line and are always followed by a newline.
+\item Opening curly braces have a space before them.
 \item Closing curly braces are on their own line unless they are followed by an \verb{else}.
 \item Closing curly braces in \code{if} conditions are on the same line as the corresponding \verb{else}.
 \item Either both or neither branch in \code{if}/\verb{else} use curly braces, i.e., either both branches use \code{{...}} or neither

--- a/man/brace_linter.Rd
+++ b/man/brace_linter.Rd
@@ -14,7 +14,8 @@ Perform various style checks related to placement and spacing of curly braces:
 }
 \details{
 \itemize{
-\item Curly braces are on their own line unless they are followed by an \verb{else}.
+\item Opening curly braces are never on their own line and are always followed by a newline.
+\item Closing curly braces are on their own line unless they are followed by an \verb{else}.
 \item Closing curly braces in \code{if} conditions are on the same line as the corresponding \verb{else}.
 \item Either both or neither branch in \code{if}/\verb{else} use curly braces, i.e., either both branches use \code{{...}} or neither
 does.

--- a/man/default_linters.Rd
+++ b/man/default_linters.Rd
@@ -5,7 +5,7 @@
 \alias{default_linters}
 \title{Default linters}
 \format{
-An object of class \code{list} of length 25.
+An object of class \code{list} of length 24.
 }
 \usage{
 default_linters
@@ -38,7 +38,6 @@ The following linters are tagged with 'default':
 \item{\code{\link{object_name_linter}}}
 \item{\code{\link{object_usage_linter}}}
 \item{\code{\link{paren_body_linter}}}
-\item{\code{\link{paren_brace_linter}}}
 \item{\code{\link{pipe_continuation_linter}}}
 \item{\code{\link{semicolon_linter}}}
 \item{\code{\link{seq_linter}}}

--- a/man/default_linters.Rd
+++ b/man/default_linters.Rd
@@ -5,7 +5,7 @@
 \alias{default_linters}
 \title{Default linters}
 \format{
-An object of class \code{list} of length 26.
+An object of class \code{list} of length 25.
 }
 \usage{
 default_linters
@@ -37,7 +37,6 @@ The following linters are tagged with 'default':
 \item{\code{\link{object_length_linter}}}
 \item{\code{\link{object_name_linter}}}
 \item{\code{\link{object_usage_linter}}}
-\item{\code{\link{open_curly_linter}}}
 \item{\code{\link{paren_body_linter}}}
 \item{\code{\link{paren_brace_linter}}}
 \item{\code{\link{pipe_continuation_linter}}}

--- a/man/linters.Rd
+++ b/man/linters.Rd
@@ -22,7 +22,7 @@ The following tags exist:
 \item{\link[=configurable_linters]{configurable} (18 linters)}
 \item{\link[=consistency_linters]{consistency} (16 linters)}
 \item{\link[=correctness_linters]{correctness} (7 linters)}
-\item{\link[=default_linters]{default} (25 linters)}
+\item{\link[=default_linters]{default} (24 linters)}
 \item{\link[=efficiency_linters]{efficiency} (14 linters)}
 \item{\link[=package_development_linters]{package_development} (14 linters)}
 \item{\link[=readability_linters]{readability} (35 linters)}
@@ -81,7 +81,7 @@ The following linters exist:
 \item{\code{\link{outer_negation_linter}} (tags: best_practices, efficiency, readability)}
 \item{\code{\link{package_hooks_linter}} (tags: correctness, package_development, style)}
 \item{\code{\link{paren_body_linter}} (tags: default, readability, style)}
-\item{\code{\link{paren_brace_linter}} (tags: default, readability, style)}
+\item{\code{\link{paren_brace_linter}} (tags: readability, style)}
 \item{\code{\link{paste_linter}} (tags: best_practices, consistency)}
 \item{\code{\link{pipe_call_linter}} (tags: readability, style)}
 \item{\code{\link{pipe_continuation_linter}} (tags: default, readability, style)}

--- a/man/linters.Rd
+++ b/man/linters.Rd
@@ -22,7 +22,7 @@ The following tags exist:
 \item{\link[=configurable_linters]{configurable} (18 linters)}
 \item{\link[=consistency_linters]{consistency} (16 linters)}
 \item{\link[=correctness_linters]{correctness} (7 linters)}
-\item{\link[=default_linters]{default} (26 linters)}
+\item{\link[=default_linters]{default} (25 linters)}
 \item{\link[=efficiency_linters]{efficiency} (14 linters)}
 \item{\link[=package_development_linters]{package_development} (14 linters)}
 \item{\link[=readability_linters]{readability} (35 linters)}
@@ -77,7 +77,7 @@ The following linters exist:
 \item{\code{\link{object_length_linter}} (tags: configurable, default, readability, style)}
 \item{\code{\link{object_name_linter}} (tags: configurable, consistency, default, style)}
 \item{\code{\link{object_usage_linter}} (tags: correctness, default, readability, style)}
-\item{\code{\link{open_curly_linter}} (tags: configurable, default, readability, style)}
+\item{\code{\link{open_curly_linter}} (tags: configurable, readability, style)}
 \item{\code{\link{outer_negation_linter}} (tags: best_practices, efficiency, readability)}
 \item{\code{\link{package_hooks_linter}} (tags: correctness, package_development, style)}
 \item{\code{\link{paren_body_linter}} (tags: default, readability, style)}

--- a/man/open_curly_linter.Rd
+++ b/man/open_curly_linter.Rd
@@ -17,5 +17,5 @@ Check that opening curly braces are never on their own line and are always follo
 \url{https://style.tidyverse.org/syntax.html#indenting}
 }
 \section{Tags}{
-\link[=configurable_linters]{configurable}, \link[=default_linters]{default}, \link[=readability_linters]{readability}, \link[=style_linters]{style}
+\link[=configurable_linters]{configurable}, \link[=readability_linters]{readability}, \link[=style_linters]{style}
 }

--- a/man/paren_brace_linter.Rd
+++ b/man/paren_brace_linter.Rd
@@ -13,5 +13,5 @@ Check that there is a space between right parentheses and an opening curly brace
 \link{linters} for a complete list of linters available in lintr.
 }
 \section{Tags}{
-\link[=default_linters]{default}, \link[=readability_linters]{readability}, \link[=style_linters]{style}
+\link[=readability_linters]{readability}, \link[=style_linters]{style}
 }

--- a/tests/testthat/test-brace_linter.R
+++ b/tests/testthat/test-brace_linter.R
@@ -10,6 +10,7 @@ test_that("brace_linter lints braces correctly", {
   linter <- brace_linter()
   expect_lint("blah", NULL, linter)
   expect_lint("a <- function() {\n}", NULL, linter)
+  expect_lint("a <- function() {  \n}", NULL, linter)
 
   expect_lint("a <- function() { 1 }", list(open_curly_msg, closed_curly_msg), linter)
   # allowed by allow_single_line

--- a/tests/testthat/test-brace_linter.R
+++ b/tests/testthat/test-brace_linter.R
@@ -1,4 +1,7 @@
-test_that("brace_linter lints closed braces correctly", {
+test_that("brace_linter lints braces correctly", {
+  open_curly_msg <- rex::rex(
+    "Opening curly braces should never go on their own line and should always be followed by a new line."
+  )
   closed_curly_msg <- rex::rex(paste(
     "Closing curly-braces should always be on their own line,",
     "unless they are followed by an else."
@@ -8,7 +11,7 @@ test_that("brace_linter lints closed braces correctly", {
   expect_lint("blah", NULL, linter)
   expect_lint("a <- function() {\n}", NULL, linter)
 
-  expect_lint("a <- function() { 1 }", closed_curly_msg, linter)
+  expect_lint("a <- function() { 1 }", list(open_curly_msg, closed_curly_msg), linter)
   # allowed by allow_single_line
   expect_lint("a <- function() { 1 }", NULL, brace_linter(allow_single_line = TRUE))
 
@@ -47,7 +50,7 @@ test_that("brace_linter lints closed braces correctly", {
   )
 
   # }) is allowed
-  expect_lint("eval(bquote({...}))", NULL, linter)
+  expect_lint("eval(bquote({\n...\n}))", NULL, linter)
 
   # }, is allowed
   expect_lint(
@@ -77,9 +80,39 @@ test_that("brace_linter lints closed braces correctly", {
     linter
   )
 
-  # }} is allowed
+  # {{ }} is allowed
   expect_lint("{{ x }}", NULL, linter)
+
+  expect_lint(
+    trim_some("
+      pkg_name <- function(path = find_package()) {
+        if (is.null(path)) {
+          return(NULL)
+        } else {
+          read.dcf(file.path(path, \"DESCRIPTION\"), fields = \"Package\")[1]
+        }
+      }
+    "),
+    NULL,
+    linter
+  )
+
+  expect_lint("a <- function()\n{\n  1 \n}", open_curly_msg, linter)
+  expect_lint("a <- function()\n    {\n  1 \n}", open_curly_msg, linter)
+  expect_lint("a <- function()\n\t{\n  1 \n}", open_curly_msg, linter)
+
+  # trailing comments are allowed
+  expect_lint(
+    trim_some('
+      if ("P" != "NP") { # what most people expect
+        print("Cryptomania is possible")
+      }
+    '),
+    NULL,
+    linter
+  )
 })
+
 
 test_that("brace_linter lints else correctly", {
   linter <- brace_linter()
@@ -145,8 +178,8 @@ test_that("brace_linter lints function expressions correctly", {
   )
 })
 
-test_that("braces_linter lints if/else matching braces correctly", {
-  linter <- braces_linter()
+test_that("brace_linter lints if/else matching braces correctly", {
+  linter <- brace_linter()
   expect_lint("if (TRUE) 1 else 2", NULL, linter)
   expect_lint("if (TRUE) 1", NULL, linter)
 

--- a/tests/testthat/test-open_curly_linter.R
+++ b/tests/testthat/test-open_curly_linter.R
@@ -1,49 +1,56 @@
 test_that("returns the correct linting", {
+  msg <- rex("Opening curly braces should never go on their own line and should always be followed by a new line.")
 
-  expect_lint("blah", NULL, open_curly_linter())
+  expect_warning(
+    linter <- open_curly_linter(),
+    "Linter open_curly_linter was deprecated",
+    fixed = TRUE
+  )
 
-  expect_lint("a <- function() {\n}", NULL, open_curly_linter())
+  expect_lint("blah", NULL, linter)
+
+  expect_lint("a <- function() {\n}", NULL, linter)
 
   expect_lint(
-"pkg_name <- function(path = find_package()) {
-  if (is.null(path)) {
-    return(NULL)
-  } else {
-    read.dcf(file.path(path, \"DESCRIPTION\"), fields = \"Package\")[1]
-  }
-}", NULL, open_curly_linter())
+    "pkg_name <- function(path = find_package()) {
+      if (is.null(path)) {
+        return(NULL)
+      } else {
+        read.dcf(file.path(path, \"DESCRIPTION\"), fields = \"Package\")[1]
+      }
+    }", NULL, linter)
 
   expect_lint("a <- function()\n{\n  1 \n}",
-    rex("Opening curly braces should never go on their own line and should always be followed by a new line."),
-    open_curly_linter())
+              msg,
+              linter)
 
   expect_lint("a <- function()\n    {\n  1 \n}",
-    rex("Opening curly braces should never go on their own line and should always be followed by a new line."),
-    open_curly_linter())
+              msg,
+              linter)
 
   expect_lint("a <- function()\n\t{\n  1 \n}",
-    rex("Opening curly braces should never go on their own line and should always be followed by a new line."),
-    open_curly_linter())
+              msg,
+              linter)
 
   expect_lint("a <- function() {  \n}",
-    rex("Opening curly braces should never go on their own line and should always be followed by a new line."),
-    open_curly_linter())
+              msg,
+              linter)
 
   expect_lint("a <- function() { 1 }",
-    rex("Opening curly braces should never go on their own line and should always be followed by a new line."),
-    open_curly_linter())
+              msg,
+              linter)
 
   expect_lint("a <- function() { 1 }",
     NULL,
-    open_curly_linter(allow_single_line = TRUE))
+    suppressWarnings(open_curly_linter(allow_single_line = TRUE)))
 
   expect_lint(
 'if ("P" != "NP") { # what most people expect
     print("Cryptomania is possible")
 }',
     NULL,
-    open_curly_linter()
+linter
   )
 
-  expect_lint("{{x}}", NULL, open_curly_linter())
+  expect_lint("{{x}}", NULL, linter)
 })

--- a/tests/testthat/test-paren_brace_linter.R
+++ b/tests/testthat/test-paren_brace_linter.R
@@ -1,5 +1,9 @@
 test_that("returns the correct linting", {
-  linter <- paren_brace_linter()
+  expect_warning(
+    linter <- paren_brace_linter(),
+    "Linter paren_brace_linter was deprecated",
+    fixed = TRUE
+  )
   msg <- rex("There should be a space between right parenthesis and an opening curly brace.")
 
   expect_lint("blah", NULL, linter)


### PR DESCRIPTION
Based against #1095, part of #1041

 - remove open_curly_linter from defaults
 - refactor to XPath based approach
 - no longer lint trailing whitespace (there's a separate linter for that)