### PR TITLE
allow (\n{ in brace_linter

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -11,7 +11,7 @@
 * Rename `semicolon_terminator_linter` to `semicolon_linter` for better consistency. `semicolon_terminator_linter` survives but is marked for deprecation. The new linter also has a new signature, taking arguments `allow_compound` and `allow_trailing` to replace the old single argument `semicolon=`, again for signature consistency with other linters.
 * Combined several curly brace related linters into a new `brace_linter` (#1041, @AshesITR):
   + `closed_curly_linter()`, also allowing `}]` in addition to `})` and `},` as exceptions.
-  + `open_curly_linter()`, no longer linting unnecessary trailing whitespace and also allowing `,` and `%>%` on
+  + `open_curly_linter()`, no longer linting unnecessary trailing whitespace and also allowing `(`, `,` and `%>%` on
     preceding lines as exceptions. (#487, #1028)
   + `paren_brace_linter()`, also linting `if`/`else` and `repeat` with missing whitespace
   + Require `else` to come on the same line as the preceding `}`, if present (#884, @michaelchirico)

--- a/R/brace_linter.R
+++ b/R/brace_linter.R
@@ -35,9 +35,11 @@ brace_linter <- function(allow_single_line = FALSE) {
         (@line1 = parent::expr/preceding-sibling::OP-LEFT-BRACE/@line1) or
         (@line1 = following-sibling::expr/OP-LEFT-BRACE/@line1)
       )",
-      # allow , and %>% on preceding line
+      # allow `(`, `,` and `%>%` on preceding line
       "not(
-        @line1 = parent::expr/preceding-sibling::*[1][self::OP-COMMA or (self::SPECIAL and text() = '%>%')]/@line2 + 1
+        @line1 = parent::expr/preceding-sibling::*[1][
+          self::OP-LEFT-PAREN or self::OP-COMMA or (self::SPECIAL and text() = '%>%')
+        ]/@line2 + 1
       )"
     ))
 

--- a/tests/testthat/test-brace_linter.R
+++ b/tests/testthat/test-brace_linter.R
@@ -130,6 +130,20 @@ test_that("brace_linter lints braces correctly", {
     linter
   )
 
+  # (\n{ is allowed optionally
+  expect_lint(
+    trim_some("
+      tryCatch(
+        {
+          print(1)
+        },
+        error = function(err) {}
+      )
+    "),
+    NULL,
+    linter
+  )
+
   # {{ }} is allowed
   expect_lint("{{ x }}", NULL, linter)
 

--- a/tests/testthat/test-brace_linter.R
+++ b/tests/testthat/test-brace_linter.R
@@ -137,7 +137,8 @@ test_that("brace_linter lints braces correctly", {
         {
           print(1)
         },
-        error = function(err) {}
+        error = function(err) {
+        }
       )
     "),
     NULL,


### PR DESCRIPTION
quick fix to #487 (also allow `(\n{`)