### PR TITLE
merge paren_brace_linter into brace_linter

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -12,7 +12,7 @@
 * Combined several curly brace related linters into a new `brace_linter` (#1041, @AshesITR):
   + `closed_curly_linter()`
   + `open_curly_linter()`, no longer linting unnecessary trailing whitespace
-  + `paren_brace_linter()`, also linting if/else and repeat with missing whitespace
+  + `paren_brace_linter()`, also linting `if`/`else` and `repeat` with missing whitespace
   + Require `else` to come on the same line as the preceding `}`, if present (#884, @michaelchirico)
   + Require functions spanning multiple lines to use curly braces (@michaelchirico)
   + Require balanced usage of `{}` in `if`/`else` conditions (@michaelchirico)

--- a/NEWS.md
+++ b/NEWS.md
@@ -12,6 +12,7 @@
 * Combined several curly brace related linters into a new `brace_linter` (#1041, @AshesITR):
   + `closed_curly_linter()`
   + `open_curly_linter()`, no longer linting unnecessary trailing whitespace
+  + `paren_brace_linter()`, also linting if/else and repeat with missing whitespace
   + Require `else` to come on the same line as the preceding `}`, if present (#884, @michaelchirico)
   + Require functions spanning multiple lines to use curly braces (@michaelchirico)
   + Require balanced usage of `{}` in `if`/`else` conditions (@michaelchirico)

--- a/R/paren_brace_linter.R
+++ b/R/paren_brace_linter.R
@@ -6,6 +6,7 @@
 #' @seealso [linters] for a complete list of linters available in lintr.
 #' @export
 paren_brace_linter <- function() {
+  lintr_deprecated("paren_brace_linter", new = "brace_linter", version = "2.0.1.9001", type = "Linter")
   Linter(function(source_file) {
     if (is.null(source_file$xml_parsed_content)) {
       return(NULL)

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -26,7 +26,6 @@ default_linters <- with_defaults(
   object_name_linter(),
   object_usage_linter(),
   paren_body_linter(),
-  paren_brace_linter(),
   pipe_continuation_linter(),
   semicolon_linter(),
   seq_linter(),

--- a/inst/lintr/linters.csv
+++ b/inst/lintr/linters.csv
@@ -47,7 +47,7 @@ open_curly_linter,style readability configurable
 outer_negation_linter,readability efficiency best_practices
 package_hooks_linter,style correctness package_development
 paren_body_linter,style readability default
-paren_brace_linter,style readability default
+paren_brace_linter,style readability
 paste_linter,best_practices consistency
 pipe_call_linter,style readability
 pipe_continuation_linter,style readability default

--- a/man/brace_linter.Rd
+++ b/man/brace_linter.Rd
@@ -15,6 +15,7 @@ Perform various style checks related to placement and spacing of curly braces:
 \details{
 \itemize{
 \item Opening curly braces are never on their own line and are always followed by a newline.
+\item Opening curly braces have a space before them.
 \item Closing curly braces are on their own line unless they are followed by an \verb{else}.
 \item Closing curly braces in \code{if} conditions are on the same line as the corresponding \verb{else}.
 \item Either both or neither branch in \code{if}/\verb{else} use curly braces, i.e., either both branches use \code{{...}} or neither

--- a/man/default_linters.Rd
+++ b/man/default_linters.Rd
@@ -5,7 +5,7 @@
 \alias{default_linters}
 \title{Default linters}
 \format{
-An object of class \code{list} of length 25.
+An object of class \code{list} of length 24.
 }
 \usage{
 default_linters
@@ -38,7 +38,6 @@ The following linters are tagged with 'default':
 \item{\code{\link{object_name_linter}}}
 \item{\code{\link{object_usage_linter}}}
 \item{\code{\link{paren_body_linter}}}
-\item{\code{\link{paren_brace_linter}}}
 \item{\code{\link{pipe_continuation_linter}}}
 \item{\code{\link{semicolon_linter}}}
 \item{\code{\link{seq_linter}}}

--- a/man/linters.Rd
+++ b/man/linters.Rd
@@ -22,7 +22,7 @@ The following tags exist:
 \item{\link[=configurable_linters]{configurable} (18 linters)}
 \item{\link[=consistency_linters]{consistency} (16 linters)}
 \item{\link[=correctness_linters]{correctness} (7 linters)}
-\item{\link[=default_linters]{default} (25 linters)}
+\item{\link[=default_linters]{default} (24 linters)}
 \item{\link[=efficiency_linters]{efficiency} (14 linters)}
 \item{\link[=package_development_linters]{package_development} (14 linters)}
 \item{\link[=readability_linters]{readability} (35 linters)}
@@ -81,7 +81,7 @@ The following linters exist:
 \item{\code{\link{outer_negation_linter}} (tags: best_practices, efficiency, readability)}
 \item{\code{\link{package_hooks_linter}} (tags: correctness, package_development, style)}
 \item{\code{\link{paren_body_linter}} (tags: default, readability, style)}
-\item{\code{\link{paren_brace_linter}} (tags: default, readability, style)}
+\item{\code{\link{paren_brace_linter}} (tags: readability, style)}
 \item{\code{\link{paste_linter}} (tags: best_practices, consistency)}
 \item{\code{\link{pipe_call_linter}} (tags: readability, style)}
 \item{\code{\link{pipe_continuation_linter}} (tags: default, readability, style)}

--- a/man/paren_brace_linter.Rd
+++ b/man/paren_brace_linter.Rd
@@ -13,5 +13,5 @@ Check that there is a space between right parentheses and an opening curly brace
 \link{linters} for a complete list of linters available in lintr.
 }
 \section{Tags}{
-\link[=default_linters]{default}, \link[=readability_linters]{readability}, \link[=style_linters]{style}
+\link[=readability_linters]{readability}, \link[=style_linters]{style}
 }

--- a/tests/testthat/test-paren_brace_linter.R
+++ b/tests/testthat/test-paren_brace_linter.R
@@ -1,5 +1,9 @@
 test_that("returns the correct linting", {
-  linter <- paren_brace_linter()
+  expect_warning(
+    linter <- paren_brace_linter(),
+    "Linter paren_brace_linter was deprecated",
+    fixed = TRUE
+  )
   msg <- rex("There should be a space between right parenthesis and an opening curly brace.")
 
   expect_lint("blah", NULL, linter)


### PR DESCRIPTION
Based against #1096, part of #1041

 * added lints for `else{` and `repeat{` while I was at it.