### PR TITLE
Ignore trailing whitespace in strings by default

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -168,6 +168,8 @@ function calls. (#850, #851, @renkun-ken)
 * Several linters tightened internal logic to allow for raw strings like `R"( a\string )"` (#1034, @michaelchirico)
 * `object_usage_linter()` correctly detects functions assigned with `=` instead of `<-` (#1081, @michaelchirico)
 * `undesirable_function_linter()` no longer lints undesirable symbols if they are used as names (#1050, @AshesITR)
+* `trailing_whitespace_linter()` ignores trailing whitespace in strings by default. 
+  This can be disabled using `allow_in_strings = FALSE` (#1045, @AshesITR)
 
 # lintr 2.0.1
 

--- a/R/trailing_whitespace_linter.R
+++ b/R/trailing_whitespace_linter.R
@@ -3,11 +3,12 @@
 #' Check that there are no space characters at the end of source lines.
 #'
 #' @param allow_empty_lines Suppress lints for lines that contain only whitespace.
+#' @param allow_in_strings Suppress lints for trailing whitespace in string constants.
 #'
 #' @evalRd rd_tags("trailing_whitespace_linter")
 #' @seealso [linters] for a complete list of linters available in lintr.
 #' @export
-trailing_whitespace_linter <- function(allow_empty_lines = FALSE) {
+trailing_whitespace_linter <- function(allow_empty_lines = FALSE, allow_in_strings = TRUE) {
   Linter(function(source_expression) {
     if (is.null(source_expression$file_lines)) return(list())
 
@@ -21,6 +22,17 @@ trailing_whitespace_linter <- function(allow_empty_lines = FALSE) {
       bad_lines <- which(res$start > 1L)
     } else {
       bad_lines <- which(!is.na(res$start))
+    }
+
+    if (isTRUE(allow_in_strings) && !is.null(source_expression$full_xml_parsed_content)) {
+      all_str_consts <- xml2::xml_find_all(source_expression$full_xml_parsed_content, "//STR_CONST")
+      start_lines <- as.integer(xml2::xml_attr(all_str_consts, "line1"))
+      end_lines <- as.integer(xml2::xml_attr(all_str_consts, "line2"))
+
+      is_in_str <- vapply(bad_lines, function(ln) {
+        any(start_lines <= ln & ln < end_lines)
+      }, logical(1L))
+      bad_lines <- bad_lines[!is_in_str]
     }
 
     lapply(

--- a/man/trailing_whitespace_linter.Rd
+++ b/man/trailing_whitespace_linter.Rd
@@ -4,10 +4,12 @@
 \alias{trailing_whitespace_linter}
 \title{Trailing whitespace linter}
 \usage{
-trailing_whitespace_linter(allow_empty_lines = FALSE)
+trailing_whitespace_linter(allow_empty_lines = FALSE, allow_in_strings = TRUE)
 }
 \arguments{
 \item{allow_empty_lines}{Suppress lints for lines that contain only whitespace.}
+
+\item{allow_in_strings}{Suppress lints for trailing whitespace in string constants.}
 }
 \description{
 Check that there are no space characters at the end of source lines.

--- a/tests/testthat/test-trailing_whitespace_linter.R
+++ b/tests/testthat/test-trailing_whitespace_linter.R
@@ -49,9 +49,24 @@ test_that("also handles trailing whitespace in string constants", {
   msg <- rex::rex("Trailing whitespace is superfluous.")
 
   expect_lint("blah <- '  \n  \n'", NULL, linter)
+  # Don't exclude past the end of string
+  expect_lint(
+    "blah <- '  \n  \n'  ",
+    list(message = msg, line_number = 3L),
+    linter
+  )
   # can be enabled with allow_in_strings = FALSE
-  expect_lint("blah <- '  \n  \n'", msg,
-              trailing_whitespace_linter(allow_empty_lines = TRUE, allow_in_strings = FALSE))
-  expect_lint("blah <- '  \n  \n'", list(msg, msg),
-              trailing_whitespace_linter(allow_in_strings = FALSE))
+  expect_lint(
+    "blah <- '  \n  \n'",
+    list(message = msg, line_number = 1L),
+    trailing_whitespace_linter(allow_empty_lines = TRUE, allow_in_strings = FALSE)
+  )
+  expect_lint(
+    "blah <- '  \n  \n'",
+    list(
+      list(message = msg, line_number = 1L),
+      list(message = msg, line_number = 2L)
+    ),
+    trailing_whitespace_linter(allow_in_strings = FALSE)
+  )
 })

--- a/tests/testthat/test-trailing_whitespace_linter.R
+++ b/tests/testthat/test-trailing_whitespace_linter.R
@@ -43,3 +43,15 @@ test_that("also handles completely empty lines per allow_empty_lines argument", 
     trailing_whitespace_linter(allow_empty_lines = TRUE)
   )
 })
+
+test_that("also handles trailing whitespace in string constants", {
+  linter <- trailing_whitespace_linter()
+  msg <- rex::rex("Trailing whitespace is superfluous.")
+
+  expect_lint("blah <- '  \n  \n'", NULL, linter)
+  # can be enabled with allow_in_strings = FALSE
+  expect_lint("blah <- '  \n  \n'", msg,
+              trailing_whitespace_linter(allow_empty_lines = TRUE, allow_in_strings = FALSE))
+  expect_lint("blah <- '  \n  \n'", list(msg, msg),
+              trailing_whitespace_linter(allow_in_strings = FALSE))
+})

--- a/tests/testthat/test-trailing_whitespace_linter.R
+++ b/tests/testthat/test-trailing_whitespace_linter.R
@@ -5,7 +5,7 @@ test_that("returns the correct linting", {
 
   expect_lint(
     "blah <- 1  ",
-    list(message = rex("Trailing whitespace is superfluous."), column_number = 10),
+    list(message = rex("Trailing whitespace is superfluous."), column_number = 10L),
     linter
   )
 
@@ -17,7 +17,7 @@ test_that("returns the correct linting", {
 
   expect_lint(
     "blah <- 1\n'hi'\na <- 2  ",
-    list(message = rex("Trailing whitespace is superfluous."), line_number = 3),
+    list(message = rex("Trailing whitespace is superfluous."), line_number = 3L),
     linter
   )
 })
@@ -27,13 +27,13 @@ test_that("also handles completely empty lines per allow_empty_lines argument", 
 
   expect_lint(
     "blah <- 1\n  \n'hi'\na <- 2",
-    list(message = rex("Trailing whitespace is superfluous."), line_number = 2),
+    list(message = rex("Trailing whitespace is superfluous."), line_number = 2L),
     linter
   )
 
   expect_lint(
     "blah <- 1  ",
-    list(message = rex("Trailing whitespace is superfluous."), column_number = 10),
+    list(message = rex("Trailing whitespace is superfluous."), column_number = 10L),
     trailing_whitespace_linter(allow_empty_lines = TRUE)
   )
 


### PR DESCRIPTION
Fixes #1045

Works by excluding all lines which are within a STR_CONST (`@line1` to `@line2 - 1`).
The last line doesn't need to be excluded because STR_CONST is guaranteed to end in a non-blank, so trailing whitespace after it should lint.