### PR TITLE
Update VS Code R extension id

### DIFF
--- a/README.md
+++ b/README.md
@@ -390,5 +390,5 @@ Installing `languageserver` package in R and `vscode-R` extension in VS Code wil
 
 ```bash
 Rscript -e 'install.packages("languageserver")'
-code --install-extension ikuyadeu.r
+code --install-extension reditorsupport.r
 ```


### PR DESCRIPTION
The publisher id of the vscode-R extension has been updated:

https://marketplace.visualstudio.com/items?itemName=REditorSupport.r

The installation command should reflect this change accordingly.

See https://github.com/REditorSupport/vscode-R/issues/690#issuecomment-1115829408.