### PR TITLE
Auto-detect imported objects from packages in `object_usage_linter()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -173,6 +173,7 @@ function calls. (#850, #851, @renkun-ken)
 * `trailing_whitespace_linter()` ignores trailing whitespace in strings by default. 
   This can be disabled using `allow_in_strings = FALSE` (#1045, @AshesITR)
 * Moved the default lintr cache directory from `~/.R/lintr_cache` to `R_user_dir("lintr", "cache")`. Note that this major version update invalidated the old cache anyway, so it can be safely deleted. (#1062, @AshesITR)
+* `object_usage_linter()` now detects functions exported by packages that are explicitly attached using `library()` or `require()` calls (#1127, @AshesITR)
 
 # lintr 2.0.1
 

--- a/R/object_usage_linter.R
+++ b/R/object_usage_linter.R
@@ -14,8 +14,6 @@ object_usage_linter <- function(interpret_glue = TRUE) {
     # If there is no xml data just return
     if (is.null(source_expression$full_xml_parsed_content)) return(list())
 
-    source_expression$parsed_content <- source_expression$full_parsed_content
-
     pkg_name <- pkg_name(find_package(dirname(source_expression$filename)))
     if (!is.null(pkg_name)) {
       parent_env <- try_silently(getNamespace(pkg_name))
@@ -27,7 +25,10 @@ object_usage_linter <- function(interpret_glue = TRUE) {
 
     declared_globals <- try_silently(utils::globalVariables(package = pkg_name %||% globalenv()))
 
-    symbols <- get_assignment_symbols(source_expression$full_xml_parsed_content)
+    symbols <- c(
+      get_assignment_symbols(source_expression$full_xml_parsed_content),
+      get_imported_symbols(source_expression$full_xml_parsed_content)
+    )
 
     # Just assign them an empty function
     for (symbol in symbols) {
@@ -274,4 +275,34 @@ parse_check_usage <- function(expression, known_used_symbols = character()) {
   }
 
   res
+}
+
+get_imported_symbols <- function(xml) {
+  import_exprs <- xml2::xml_find_all(
+    xml,
+    "//expr[
+      expr[SYMBOL_FUNCTION_CALL[text() = 'library' or text() = 'require']]
+      and
+      (
+        not(SYMBOL_SUB[
+          text() = 'character.only' and
+          following-sibling::expr[1][NUM_CONST[text() = 'TRUE'] or SYMBOL[text() = 'T']]
+        ]) or
+        expr[2][STR_CONST]
+      )
+    ]/expr[STR_CONST|SYMBOL][1]"
+  )
+  if (length(import_exprs) == 0L) {
+    return(character())
+  }
+  imported_pkgs <- get_r_string(import_exprs)
+
+  unlist(lapply(imported_pkgs, function(pkg) {
+    tryCatch(
+      getNamespaceExports(pkg),
+      error = function(e) {
+        character()
+      }
+    )
+  }))
 }

--- a/tests/testthat/test-object_usage_linter.R
+++ b/tests/testthat/test-object_usage_linter.R
@@ -379,3 +379,30 @@ test_that("definitions below top level are ignored (for now)", {
     object_usage_linter()
   )
 })
+
+# reported as #1127
+test_that("package imports are detected if present in file", {
+  expect_lint(
+    trim_some("
+      dog <- function() {
+        a <- iris %>% summarise(m = 42)
+        a
+      }
+    "),
+    rex::rex("no visible global function definition for ", anything, "summarise"),
+    object_usage_linter()
+  )
+
+  expect_lint(
+    trim_some("
+      library(dplyr)
+
+      dog <- function() {
+        a <- iris %>% summarise(m = 42)
+        a
+      }
+    "),
+    NULL,
+    object_usage_linter()
+  )
+})


### PR DESCRIPTION
Partially fixes #1127.
The example provided in the original issue is more complex because `library(tidyverse)` doesn't export the functions used.
Instead, it attaches other packages as a side-effect. I don't have a good idea how to (without acutally running `library(...)`) detect these.

IIRC, the packages aren't even registered as `Depends`.