### PR TITLE
Use partial matching for linter names in exclusion directives

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -68,6 +68,7 @@
 * New syntax to exclude only selected linters from linting lines or passages. Use `# nolint: linter_name, linter2_name.`
   or `# nolint start: linter_name, linter2_name.` in source files or named lists of line numbers in `.lintr`.
   (#660, @AshesITR)
+  + Extended to allow for partial matching as long as the supplied prefix is unique (#872, @AshesITR)
 * Fixed `spaces_left_parentheses_linter` sporadically causing warnings (#654, #674, @AshesITR)
 * Fixed `line_length_linter` causing duplicate lints for lines containing multiple expressions (#681, #682, @AshesITR)
 * `line_length_linter` now places the source marker at the margin of the affected line to improve user experience during 

--- a/R/T_and_F_symbol_linter.R
+++ b/R/T_and_F_symbol_linter.R
@@ -7,7 +7,7 @@
 #'   [linters] for a complete list of linters available in lintr. \cr
 #'   <https://style.tidyverse.org/syntax.html#logical-vectors>
 #' @export
-T_and_F_symbol_linter <- function() { # nolint: object_name_linter.
+T_and_F_symbol_linter <- function() { # nolint: object_name.
   Linter(function(source_expression) {
     if (is.null(source_expression$xml_parsed_content)) return(list())
 

--- a/R/exclude.R
+++ b/R/exclude.R
@@ -166,15 +166,16 @@ add_exclusions <- function(exclusions, lines, linters_string, exclude_linter_sep
     excluded_linters <- strsplit(linters_string, exclude_linter_sep)[[1L]]
     if (!is.null(linter_names)) {
       idxs <- pmatch(excluded_linters, linter_names, duplicates.ok = TRUE)
-      if (anyNA(idxs)) {
-        bad <- excluded_linters[is.na(idxs)]
+      matched <- !is.na(idxs)
+      if (!all(matched)) {
+        bad <- excluded_linters[!matched]
         warning(
           "Could not find linter", if (length(bad) > 1L) "s" else "", " named ",
           glue::glue_collapse(sQuote(bad), sep = ", ", last = " and "),
           " in the list of active linters. Make sure the linter is uniquely identified by the given name or prefix."
         )
       }
-      excluded_linters[!is.na(idxs)] <- linter_names[na.omit(idxs)]
+      excluded_linters[matched] <- linter_names[idxs[matched]]
     }
     exclusions <- add_excluded_lines(exclusions, lines, excluded_linters)
   }

--- a/R/exclude.R
+++ b/R/exclude.R
@@ -17,7 +17,7 @@
 #'     list of the files and lines to exclude, or just the filenames if you want to exclude the entire file, or the
 #'     directory names if you want to exclude all files in a directory.
 exclude <- function(lints, exclusions = settings$exclusions, linter_names = NULL, ...) {
-  if (length(lints) <= 0) {
+  if (length(lints) <= 0L) {
     return(lints)
   }
 
@@ -59,9 +59,9 @@ line_info <- function(line_numbers, type = c("start", "end")) {
   type <- match.arg(type)
   range_word <- paste0("range ", type, if (length(line_numbers) != 1L) "s")
   n <- length(line_numbers)
-  if (n == 0) {
+  if (n == 0L) {
     paste("0", range_word)
-  } else if (n == 1) {
+  } else if (n == 1L) {
     paste0("1 ", range_word, " (line ", line_numbers, ")")
   } else {
     paste0(n, " ", range_word, " (lines ", toString(line_numbers), ")")
@@ -105,7 +105,7 @@ parse_exclusions <- function(file, exclude = settings$exclude,
   starts <- which(!is.na(start_locations))
   ends <- which(!is.na(end_locations))
 
-  if (length(starts) > 0) {
+  if (length(starts) > 0L) {
     if (length(starts) != length(ends)) {
       starts_msg <- line_info(starts, type = "start")
       ends_msg <- line_info(ends, type = "end")
@@ -207,7 +207,7 @@ add_exclusions <- function(exclusions, lines, linters_string, exclude_linter_sep
 normalize_exclusions <- function(x, normalize_path = TRUE,
                                  root = getwd(),
                                  pattern = NULL) {
-  if (is.null(x) || length(x) <= 0) {
+  if (is.null(x) || length(x) <= 0L) {
     return(list())
   }
 

--- a/R/exclude.R
+++ b/R/exclude.R
@@ -2,6 +2,7 @@
 #'
 #' @param lints that need to be filtered.
 #' @param exclusions manually specified exclusions
+#' @param linter_names character vector of names of the active linters, used for parsing inline exclusions.
 #' @param ... additional arguments passed to [parse_exclusions()]
 #' @details
 #' Exclusions can be specified in three different ways.

--- a/R/function_left_parentheses.R
+++ b/R/function_left_parentheses.R
@@ -20,7 +20,7 @@ function_left_parentheses_linter <- function() { # nolint: object_length.
             source_expression$parsed_content$col1 < parsed$col1 &
             source_expression$parsed_content$terminal
 
-        last_type <- tail(source_expression$parsed_content$token[terminal_tokens_before], n = 1)
+        last_type <- tail(source_expression$parsed_content$token[terminal_tokens_before], n = 1L)
 
         is_function_call <- length(last_type) %!=% 0L &&
           (last_type %in% c("SYMBOL_FUNCTION_CALL", "FUNCTION", "'}'", "']'"))

--- a/R/function_left_parentheses.R
+++ b/R/function_left_parentheses.R
@@ -7,7 +7,7 @@
 #'   [linters] for a complete list of linters available in lintr. \cr
 #'   <https://style.tidyverse.org/syntax.html#parentheses>
 #' @export
-function_left_parentheses_linter <- function() { # nolint: object_length_linter.
+function_left_parentheses_linter <- function() { # nolint: object_length.
   Linter(function(source_expression) {
     lapply(
       ids_with_token(source_expression, "'('"),

--- a/R/lint.R
+++ b/R/lint.R
@@ -104,7 +104,7 @@ lint <- function(filename, linters = NULL, ..., cache = FALSE, parse_settings = 
     if (!is.null(lints)) {
       # TODO: once cache= is fully deprecated as 3rd positional argument (see top of body), we can restore the cleaner:
       # > exclude(lints, lines = lines, ...)
-      return(do.call(exclude, c(list(lints, lines = lines), dots)))
+      return(do.call(exclude, c(list(lints, lines = lines, linter_names = names(linters)), dots)))
     }
     cache <- TRUE
   } else {
@@ -152,7 +152,7 @@ lint <- function(filename, linters = NULL, ..., cache = FALSE, parse_settings = 
 
   # TODO: once cache= is fully deprecated as 3rd positional argument (see top of body), we can restore the cleaner:
   # > exclude(lints, lines = lines, ...)
-  res <- do.call(exclude, c(list(lints, lines = lines), dots))
+  res <- do.call(exclude, c(list(lints, lines = lines, linter_names = names(linters)), dots))
 
   # simplify filename if inline
   if (no_filename) {
@@ -476,7 +476,7 @@ pkg_name <- function(path = find_package()) {
 #' @param linter deprecated. No longer used.
 #' @return an object of class 'lint'.
 #' @export
-Lint <- function(filename, line_number = 1L, column_number = 1L, # nolint: object_name_linter.
+Lint <- function(filename, line_number = 1L, column_number = 1L, # nolint: object_name.
                  type = c("style", "warning", "error"),
                  message = "", line = "", ranges = NULL, linter = "") {
   if (!missing(linter)) {

--- a/R/lint.R
+++ b/R/lint.R
@@ -461,7 +461,7 @@ pkg_name <- function(path = find_package()) {
   if (is.null(path)) {
     return(NULL)
   } else {
-    read.dcf(file.path(path, "DESCRIPTION"), fields = "Package")[1]
+    read.dcf(file.path(path, "DESCRIPTION"), fields = "Package")[1L]
   }
 }
 

--- a/R/methods.R
+++ b/R/methods.R
@@ -137,7 +137,7 @@ split.lints <- function(x, f = NULL, ...) {
 }
 
 #' @export
-as.data.frame.lints <- function(x, row.names = NULL, optional = FALSE, ...) { # nolint: object_name_linter. (row.names)
+as.data.frame.lints <- function(x, row.names = NULL, optional = FALSE, ...) { # nolint: object_name. (row.names)
   data.frame(filename = vapply(x, `[[`, character(1), "filename"),
              line_number = vapply(x, `[[`, numeric(1), "line_number"),
              column_number = vapply(x, `[[`, numeric(1), "column_number"),

--- a/R/utils.R
+++ b/R/utils.R
@@ -177,7 +177,7 @@ reset_lang <- function(old_lang) {
 #' Lints produced by the linter will be labelled with `name` by default.
 #' @return The same function with its class set to 'linter'.
 #' @export
-Linter <- function(fun, name = linter_auto_name()) { # nolint: object_name_linter.
+Linter <- function(fun, name = linter_auto_name()) { # nolint: object_name.
   if (!is.function(fun) || length(formals(args(fun))) != 1L) {
     stop("`fun` must be a function taking exactly one argument.", call. = FALSE)
   }

--- a/man/exclude.Rd
+++ b/man/exclude.Rd
@@ -4,7 +4,7 @@
 \alias{exclude}
 \title{Exclude lines or files from linting}
 \usage{
-exclude(lints, exclusions = settings$exclusions, ...)
+exclude(lints, exclusions = settings$exclusions, linter_names = NULL, ...)
 }
 \arguments{
 \item{lints}{that need to be filtered.}

--- a/man/exclude.Rd
+++ b/man/exclude.Rd
@@ -11,6 +11,8 @@ exclude(lints, exclusions = settings$exclusions, linter_names = NULL, ...)
 
 \item{exclusions}{manually specified exclusions}
 
+\item{linter_names}{character vector of names of the active linters, used for parsing inline exclusions.}
+
 \item{...}{additional arguments passed to \code{\link[=parse_exclusions]{parse_exclusions()}}}
 }
 \description{

--- a/man/parse_exclusions.Rd
+++ b/man/parse_exclusions.Rd
@@ -11,7 +11,8 @@ parse_exclusions(
   exclude_end = settings$exclude_end,
   exclude_linter = settings$exclude_linter,
   exclude_linter_sep = settings$exclude_linter_sep,
-  lines = NULL
+  lines = NULL,
+  linter_names = NULL
 )
 }
 \arguments{
@@ -29,6 +30,8 @@ parse_exclusions(
 \item{exclude_linter_sep}{regular expression used to split a linter list into indivdual linter names for exclusion.}
 
 \item{lines}{a character vector of the content lines of \code{file}}
+
+\item{linter_names}{Names of active linters}
 }
 \value{
 A possibly named list of excluded lines, possibly for specific linters.

--- a/tests/testthat/dummy_projects/project/partially_matched_exclusions.R
+++ b/tests/testthat/dummy_projects/project/partially_matched_exclusions.R
@@ -1,0 +1,13 @@
+# nolint start: assign.
+a = 2
+# nolint end
+
+# nolint start: s. warn (and lint) because of non-unique identifier
+x <- 42; y <- 2
+# nolint end
+
+# nolint start: bogus_linter. warn because of nonexistent identifier
+
+# nolint end
+
+# nolint: hokus_pokus, bogus.

--- a/tests/testthat/dummy_projects/project/partially_matched_exclusions.R
+++ b/tests/testthat/dummy_projects/project/partially_matched_exclusions.R
@@ -10,4 +10,4 @@ x <- 42; y <- 2
 
 # nolint end
 
-# nolint: hokus_pokus, bogus.
+# nolint: hocus_pocus, bogus.

--- a/tests/testthat/test-exclusions.R
+++ b/tests/testthat/test-exclusions.R
@@ -13,11 +13,13 @@ test_that("line_info works as expected", {
   )
 })
 
-old_ops <- options(lintr.exclude = "#TeSt_NoLiNt",
-                   lintr.exclude_start = "#TeSt_NoLiNt_StArT",
-                   lintr.exclude_end = "#TeSt_NoLiNt_EnD")
-
 test_that("it excludes properly", {
+  withr::local_options(
+    lintr.exclude = "#TeSt_NoLiNt",
+    lintr.exclude_start = "#TeSt_NoLiNt_StArT",
+    lintr.exclude_end = "#TeSt_NoLiNt_EnD"
+  )
+
   read_settings(NULL)
 
   t1 <- lint("exclusions-test", parse_settings = FALSE)
@@ -42,12 +44,15 @@ test_that("it excludes properly", {
 })
 
 test_that("it doesn't fail when encountering misspecified encodings", {
+  withr::local_options(
+    lintr.exclude = "#TeSt_NoLiNt",
+    lintr.exclude_start = "#TeSt_NoLiNt_StArT",
+    lintr.exclude_end = "#TeSt_NoLiNt_EnD"
+  )
   read_settings(NULL)
 
   expect_length(parse_exclusions("dummy_projects/project/cp1252.R"), 0L)
 })
-
-options(old_ops)
 
 test_that("it gives the expected error message when there is only one start but no end", {
   read_settings(NULL)
@@ -66,5 +71,24 @@ test_that("it gives the expected error message when there is mismatch between mu
     parse_exclusions("dummy_projects/project/mismatched_starts_ends.R"),
     "has 3 range starts (lines 3, 7, 11) but only 2 range ends (lines 1, 9) for exclusion from linting",
     fixed = TRUE
+  )
+})
+
+test_that("partial matching works for exclusions but warns if no linter found", {
+  read_settings(NULL)
+
+  expect_warning(
+    expect_warning(
+      expect_warning(
+        expect_lint(
+          file = "dummy_projects/project/partially_matched_exclusions.R",
+          checks = rex::rex("semicolons"),
+          parse_settings = FALSE
+        ),
+        rex::rex("Could not find linter named ", anything, "s")
+      ),
+      rex::rex("Could not find linter named ", anything, "bogus_linter")
+    ),
+    rex::rex("Could not find linters named ", anything, "hokus_pokus", anything, "bogus")
   )
 })

--- a/tests/testthat/test-exclusions.R
+++ b/tests/testthat/test-exclusions.R
@@ -89,6 +89,6 @@ test_that("partial matching works for exclusions but warns if no linter found", 
       ),
       rex::rex("Could not find linter named ", anything, "bogus_linter")
     ),
-    rex::rex("Could not find linters named ", anything, "hokus_pokus", anything, "bogus")
+    rex::rex("Could not find linters named ", anything, "hocus_pocus", anything, "bogus")
   )
 })

--- a/vignettes/using_lintr.Rmd
+++ b/vignettes/using_lintr.Rmd
@@ -265,6 +265,25 @@ lintr::lint(
 )
 ```
 
+You can also specify the linter names by a unique prefix instead of their full name:
+
+**file5.R**
+```r
+X = 42L # nolint: object_name, line_len. this comment still overflows the default 80 chars line length.
+```
+
+`> lint("file5.R")`
+```{r, echo = FALSE}
+lintr::lint(
+  paste(
+    "X = 42L",
+    "# nolint: object_name, line_len. this comment still overflows the default 80 chars line length.\n"
+  ),
+  parse_settings = FALSE
+)
+```
+
+
 ### Excluding multiple lines of codes
 
 If any or all linters should be disabled for a contiguous block of code, the `exclude_start` and `exclude_end` patterns


### PR DESCRIPTION
fixes #872 

- transitioned our internal `# nolint`s to the short-hand notation
- we raise a warning if no linter could be matched by an exclusion
- documented the short-hand notation
- added an example in the `using_lintr` vignette
- added tests
- extended NEWS bullet for #660 