### PR TITLE
add a tag for deprecated linters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ lintr_*.tar.gz
 testthat-problems.rds
 
 .dev/*.csv
+.dev/.partial

--- a/R/linter_tag_docs.R
+++ b/R/linter_tag_docs.R
@@ -80,3 +80,11 @@ NULL
 #' @evalRd rd_linters("package_development")
 #' @seealso [linters] for a complete list of linters available in lintr.
 NULL
+
+#' Deprecated linters
+#' @name deprecated_linters
+#' @description
+#' Linters that have been deprecated. See NEWS for explanations.
+#' @evalRd rd_linters("deprecated_linters")
+#' @seealso [linters] for a complete list of linters available in lintr.
+

--- a/inst/lintr/linters.csv
+++ b/inst/lintr/linters.csv
@@ -6,7 +6,7 @@ assignment_linter,style consistency default
 backport_linter,robustness configurable package_development
 brace_linter,style readability default configurable
 class_equals_linter,best_practices robustness consistency
-closed_curly_linter,style readability configurable
+closed_curly_linter,style readability configurable deprecated
 commas_linter,style readability default
 commented_code_linter,style readability best_practices default
 condition_message_linter,best_practices consistency
@@ -43,18 +43,18 @@ numeric_leading_zero_linter,style consistency readability
 object_length_linter,style readability default configurable
 object_name_linter,style consistency default configurable
 object_usage_linter,style readability correctness default
-open_curly_linter,style readability configurable
+open_curly_linter,style readability configurable deprecated
 outer_negation_linter,readability efficiency best_practices
 package_hooks_linter,style correctness package_development
 paren_body_linter,style readability default
-paren_brace_linter,style readability
+paren_brace_linter,style readability deprecated
 paste_linter,best_practices consistency
 pipe_call_linter,style readability
 pipe_continuation_linter,style readability default
 redundant_ifelse_linter,best_practices efficiency consistency
 regex_subset_linter,best_practices efficiency
 semicolon_linter,style readability default configurable
-semicolon_terminator_linter,style readability configurable
+semicolon_terminator_linter,style readability configurable deprecated
 seq_linter,robustness efficiency consistency best_practices default
 single_quotes_linter,style consistency readability default
 spaces_inside_linter,style readability default

--- a/man/closed_curly_linter.Rd
+++ b/man/closed_curly_linter.Rd
@@ -17,5 +17,5 @@ Check that closed curly braces are on their own line unless they follow an else.
 \url{https://style.tidyverse.org/syntax.html#indenting}
 }
 \section{Tags}{
-\link[=configurable_linters]{configurable}, \link[=readability_linters]{readability}, \link[=style_linters]{style}
+\link[=configurable_linters]{configurable}, \link[=deprecated_linters]{deprecated}, \link[=readability_linters]{readability}, \link[=style_linters]{style}
 }

--- a/man/linters.Rd
+++ b/man/linters.Rd
@@ -23,6 +23,7 @@ The following tags exist:
 \item{\link[=consistency_linters]{consistency} (16 linters)}
 \item{\link[=correctness_linters]{correctness} (7 linters)}
 \item{\link[=default_linters]{default} (24 linters)}
+\item{\link[=deprecated_linters]{deprecated} (4 linters)}
 \item{\link[=efficiency_linters]{efficiency} (14 linters)}
 \item{\link[=package_development_linters]{package_development} (14 linters)}
 \item{\link[=readability_linters]{readability} (35 linters)}
@@ -40,7 +41,7 @@ The following linters exist:
 \item{\code{\link{backport_linter}} (tags: configurable, package_development, robustness)}
 \item{\code{\link{brace_linter}} (tags: configurable, default, readability, style)}
 \item{\code{\link{class_equals_linter}} (tags: best_practices, consistency, robustness)}
-\item{\code{\link{closed_curly_linter}} (tags: configurable, readability, style)}
+\item{\code{\link{closed_curly_linter}} (tags: configurable, deprecated, readability, style)}
 \item{\code{\link{commas_linter}} (tags: default, readability, style)}
 \item{\code{\link{commented_code_linter}} (tags: best_practices, default, readability, style)}
 \item{\code{\link{condition_message_linter}} (tags: best_practices, consistency)}
@@ -77,18 +78,18 @@ The following linters exist:
 \item{\code{\link{object_length_linter}} (tags: configurable, default, readability, style)}
 \item{\code{\link{object_name_linter}} (tags: configurable, consistency, default, style)}
 \item{\code{\link{object_usage_linter}} (tags: correctness, default, readability, style)}
-\item{\code{\link{open_curly_linter}} (tags: configurable, readability, style)}
+\item{\code{\link{open_curly_linter}} (tags: configurable, deprecated, readability, style)}
 \item{\code{\link{outer_negation_linter}} (tags: best_practices, efficiency, readability)}
 \item{\code{\link{package_hooks_linter}} (tags: correctness, package_development, style)}
 \item{\code{\link{paren_body_linter}} (tags: default, readability, style)}
-\item{\code{\link{paren_brace_linter}} (tags: readability, style)}
+\item{\code{\link{paren_brace_linter}} (tags: deprecated, readability, style)}
 \item{\code{\link{paste_linter}} (tags: best_practices, consistency)}
 \item{\code{\link{pipe_call_linter}} (tags: readability, style)}
 \item{\code{\link{pipe_continuation_linter}} (tags: default, readability, style)}
 \item{\code{\link{redundant_ifelse_linter}} (tags: best_practices, consistency, efficiency)}
 \item{\code{\link{regex_subset_linter}} (tags: best_practices, efficiency)}
 \item{\code{\link{semicolon_linter}} (tags: configurable, default, readability, style)}
-\item{\code{\link{semicolon_terminator_linter}} (tags: configurable, readability, style)}
+\item{\code{\link{semicolon_terminator_linter}} (tags: configurable, deprecated, readability, style)}
 \item{\code{\link{seq_linter}} (tags: best_practices, consistency, default, efficiency, robustness)}
 \item{\code{\link{single_quotes_linter}} (tags: consistency, default, readability, style)}
 \item{\code{\link{spaces_inside_linter}} (tags: default, readability, style)}

--- a/man/open_curly_linter.Rd
+++ b/man/open_curly_linter.Rd
@@ -17,5 +17,5 @@ Check that opening curly braces are never on their own line and are always follo
 \url{https://style.tidyverse.org/syntax.html#indenting}
 }
 \section{Tags}{
-\link[=configurable_linters]{configurable}, \link[=readability_linters]{readability}, \link[=style_linters]{style}
+\link[=configurable_linters]{configurable}, \link[=deprecated_linters]{deprecated}, \link[=readability_linters]{readability}, \link[=style_linters]{style}
 }

--- a/man/paren_brace_linter.Rd
+++ b/man/paren_brace_linter.Rd
@@ -13,5 +13,5 @@ Check that there is a space between right parentheses and an opening curly brace
 \link{linters} for a complete list of linters available in lintr.
 }
 \section{Tags}{
-\link[=readability_linters]{readability}, \link[=style_linters]{style}
+\link[=deprecated_linters]{deprecated}, \link[=readability_linters]{readability}, \link[=style_linters]{style}
 }


### PR DESCRIPTION
Part of #1098 

Any idea why `roxygen2::roxygenize()` isn't creating the `deprecated_linters.Rd` file?