### PR TITLE
Fix test warnings

### DIFF
--- a/R/cache.R
+++ b/R/cache.R
@@ -32,6 +32,9 @@ load_cache <- function(file, path = NULL) {
   if (file.exists(file)) {
     tryCatch(
       load(file = file, envir = env),
+      warning = function(w) {
+        invokeRestart("muffleWarning")
+      },
       error = function(e) {
         warning(
           "Could not load cache file '", file, "':\n",

--- a/R/lint.R
+++ b/R/lint.R
@@ -38,7 +38,7 @@ NULL
 lint <- function(filename, linters = NULL, ..., cache = FALSE, parse_settings = TRUE, text = NULL) {
   # TODO(next release after 3.0.0): remove this deprecated workaround
   dots <- list(...)
-  if (length(dots) > 0L && is.logical(dots[[1L]])) {
+  if (length(dots) > 0L && is.logical(dots[[1L]]) && !nzchar(names2(dots)[1L])) {
     warning(
       "'cache' is no longer available as a positional argument; please supply 'cache' as a named argument instead. ",
       "This warning will be upgraded to an error in the next release."
@@ -194,7 +194,7 @@ lint_dir <- function(path = ".", ...,
                      parse_settings = TRUE) {
   # TODO(next release after 3.0.0): remove this deprecated workaround
   dots <- list(...)
-  if (length(dots) > 0L && is.logical(dots[[1L]])) {
+  if (length(dots) > 0L && is.logical(dots[[1L]]) && !nzchar(names2(dots)[1L])) {
     warning(
       "'relative_path' is no longer available as a positional argument; ",
       "please supply 'relative_path' as a named argument instead. ",
@@ -300,7 +300,7 @@ lint_package <- function(path = ".", ...,
                          parse_settings = TRUE) {
   # TODO(next release after 3.0.0): remove this deprecated workaround
   dots <- list(...)
-  if (length(dots) > 0L && is.logical(dots[[1L]])) {
+  if (length(dots) > 0L && is.logical(dots[[1L]]) && !nzchar(names2(dots)[1L])) {
     warning(
       "'relative_path' is no longer available as a positional argument; ",
       "please supply 'relative_path' as a named argument instead. ",

--- a/tests/testthat/test-comments.R
+++ b/tests/testthat/test-comments.R
@@ -1,26 +1,18 @@
-org_travis_repo_slug <- Sys.getenv("TRAVIS_REPO_SLUG")
-org_jenkins_url <- Sys.getenv("JENKINS_URL")
-org_git_url <- Sys.getenv("GIT_URL")
-org_git_url_1 <- Sys.getenv("GIT_URL_1")
-org_change_id <- Sys.getenv("CHANGE_ID")
-org_git_commit <- Sys.getenv("GIT_COMMIT")
-
-setup({
-  Sys.unsetenv(c("JENKINS_URL", "GIT_URL", "GIT_URL_1", "CHANGE_ID", "GIT_COMMIT"))
-})
-
-teardown({
-  Sys.setenv(
-    TRAVIS_REPO_SLUG = org_travis_repo_slug,
-    JENKINS_URL = org_jenkins_url,
-    GIT_URL = org_git_url,
-    GIT_URL_1 = org_git_url_1,
-    CHANGE_ID = org_change_id,
-    GIT_COMMIT = org_git_commit
+clear_ci_info <- function() {
+  withr::local_envvar(
+    c(
+      "JENKINS_URL" = NA_character_,
+      "GIT_URL" = NA_character_,
+      "GIT_URL_1" = NA_character_,
+      "CHANGE_ID" = NA_character_,
+      "GIT_COMMIT" = NA_character_
+    ),
+    .local_envir = parent.frame()
   )
-})
+}
 
 test_that("it detects CI environments", {
+  clear_ci_info()
   Sys.setenv(TRAVIS_REPO_SLUG = "foo/bar")
   expect_true(in_ci())
   Sys.setenv(TRAVIS_REPO_SLUG = "")
@@ -28,16 +20,17 @@ test_that("it detects CI environments", {
 })
 
 test_that("it returns NULL if GIT_URL is not on github", {
+  clear_ci_info()
   Sys.setenv(
     JENKINS_URL = "https://jenkins.example.org/",
     GIT_URL = "https://example.com/user/repo.git",
     CHANGE_ID = "123"
   )
   expect_false(in_ci())
-  Sys.unsetenv(c("JENKINS_URL", "GIT_URL", "CHANGE_ID"))
 })
 
 test_that("it determines Jenkins PR build info", {
+  clear_ci_info()
   Sys.setenv(
     JENKINS_URL = "https://jenkins.example.org/",
     GIT_URL = "https://github.com/user/repo.git",
@@ -57,6 +50,7 @@ test_that("it determines Jenkins PR build info", {
 })
 
 test_that("it determines Jenkins commit build info", {
+  clear_ci_info()
   Sys.setenv(
     JENKINS_URL = "https://jenkins.example.org/",
     GIT_URL_1 = "https://github.com/user/repo.git",
@@ -70,6 +64,4 @@ test_that("it determines Jenkins commit build info", {
     pull = NULL,
     commit = "abcde"
   ))
-
-  Sys.unsetenv(c("JENKINS_URL", "GIT_URL_1", "GIT_COMMIT"))
 })

--- a/tests/testthat/test-error.R
+++ b/tests/testthat/test-error.R
@@ -1,5 +1,5 @@
 test_that("returns the correct linting", {
-  msg_escape_char <- rex("is an unrecognized escape in character string starting")
+  msg_escape_char <- rex("is an unrecognized escape in character string")
   expect_lint("\"\\R\"", msg_escape_char)
   expect_lint("\"\\A\"", msg_escape_char)
   expect_lint("\"\\z\"", msg_escape_char)

--- a/tests/testthat/test-yoda_test_linter.R
+++ b/tests/testthat/test-yoda_test_linter.R
@@ -39,7 +39,7 @@ test_that("yoda_test_linter ignores strings in $ expressions", {
 # if we only inspect the first argument & ignore context, get false positives
 test_that("yoda_test_linter ignores usage in pipelines", {
   expect_lint("foo() %>% expect_identical(2)", NULL, yoda_test_linter())
-  skip_if_not_installed("base", "4.1.0")
+  skip_if_not_r_version("4.1.0")
   expect_lint("bar() |> expect_equal('a')", NULL, yoda_test_linter())
 })
 


### PR DESCRIPTION
Fixes #1128, based against #1129 to prevent r-devel build failures.

The changes are:

 - suppress warnings during `load()`, since these aren't really helpful anyway if cache loading fails and hard to track down if it doesn't
 - fix false positive argument deprecation warnings by also checking the positional argument is unnamed
 - fix testthat 3e warnings for `setup()` and `teardown()` by using `local_envvar()`. I've locally confirmed that setting an envvar to `NA_character_` has the same effect as `Sys.unsetenv()`.
 - Unified R version based skips (test-yoda_test_linter still tested for package base version instead of using `skip_if_not_r_version()`)

Browsing the logs, we can see that R <= 3.6.3 produces ~ 100 Warnings due to a bug in `utils::isS3StdGeneric()` which I don't think is worth working around, all newer R versions produce clean testthat output as of now.