### PR TITLE
support R-devel parseError metadata

### DIFF
--- a/tests/testthat/test-error.R
+++ b/tests/testthat/test-error.R
@@ -1,5 +1,5 @@
 test_that("returns the correct linting", {
-  msg_escape_char <- rex("is an unrecognized escape in character string starting")
+  msg_escape_char <- rex("is an unrecognized escape in character string")
   expect_lint("\"\\R\"", msg_escape_char)
   expect_lint("\"\\A\"", msg_escape_char)
   expect_lint("\"\\z\"", msg_escape_char)


### PR DESCRIPTION
Fixes #1126.
One test message had to be shortened to match both old and new R versions, the rest works by using the `parseError` metadata provided by R-devel instead of working with the message strings in `lint_parse_error()`.