### PR TITLE
change lintr URLs to r-lib org

### DIFF
--- a/.github/workflows/lint-changed-files.yaml
+++ b/.github/workflows/lint-changed-files.yaml
@@ -32,7 +32,7 @@ jobs:
 
       - name: Extract and lint files changed by this PR
         run: |
-          files <- gh::gh("GET https://api.github.com/repos/jimhester/lintr/pulls/${{ github.event.pull_request.number }}/files")
+          files <- gh::gh("GET https://api.github.com/repos/r-lib/lintr/pulls/${{ github.event.pull_request.number }}/files")
           changed_files <- purrr::map_chr(files, "filename")
           all_files <- list.files(recursive = TRUE)
           exclusions_list <- as.list(setdiff(all_files, changed_files))

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -9,8 +9,8 @@ Authors@R: c(
     person("Kun", "Ren", role = "aut"),
     person("Alexander", "Rosenstock", role = "aut")
     )
-URL: https://github.com/jimhester/lintr
-BugReports: https://github.com/jimhester/lintr/issues
+URL: https://github.com/r-lib/lintr
+BugReports: https://github.com/r-lib/lintr/issues
 Description: Checks adherence to a given style, syntax errors and possible semantic issues.
     Supports on the fly checking of R code edited with 'RStudio IDE', 'Emacs', 'Vim', 'Sublime Text',
     'Atom' and 'Visual Studio Code'.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # lintr
-[![R build status](https://github.com/r-lib/lintr/workflows/R-CMD-check/badge.svg)](https://github.com/jimhester/lintr/actions)
-[![codecov.io](https://codecov.io/github/r-lib/lintr/coverage.svg?branch=master)](https://codecov.io/github/jimhester/lintr?branch=master)
+[![R build status](https://github.com/r-lib/lintr/workflows/R-CMD-check/badge.svg)](https://github.com/r-lib/lintr/actions)
+[![codecov.io](https://codecov.io/github/r-lib/lintr/coverage.svg?branch=master)](https://codecov.io/github/r-lib/lintr?branch=master)
 [![CRAN_Status_Badge](https://www.r-pkg.org/badges/version/lintr)](https://cran.r-project.org/package=lintr)
 [![Join the chat at https://gitter.im/jimhester-lintr/Lobby](https://badges.gitter.im/jimhester-lintr/Lobby.svg)](https://gitter.im/jimhester-lintr/Lobby?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 # lintr
-[![R build status](https://github.com/jimhester/lintr/workflows/R-CMD-check/badge.svg)](https://github.com/jimhester/lintr/actions)
-[![codecov.io](https://codecov.io/github/jimhester/lintr/coverage.svg?branch=master)](https://codecov.io/github/jimhester/lintr?branch=master)
-[![CRAN_Status_Badge](https://www.r-pkg.org/badges/version/lintr)](https://cran.r-project.org/package=lintr) [![Join the chat at https://gitter.im/jimhester-lintr/Lobby](https://badges.gitter.im/jimhester-lintr/Lobby.svg)](https://gitter.im/jimhester-lintr/Lobby?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
+[![R build status](https://github.com/r-lib/lintr/workflows/R-CMD-check/badge.svg)](https://github.com/jimhester/lintr/actions)
+[![codecov.io](https://codecov.io/github/r-lib/lintr/coverage.svg?branch=master)](https://codecov.io/github/jimhester/lintr?branch=master)
+[![CRAN_Status_Badge](https://www.r-pkg.org/badges/version/lintr)](https://cran.r-project.org/package=lintr)
+[![Join the chat at https://gitter.im/jimhester-lintr/Lobby](https://badges.gitter.im/jimhester-lintr/Lobby.svg)](https://gitter.im/jimhester-lintr/Lobby?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
 ## Static code analysis for R ##
 
@@ -218,7 +219,7 @@ following line to your `.travis.yml`
 
 ```yaml
 r_github_packages:
-  - jimhester/lintr
+  - r-lib/lintr
 ```
 
 We recommend running `lintr::lint_package()` as an [after_success step in your build process](#non-failing-lints)]
@@ -260,7 +261,7 @@ included in a given project.
 To install the latest development version of lintr from GitHub
 
 ```r
-devtools::install_github("jimhester/lintr")
+devtools::install_github("r-lib/lintr")
 ```
 
 

--- a/vignettes/creating_linters.Rmd
+++ b/vignettes/creating_linters.Rmd
@@ -103,7 +103,7 @@ testing. You can run all of the currently available tests using
 `filter` argument to `devtools::test()`.
 
 Linter tests should be put in the
-[tests/testthat/](https://github.com/jimhester/lintr/tree/master/tests/testthat)
+[tests/testthat/](https://github.com/r-lib/lintr/tree/master/tests/testthat)
 folder.  The test filename should be the linter name prefixed by `test-`, e.g.
 `test-assignment_linter.R`.
 
@@ -181,5 +181,5 @@ list before the `NULL` at the end.
 
 ## Submit pull request ##
 Push your changes to a branch of your fork of the
-[lintr](https://github.com/jimhester/lintr) repository, and submit a pull
+[lintr](https://github.com/r-lib/lintr) repository, and submit a pull
 request to get your linter merged into lintr!


### PR DESCRIPTION
This replaces `jimhester` with `r-lib` in the GitHub URLs / repo address.

Questions:

1. The URL in the `lint-changed-file.yaml` needs to be changed as well, I assume?
    https://github.com/r-lib/lintr/blob/4ca7e484bcbe538cc5a81338c0ec55a0ae084cb0/.github/workflows/lint-changed-files.yaml#L35
2. Is the [gitter chat](https://github.com/dpprdan/lintr/blob/9fa72489b5d641312ca7c27128599298a7f0b506/README.md?plain=1#L5) still maintained? The last activity was over a year ago, AFAICT.
