### PR TITLE
de-lint master

### DIFF
--- a/.lintr
+++ b/.lintr
@@ -1,6 +1,7 @@
 linters: with_defaults( # The following TODOs are part of an effort to have {lintr} lint-free (#584)
    line_length_linter = line_length_linter(120),
-   cyclocomp_linter = cyclocomp_linter(28) # TODO reduce to 15
+   # TODO add implicit_integer_linter()
+   cyclocomp_linter = cyclocomp_linter(37) # TODO reduce to 15
  )
 exclusions: list(
   "inst/doc/creating_linters.R" = 1,

--- a/.lintr_new
+++ b/.lintr_new
@@ -1,4 +1,5 @@
 linters: with_defaults(
+    implicit_integer_linter(),
     line_length_linter = line_length_linter(120)
   )
 exclusions: list(

--- a/R/condition_message_linter.R
+++ b/R/condition_message_linter.R
@@ -27,7 +27,10 @@ condition_message_linter <- function() {
     ]")
 
     bad_expr <- xml2::xml_find_all(xml, xpath)
-    sep_value <- get_r_string(xml2::xml_find_first(bad_expr, "./expr/SYMBOL_SUB[text() = 'sep']/following-sibling::expr/STR_CONST"))
+    sep_value <- get_r_string(xml2::xml_find_first(
+      bad_expr,
+      "./expr/SYMBOL_SUB[text() = 'sep']/following-sibling::expr/STR_CONST"
+    ))
 
     lapply(
       bad_expr[is.na(sep_value) | sep_value %in% c("", " ")],

--- a/R/get_source_expressions.R
+++ b/R/get_source_expressions.R
@@ -628,7 +628,9 @@ fix_octal_escapes <- function(pc, lines) {
     out[ii] <- paste(
       c(
         substring(lines[str_const$line1[ii]], str_const$col1[ii]),
-        if (str_const$line1[ii] < str_const$line2[ii] - 1L) lines[(str_const$line1[ii] + 1L):(str_const$line2[ii] - 1L)],
+        if (str_const$line1[ii] < str_const$line2[ii] - 1L) {
+          lines[(str_const$line1[ii] + 1L):(str_const$line2[ii] - 1L)]
+        },
         substr(lines[str_const$line2[ii]], 1L, str_const$col2[ii])
       ),
       collapse = "\n"

--- a/R/get_source_expressions.R
+++ b/R/get_source_expressions.R
@@ -246,16 +246,16 @@ lint_parse_error <- function(e, source_file) {
           options = "multi-line",
           locations = TRUE)
         loc <- loc[!is.na(loc$start) & !is.na(loc$end), ]
-        if (nrow(loc) > 0) {
-          line_location <- loc[1, ]
+        if (nrow(loc) > 0L) {
+          line_location <- loc[1L, ]
         }
       } else {
         # nocov start
         return(
           Lint(
             filename = source_file$filename,
-            line_number = 1,
-            column_number = 1,
+            line_number = 1L,
+            column_number = 1L,
             type = "error",
             message = e$message,
             line = ""
@@ -397,11 +397,13 @@ find_line_fun <- function(content) {
     re_matches(content,
       rex("\n"),
       locations = TRUE,
-      global = TRUE)[[1]]$start
+      global = TRUE
+    )[[1L]]$start
 
   newline_locs <- c(0L,
-    if (!is.na(newline_search[1])) newline_search,
-    nchar(content) + 1L)
+    if (!is.na(newline_search[1L])) newline_search,
+    nchar(content) + 1L
+  )
 
   function(x) {
     which(newline_locs >= x)[1L] - 1L
@@ -413,11 +415,13 @@ find_column_fun <- function(content) {
     re_matches(content,
       rex("\n"),
       locations = TRUE,
-      global = TRUE)[[1]]$start
+      global = TRUE
+    )[[1L]]$start
 
   newline_locs <- c(0L,
-    if (!is.na(newline_search[1])) newline_search,
-    nchar(content) + 1L)
+    if (!is.na(newline_search[1L])) newline_search,
+    nchar(content) + 1L
+  )
 
   function(x) {
     line_number <- which(newline_locs >= x)[1L] - 1L
@@ -457,7 +461,7 @@ fix_tab_indentations <- function(source_file) {
   }
 
   pc_cols <- c("line1", "line2", "col1", "col2")
-  dat <- matrix(data = unlist(pc[, pc_cols], use.names = FALSE), ncol = 2)
+  dat <- matrix(data = unlist(pc[, pc_cols], use.names = FALSE), ncol = 2L)
   lines <- as.integer(names(tab_cols))
   for (i in seq_along(tab_cols)) {
     is_curr_line <- dat[, 1L] == lines[[i]]
@@ -504,8 +508,8 @@ fix_eq_assigns <- function(pc) {
     return(pc)
   }
 
-  prev_locs <- vapply(eq_assign_locs, prev_with_parent, pc = pc, integer(1))
-  next_locs <- vapply(eq_assign_locs, next_with_parent, pc = pc, integer(1))
+  prev_locs <- vapply(eq_assign_locs, prev_with_parent, pc = pc, integer(1L))
+  next_locs <- vapply(eq_assign_locs, next_with_parent, pc = pc, integer(1L))
   expr_locs <- (function(x) {
     x[is.na(x)] <- FALSE
     !x
@@ -601,7 +605,7 @@ next_with_parent <- function(pc, loc) {
 
 top_level_expressions <- function(pc) {
   if (is.null(pc)) {
-    return(integer(0))
+    return(integer(0L))
   }
   which(pc$parent <= 0L)
 }

--- a/R/missing_package_linter.R
+++ b/R/missing_package_linter.R
@@ -33,7 +33,10 @@ missing_package_linter <- function() {
     ]"
 
     pkg_calls <- xml2::xml_find_all(xml, call_xpath)
-    pkg_names <- get_r_string(xml2::xml_find_all(pkg_calls, "OP-LEFT-PAREN[1]/following-sibling::expr[1][SYMBOL | STR_CONST]"))
+    pkg_names <- get_r_string(xml2::xml_find_all(
+      pkg_calls,
+      "OP-LEFT-PAREN[1]/following-sibling::expr[1][SYMBOL | STR_CONST]"
+    ))
 
     installed_packges <- .packages(all.available = TRUE)
     missing_ids <- which(!(pkg_names %in% installed_packges))

--- a/R/object_usage_linter.R
+++ b/R/object_usage_linter.R
@@ -191,22 +191,23 @@ get_function_assignments <- function(xml) {
   # NB: difference across R versions in how EQ_ASSIGN is represented in the AST
   #   (under <expr_or_assign_or_help> or <equal_assign>)
   # TODO(#1106): use //*[...] to capture assignments in more scopes
-  direct_assignment_functions <- xml2::xml_find_all(xml, "
-    *[
-      (
-        (self::expr and (LEFT_ASSIGN or EQ_ASSIGN))
-        or ((self::expr_or_assign_or_help or self::equal_assign) and EQ_ASSIGN)
-      )
-      and expr[2][FUNCTION]
-    ]
-    /expr[2]
-  ")
-  assign_or_setmethod_assignment_functions <-
-    xml2::xml_find_all(xml, "//expr[expr[SYMBOL_FUNCTION_CALL[text() = 'assign' or text() = 'setMethod']]]/expr[3]")
-
-  funs <- c(
-    direct_assignment_functions,
-    assign_or_setmethod_assignment_functions
+  funs <- xml2::xml_find_all(
+    xml,
+    paste(
+      # direct assignments
+      "*[
+        (
+          (self::expr and (LEFT_ASSIGN or EQ_ASSIGN))
+          or ((self::expr_or_assign_or_help or self::equal_assign) and EQ_ASSIGN)
+        )
+        and expr[2][FUNCTION]
+      ]
+      /expr[2]
+      ",
+      # assign() and setMethod() assignments
+      "//expr[expr[SYMBOL_FUNCTION_CALL[text() = 'assign' or text() = 'setMethod']]]/expr[3]",
+      sep = " | "
+    )
   )
 
    if (length(funs) == 0L) {

--- a/R/paste_linter.R
+++ b/R/paste_linter.R
@@ -33,7 +33,10 @@ paste_linter <- function(allow_empty_sep = FALSE, allow_to_string = FALSE) {
       ]"
 
       empty_sep_expr <- xml2::xml_find_all(xml, sep_xpath)
-      sep_value <- get_r_string(xml2::xml_find_first(empty_sep_expr, "./SYMBOL_SUB[text() = 'sep']/following-sibling::expr[1]"))
+      sep_value <- get_r_string(xml2::xml_find_first(
+        empty_sep_expr,
+        "./SYMBOL_SUB[text() = 'sep']/following-sibling::expr[1]"
+      ))
 
       empty_sep_lints <- lapply(
         empty_sep_expr[!nzchar(sep_value)],
@@ -54,7 +57,10 @@ paste_linter <- function(allow_empty_sep = FALSE, allow_to_string = FALSE) {
         and SYMBOL_SUB[text() = 'collapse']/following-sibling::expr[1][STR_CONST]
       ]")
       to_string_expr <- xml2::xml_find_all(xml, to_string_xpath)
-      collapse_value <- get_r_string(xml2::xml_find_first(to_string_expr, "./SYMBOL_SUB[text() = 'collapse']/following-sibling::expr[1]"))
+      collapse_value <- get_r_string(xml2::xml_find_first(
+        to_string_expr,
+        "./SYMBOL_SUB[text() = 'collapse']/following-sibling::expr[1]"
+      ))
 
       to_string_lints <- lapply(
         to_string_expr[collapse_value == ", "],

--- a/R/semicolon_linter.R
+++ b/R/semicolon_linter.R
@@ -54,7 +54,12 @@ semicolon_linter <- function(allow_compound = FALSE, allow_trailing = FALSE) {
 #' }
 #' @export
 semicolon_terminator_linter <- function(semicolon = c("compound", "trailing")) {
-  lintr_deprecated(old = "semicolon_terminator_linter", new = "semicolon_linter", version = "2.0.1.9001", type = "Linter")
+  lintr_deprecated(
+    old = "semicolon_terminator_linter",
+    new = "semicolon_linter",
+    version = "2.0.1.9001",
+    type = "Linter"
+  )
   semicolon <- match.arg(semicolon, several.ok = TRUE)
   allow_compound <- !"compound" %in% semicolon
   allow_trailing <- !"trailing" %in% semicolon

--- a/R/single_quotes_linter.R
+++ b/R/single_quotes_linter.R
@@ -17,7 +17,7 @@ single_quotes_linter <- function() {
     str_idx <- which(content$token == "STR_CONST")
     squote_matches <- which(re_matches(
       content[str_idx, "text"],
-      rex(start, zero_or_one(character_class('rR')), single_quote, any_non_double_quotes, single_quote, end)
+      rex(start, zero_or_one(character_class("rR")), single_quote, any_non_double_quotes, single_quote, end)
     ))
 
     lapply(

--- a/tests/testthat/test-object_usage_linter.R
+++ b/tests/testthat/test-object_usage_linter.R
@@ -367,14 +367,14 @@ test_that("interprets glue expressions", {
 # reported as #1088
 test_that("definitions below top level are ignored (for now)", {
   expect_lint(
-    trim_some('
+    trim_some("
       local({
         x <- 1
         f <- function() {
           x
         }
       })
-    '),
+    "),
     NULL,
     object_usage_linter()
   )


### PR DESCRIPTION
remove all easy to clean lints from master.
Notable exception: `lint()` has reached a cyclocomp of 37, mainly due to compatibility layer and the outstanding PR to factor out the cache complexity.

I also added `implicit_integer_linter()` to `.lintr_new` in line with #699.
However, master currently has 449 implicit integer lints, so not enabling it yet.