### PR TITLE
Use xml_find_chr where appropriate

### DIFF
--- a/R/class_equals_linter.R
+++ b/R/class_equals_linter.R
@@ -30,7 +30,7 @@ class_equals_linter <- function() {
       bad_expr,
       source_expression = source_expression,
       lint_message = function(expr) {
-        op <- xml2::xml_text(xml2::xml_find_first(expr, "*[2]"))
+        op <- xml2::xml_find_chr(expr, "string(*[2])")
         message <- sprintf("Instead of comparing class(x) with %s,", op)
         paste(message, "use inherits(x, 'class-name') or is.<class> or is(x, 'class')")
       },

--- a/R/condition_message_linter.R
+++ b/R/condition_message_linter.R
@@ -27,10 +27,7 @@ condition_message_linter <- function() {
     ]")
 
     bad_expr <- xml2::xml_find_all(xml, xpath)
-    sep_value <- get_r_string(xml2::xml_find_chr(
-      bad_expr,
-      "string(./expr/SYMBOL_SUB[text() = 'sep']/following-sibling::expr/STR_CONST)"
-    ))
+    sep_value <- get_r_string(bad_expr, xpath = "./expr/SYMBOL_SUB[text() = 'sep']/following-sibling::expr/STR_CONST")
 
     xml_nodes_to_lints(
       bad_expr[is.na(sep_value) | sep_value %in% c("", " ")],

--- a/R/condition_message_linter.R
+++ b/R/condition_message_linter.R
@@ -27,17 +27,17 @@ condition_message_linter <- function() {
     ]")
 
     bad_expr <- xml2::xml_find_all(xml, xpath)
-    sep_value <- get_r_string(xml2::xml_find_first(
+    sep_value <- get_r_string(xml2::xml_find_chr(
       bad_expr,
-      "./expr/SYMBOL_SUB[text() = 'sep']/following-sibling::expr/STR_CONST"
+      "string(./expr/SYMBOL_SUB[text() = 'sep']/following-sibling::expr/STR_CONST)"
     ))
 
     xml_nodes_to_lints(
       bad_expr[is.na(sep_value) | sep_value %in% c("", " ")],
       source_expression = source_expression,
       lint_message = function(expr) {
-        outer_call <- xml2::xml_text(xml2::xml_find_first(expr, "expr/SYMBOL_FUNCTION_CALL"))
-        inner_call <- xml2::xml_text(xml2::xml_find_first(expr, "expr/expr/SYMBOL_FUNCTION_CALL"))
+        outer_call <- xml2::xml_find_chr(expr, "string(expr/SYMBOL_FUNCTION_CALL)")
+        inner_call <- xml2::xml_find_chr(expr, "string(expr/expr/SYMBOL_FUNCTION_CALL)")
 
         message <- sprintf("Don't use %s to build %s strings.", inner_call, outer_call)
         paste(

--- a/R/condition_message_linter.R
+++ b/R/condition_message_linter.R
@@ -36,8 +36,8 @@ condition_message_linter <- function() {
       bad_expr[is.na(sep_value) | sep_value %in% c("", " ")],
       source_expression = source_expression,
       lint_message = function(expr) {
-        outer_call <- xml2::xml_find_chr(expr, "string(expr/SYMBOL_FUNCTION_CALL)")
-        inner_call <- xml2::xml_find_chr(expr, "string(expr/expr/SYMBOL_FUNCTION_CALL)")
+        outer_call <- xp_call_name(expr)
+        inner_call <- xp_call_name(expr, depth = 2L)
 
         message <- sprintf("Don't use %s to build %s strings.", inner_call, outer_call)
         paste(

--- a/R/conjunct_test_linter.R
+++ b/R/conjunct_test_linter.R
@@ -41,7 +41,7 @@ conjunct_test_linter <- function(allow_named_stopifnot = TRUE) {
       bad_expr,
       source_expression,
       lint_message = function(expr) {
-        matched_fun <- xml2::xml_find_chr(expr, "string(expr/SYMBOL_FUNCTION_CALL)")
+        matched_fun <- xp_call_name(expr)
         op <- xml2::xml_find_chr(expr, "string(expr/*[self::AND2 or self::OR2])")
         instead_of <- sprintf("Instead of %s(A %s B),", matched_fun, op)
         if (matched_fun %in% c("expect_true", "expect_false")) {

--- a/R/conjunct_test_linter.R
+++ b/R/conjunct_test_linter.R
@@ -41,8 +41,8 @@ conjunct_test_linter <- function(allow_named_stopifnot = TRUE) {
       bad_expr,
       source_expression,
       lint_message = function(expr) {
-        matched_fun <- xml2::xml_text(xml2::xml_find_first(expr, "expr/SYMBOL_FUNCTION_CALL"))
-        op <- xml2::xml_text(xml2::xml_find_first(expr, "expr/*[self::AND2 or self::OR2]"))
+        matched_fun <- xml2::xml_find_chr(expr, "string(expr/SYMBOL_FUNCTION_CALL)")
+        op <- xml2::xml_find_chr(expr, "string(expr/*[self::AND2 or self::OR2])")
         instead_of <- sprintf("Instead of %s(A %s B),", matched_fun, op)
         if (matched_fun %in% c("expect_true", "expect_false")) {
           replacement <- sprintf("write multiple expectations like %1$s(A) and %1$s(B)", matched_fun)

--- a/R/duplicate_argument_linter.R
+++ b/R/duplicate_argument_linter.R
@@ -20,11 +20,7 @@ duplicate_argument_linter <- function(except = character()) {
     calls <- xml2::xml_find_all(xml, xpath)
 
     if (length(except)) {
-      calls_names <- xml2::xml_find_first(calls, "expr[1][count(*)=1]/*[1]")
-      calls_text <- vapply(
-        parse(text = xml2::xml_text(calls_names)),
-        as.character, character(1L)
-      )
+      calls_text <- get_r_string(xml2::xml_find_chr(calls_names, "string(expr[1][count(*)=1]/*[1])"))
       calls <- calls[!(calls_text %in% except)]
     }
 

--- a/R/duplicate_argument_linter.R
+++ b/R/duplicate_argument_linter.R
@@ -20,7 +20,7 @@ duplicate_argument_linter <- function(except = character()) {
     calls <- xml2::xml_find_all(xml, xpath)
 
     if (length(except)) {
-      calls_text <- get_r_string(xml2::xml_find_chr(calls_names, "string(expr[1][count(*)=1]/*[1])"))
+      calls_text <- get_r_string(xml2::xml_find_chr(calls, "string(expr[1][count(*)=1]/*[1])"))
       calls <- calls[!(calls_text %in% except)]
     }
 

--- a/R/duplicate_argument_linter.R
+++ b/R/duplicate_argument_linter.R
@@ -20,7 +20,7 @@ duplicate_argument_linter <- function(except = character()) {
     calls <- xml2::xml_find_all(xml, xpath)
 
     if (length(except)) {
-      calls_text <- get_r_string(xml2::xml_find_chr(calls, "string(expr[1][count(*)=1]/*[1])"))
+      calls_text <- get_r_string(calls, xpath = "expr[1][count(*)=1]/*[1]")
       calls <- calls[!(calls_text %in% except)]
     }
 

--- a/R/expect_comparison_linter.R
+++ b/R/expect_comparison_linter.R
@@ -37,7 +37,7 @@ expect_comparison_linter <- function() {
       bad_expr,
       source_expression,
       lint_message = function(expr) {
-        comparator <- xml2::xml_text(xml2::xml_find_first(expr, "expr[2]/*[2]"))
+        comparator <- xml2::xml_find_chr(expr, "string(expr[2]/*[2])")
         expectation <- comparator_expectation_map[[comparator]]
         sprintf("%s(x, y) is better than expect_true(x %s y).", expectation, comparator)
       },

--- a/R/expect_length_linter.R
+++ b/R/expect_length_linter.R
@@ -30,7 +30,7 @@ expect_length_linter <- function() {
       bad_expr,
       source_expression,
       function(expr) {
-        matched_function <- xml2::xml_text(xml2::xml_find_first(expr, "expr/SYMBOL_FUNCTION_CALL"))
+        matched_function <- xml2::xml_find_chr(expr, "string(expr/SYMBOL_FUNCTION_CALL)")
         sprintf("expect_length(x, n) is better than %s(length(x), n)", matched_function)
       },
       type = "warning"

--- a/R/expect_length_linter.R
+++ b/R/expect_length_linter.R
@@ -30,7 +30,7 @@ expect_length_linter <- function() {
       bad_expr,
       source_expression,
       function(expr) {
-        matched_function <- xml2::xml_find_chr(expr, "string(expr/SYMBOL_FUNCTION_CALL)")
+        matched_function <- xp_call_name(expr)
         sprintf("expect_length(x, n) is better than %s(length(x), n)", matched_function)
       },
       type = "warning"

--- a/R/expect_named_linter.R
+++ b/R/expect_named_linter.R
@@ -28,7 +28,7 @@ expect_named_linter <- function() {
       bad_expr,
       source_expression = source_expression,
       lint_message = function(expr) {
-        matched_function <- xp_call_name(expr)
+        matched_function <- xp_call_name(expr, depth = 0L)
         sprintf("expect_named(x, n) is better than %s(names(x), n)", matched_function)
       },
       type = "warning"

--- a/R/expect_named_linter.R
+++ b/R/expect_named_linter.R
@@ -28,7 +28,7 @@ expect_named_linter <- function() {
       bad_expr,
       source_expression = source_expression,
       lint_message = function(expr) {
-        matched_function <- xml2::xml_find_chr(expr, "string(SYMBOL_FUNCTION_CALL)")
+        matched_function <- xp_call_name(expr)
         sprintf("expect_named(x, n) is better than %s(names(x), n)", matched_function)
       },
       type = "warning"

--- a/R/expect_named_linter.R
+++ b/R/expect_named_linter.R
@@ -28,7 +28,7 @@ expect_named_linter <- function() {
       bad_expr,
       source_expression = source_expression,
       lint_message = function(expr) {
-        matched_function <- xml2::xml_text(xml2::xml_find_first(expr, "SYMBOL_FUNCTION_CALL"))
+        matched_function <- xml2::xml_find_chr(expr, "string(SYMBOL_FUNCTION_CALL)")
         sprintf("expect_named(x, n) is better than %s(names(x), n)", matched_function)
       },
       type = "warning"

--- a/R/expect_null_linter.R
+++ b/R/expect_null_linter.R
@@ -38,7 +38,7 @@ expect_null_linter <- function() {
       bad_expr,
       source_expression,
       function(expr) {
-        matched_function <- xml2::xml_text(xml2::xml_find_first(expr, "SYMBOL_FUNCTION_CALL"))
+        matched_function <- xml2::xml_find_chr(expr, "string(SYMBOL_FUNCTION_CALL)")
         if (matched_function %in% c("expect_equal", "expect_identical")) {
           sprintf("expect_null(x) is better than %s(x, NULL)", matched_function)
         } else {

--- a/R/expect_null_linter.R
+++ b/R/expect_null_linter.R
@@ -38,7 +38,7 @@ expect_null_linter <- function() {
       bad_expr,
       source_expression,
       function(expr) {
-        matched_function <- xml2::xml_find_chr(expr, "string(SYMBOL_FUNCTION_CALL)")
+        matched_function <- xp_call_name(expr, depth = 0L)
         if (matched_function %in% c("expect_equal", "expect_identical")) {
           sprintf("expect_null(x) is better than %s(x, NULL)", matched_function)
         } else {

--- a/R/expect_s3_class_linter.R
+++ b/R/expect_s3_class_linter.R
@@ -40,7 +40,7 @@ expect_s3_class_linter <- function() {
       bad_expr,
       source_expression,
       function(expr) {
-        matched_function <- xml2::xml_find_chr(expr, "string(expr/SYMBOL_FUNCTION_CALL)")
+        matched_function <- xp_call_name(expr)
         if (matched_function %in% c("expect_equal", "expect_identical")) {
           lint_msg <- sprintf("expect_s3_class(x, k) is better than %s(class(x), k).", matched_function)
         } else {

--- a/R/expect_s3_class_linter.R
+++ b/R/expect_s3_class_linter.R
@@ -40,7 +40,7 @@ expect_s3_class_linter <- function() {
       bad_expr,
       source_expression,
       function(expr) {
-        matched_function <- xml2::xml_text(xml2::xml_find_first(expr, "expr/SYMBOL_FUNCTION_CALL"))
+        matched_function <- xml2::xml_find_chr(expr, "string(expr/SYMBOL_FUNCTION_CALL)")
         if (matched_function %in% c("expect_equal", "expect_identical")) {
           lint_msg <- sprintf("expect_s3_class(x, k) is better than %s(class(x), k).", matched_function)
         } else {

--- a/R/expect_true_false_linter.R
+++ b/R/expect_true_false_linter.R
@@ -27,10 +27,8 @@ expect_true_false_linter <- function() {
       source_expression,
       function(expr) {
         # NB: use expr/$node, not expr[$node], to exclude other things (especially ns:: parts of the call)
-        call_name <- xml2::xml_text(
-          xml2::xml_find_first(expr, "expr/SYMBOL_FUNCTION_CALL[starts-with(text(), 'expect_')]")
-        )
-        truth_value <- xml2::xml_text(xml2::xml_find_first(expr, "expr/NUM_CONST[text() = 'TRUE' or text() = 'FALSE']"))
+        call_name <- xml2::xml_find_chr(expr, "string(expr/SYMBOL_FUNCTION_CALL[starts-with(text(), 'expect_')])")
+        truth_value <- xml2::xml_find_chr(expr, "string(expr/NUM_CONST[text() = 'TRUE' or text() = 'FALSE'])")
         if (truth_value == "TRUE") {
           sprintf("expect_true(x) is better than %s(x, TRUE)", call_name)
         } else {

--- a/R/expect_true_false_linter.R
+++ b/R/expect_true_false_linter.R
@@ -27,7 +27,7 @@ expect_true_false_linter <- function() {
       source_expression,
       function(expr) {
         # NB: use expr/$node, not expr[$node], to exclude other things (especially ns:: parts of the call)
-        call_name <- xml2::xml_find_chr(expr, "string(expr/SYMBOL_FUNCTION_CALL[starts-with(text(), 'expect_')])")
+        call_name <- xp_call_name(expr, condition = "starts-with(text(), 'expect_')")
         truth_value <- xml2::xml_find_chr(expr, "string(expr/NUM_CONST[text() = 'TRUE' or text() = 'FALSE'])")
         if (truth_value == "TRUE") {
           sprintf("expect_true(x) is better than %s(x, TRUE)", call_name)

--- a/R/expect_type_linter.R
+++ b/R/expect_type_linter.R
@@ -38,7 +38,7 @@ expect_type_linter <- function() {
       bad_expr,
       source_expression,
       function(expr) {
-        matched_function <- xml2::xml_find_chr(expr, "string(expr/SYMBOL_FUNCTION_CALL)")
+        matched_function <- xp_call_name(expr)
         if (matched_function %in% c("expect_equal", "expect_identical")) {
           sprintf("expect_type(x, t) is better than %s(typeof(x), t)", matched_function)
         } else {

--- a/R/expect_type_linter.R
+++ b/R/expect_type_linter.R
@@ -38,7 +38,7 @@ expect_type_linter <- function() {
       bad_expr,
       source_expression,
       function(expr) {
-        matched_function <- xml2::xml_text(xml2::xml_find_first(expr, "expr/SYMBOL_FUNCTION_CALL"))
+        matched_function <- xml2::xml_find_chr(expr, "string(expr/SYMBOL_FUNCTION_CALL)")
         if (matched_function %in% c("expect_equal", "expect_identical")) {
           sprintf("expect_type(x, t) is better than %s(typeof(x), t)", matched_function)
         } else {

--- a/R/ifelse_censor_linter.R
+++ b/R/ifelse_censor_linter.R
@@ -33,7 +33,7 @@ ifelse_censor_linter <- function() {
       bad_expr,
       source_expression = source_expression,
       lint_message = function(expr) {
-        matched_call <- xml2::xml_find_chr(expr, "string(expr/SYMBOL_FUNCTION_CALL)")
+        matched_call <- xp_call_name(expr)
         op <- xml2::xml_find_chr(expr, "string(expr[2]/*[2])")
         match_first <- !is.na(xml2::xml_find_first(expr, "expr[2][expr[1] = following-sibling::expr[1]]"))
         if (op %in% c("<", "<=")) {

--- a/R/ifelse_censor_linter.R
+++ b/R/ifelse_censor_linter.R
@@ -33,8 +33,8 @@ ifelse_censor_linter <- function() {
       bad_expr,
       source_expression = source_expression,
       lint_message = function(expr) {
-        matched_call <- xml2::xml_text(xml2::xml_find_first(expr, "expr/SYMBOL_FUNCTION_CALL"))
-        op <- xml2::xml_text(xml2::xml_find_first(expr, "expr[2]/*[2]"))
+        matched_call <- xml2::xml_find_chr(expr, "string(expr/SYMBOL_FUNCTION_CALL)")
+        op <- xml2::xml_find_chr(expr, "string(expr[2]/*[2])")
         match_first <- !is.na(xml2::xml_find_first(expr, "expr[2][expr[1] = following-sibling::expr[1]]"))
         if (op %in% c("<", "<=")) {
           if (match_first) {

--- a/R/inner_combine_linter.R
+++ b/R/inner_combine_linter.R
@@ -79,7 +79,7 @@ inner_combine_linter <- function() {
       bad_expr,
       source_expression = source_expression,
       lint_message = function(expr) {
-        matched_call <- xml2::xml_text(xml2::xml_find_first(expr, "expr/expr/SYMBOL_FUNCTION_CALL"))
+        matched_call <- xml2::xml_find_chr(expr, "string(expr/expr/SYMBOL_FUNCTION_CALL)")
         message <- sprintf(
           "%1$s(c(x, y)) only runs the more expensive %1$s() once as compared to c(%1$s(x), %1$s(y)).",
           matched_call

--- a/R/inner_combine_linter.R
+++ b/R/inner_combine_linter.R
@@ -79,7 +79,7 @@ inner_combine_linter <- function() {
       bad_expr,
       source_expression = source_expression,
       lint_message = function(expr) {
-        matched_call <- xml2::xml_find_chr(expr, "string(expr/expr/SYMBOL_FUNCTION_CALL)")
+        matched_call <- xp_call_name(expr, depth = 2L)
         message <- sprintf(
           "%1$s(c(x, y)) only runs the more expensive %1$s() once as compared to c(%1$s(x), %1$s(y)).",
           matched_call

--- a/R/nested_ifelse_linter.R
+++ b/R/nested_ifelse_linter.R
@@ -35,7 +35,7 @@ nested_ifelse_linter <- function() {
       bad_expr,
       source_expression = source_expression,
       lint_message = function(expr) {
-        matched_call <- xml2::xml_text(xml2::xml_find_first(expr, "expr/SYMBOL_FUNCTION_CALL"))
+        matched_call <- xml2::xml_find_chr(expr, "string(expr/SYMBOL_FUNCTION_CALL)")
         lint_message <- sprintf("Don't use nested %s() calls;", matched_call)
         paste(lint_message, "instead, try (1) data.table::fcase; (2) dplyr::case_when; or (3) using a lookup table.")
       },

--- a/R/nested_ifelse_linter.R
+++ b/R/nested_ifelse_linter.R
@@ -35,7 +35,7 @@ nested_ifelse_linter <- function() {
       bad_expr,
       source_expression = source_expression,
       lint_message = function(expr) {
-        matched_call <- xml2::xml_find_chr(expr, "string(expr/SYMBOL_FUNCTION_CALL)")
+        matched_call <- xp_call_name(expr)
         lint_message <- sprintf("Don't use nested %s() calls;", matched_call)
         paste(lint_message, "instead, try (1) data.table::fcase; (2) dplyr::case_when; or (3) using a lookup table.")
       },

--- a/R/outer_negation_linter.R
+++ b/R/outer_negation_linter.R
@@ -38,7 +38,7 @@ outer_negation_linter <- function() {
       bad_expr,
       source_expression = source_expression,
       lint_message = function(expr) {
-        matched_call <- xml2::xml_find_chr(expr, "string(expr/SYMBOL_FUNCTION_CALL)")
+        matched_call <- xp_call_name(expr)
         inverse_call <- if (matched_call == "any") "all" else "any"
         message <- sprintf("!%s(x) is better than %s(!x).", inverse_call, matched_call)
         paste(

--- a/R/outer_negation_linter.R
+++ b/R/outer_negation_linter.R
@@ -38,7 +38,7 @@ outer_negation_linter <- function() {
       bad_expr,
       source_expression = source_expression,
       lint_message = function(expr) {
-        matched_call <- xml2::xml_text(xml2::xml_find_first(expr, "expr/SYMBOL_FUNCTION_CALL"))
+        matched_call <- xml2::xml_find_chr(expr, "string(expr/SYMBOL_FUNCTION_CALL)")
         inverse_call <- if (matched_call == "any") "all" else "any"
         message <- sprintf("!%s(x) is better than %s(!x).", inverse_call, matched_call)
         paste(

--- a/R/paste_linter.R
+++ b/R/paste_linter.R
@@ -33,9 +33,9 @@ paste_linter <- function(allow_empty_sep = FALSE, allow_to_string = FALSE) {
       ]"
 
       empty_sep_expr <- xml2::xml_find_all(xml, sep_xpath)
-      sep_value <- get_r_string(xml2::xml_find_first(
+      sep_value <- get_r_string(xml2::xml_find_chr(
         empty_sep_expr,
-        "./SYMBOL_SUB[text() = 'sep']/following-sibling::expr[1]"
+        "string(./SYMBOL_SUB[text() = 'sep']/following-sibling::expr[1])"
       ))
 
       empty_sep_lints <- xml_nodes_to_lints(
@@ -56,9 +56,9 @@ paste_linter <- function(allow_empty_sep = FALSE, allow_to_string = FALSE) {
         and SYMBOL_SUB[text() = 'collapse']/following-sibling::expr[1][STR_CONST]
       ]")
       to_string_expr <- xml2::xml_find_all(xml, to_string_xpath)
-      collapse_value <- get_r_string(xml2::xml_find_first(
+      collapse_value <- get_r_string(xml2::xml_find_chr(
         to_string_expr,
-        "./SYMBOL_SUB[text() = 'collapse']/following-sibling::expr[1]"
+        "string(./SYMBOL_SUB[text() = 'collapse']/following-sibling::expr[1])"
       ))
 
       to_string_lints <- xml_nodes_to_lints(

--- a/R/paste_linter.R
+++ b/R/paste_linter.R
@@ -33,10 +33,7 @@ paste_linter <- function(allow_empty_sep = FALSE, allow_to_string = FALSE) {
       ]"
 
       empty_sep_expr <- xml2::xml_find_all(xml, sep_xpath)
-      sep_value <- get_r_string(xml2::xml_find_chr(
-        empty_sep_expr,
-        "string(./SYMBOL_SUB[text() = 'sep']/following-sibling::expr[1])"
-      ))
+      sep_value <- get_r_string(empty_sep_expr, xpath = "./SYMBOL_SUB[text() = 'sep']/following-sibling::expr[1]")
 
       empty_sep_lints <- xml_nodes_to_lints(
         empty_sep_expr[!nzchar(sep_value)],
@@ -56,10 +53,7 @@ paste_linter <- function(allow_empty_sep = FALSE, allow_to_string = FALSE) {
         and SYMBOL_SUB[text() = 'collapse']/following-sibling::expr[1][STR_CONST]
       ]")
       to_string_expr <- xml2::xml_find_all(xml, to_string_xpath)
-      collapse_value <- get_r_string(xml2::xml_find_chr(
-        to_string_expr,
-        "string(./SYMBOL_SUB[text() = 'collapse']/following-sibling::expr[1])"
-      ))
+      collapse_value <- get_r_string(to_string_expr, xpath = "./SYMBOL_SUB[text() = 'collapse']/following-sibling::expr[1]")
 
       to_string_lints <- xml_nodes_to_lints(
         to_string_expr[collapse_value == ", "],

--- a/R/paste_linter.R
+++ b/R/paste_linter.R
@@ -53,7 +53,10 @@ paste_linter <- function(allow_empty_sep = FALSE, allow_to_string = FALSE) {
         and SYMBOL_SUB[text() = 'collapse']/following-sibling::expr[1][STR_CONST]
       ]")
       to_string_expr <- xml2::xml_find_all(xml, to_string_xpath)
-      collapse_value <- get_r_string(to_string_expr, xpath = "./SYMBOL_SUB[text() = 'collapse']/following-sibling::expr[1]")
+      collapse_value <- get_r_string(
+        to_string_expr,
+        xpath = "./SYMBOL_SUB[text() = 'collapse']/following-sibling::expr[1]"
+      )
 
       to_string_lints <- xml_nodes_to_lints(
         to_string_expr[collapse_value == ", "],

--- a/R/redundant_ifelse_linter.R
+++ b/R/redundant_ifelse_linter.R
@@ -29,10 +29,10 @@ redundant_ifelse_linter <- function(allow10 = FALSE) {
       tf_expr,
       source_expression = source_expression,
       lint_message = function(expr) {
-        matched_call <- xml2::xml_text(xml2::xml_find_first(expr, "expr/SYMBOL_FUNCTION_CALL"))
+        matched_call <- xml2::xml_find_chr(expr, "string(expr/SYMBOL_FUNCTION_CALL)")
         # [1] call; [2] logical condiditon
-        first_arg <- xml2::xml_text(xml2::xml_find_first(expr, "expr[3]/NUM_CONST"))
-        second_arg <- xml2::xml_text(xml2::xml_find_first(expr, "expr[4]/NUM_CONST"))
+        first_arg <- xml2::xml_find_chr(expr, "string(expr[3]/NUM_CONST)")
+        second_arg <- xml2::xml_find_chr(expr, "string(expr[4]/NUM_CONST)")
         sprintf(
           "Just use the logical condition (or its negation) directly instead of calling %s(x, %s, %s)",
           matched_call, first_arg, second_arg
@@ -54,10 +54,10 @@ redundant_ifelse_linter <- function(allow10 = FALSE) {
         num_expr,
         source_expression = source_expression,
         lint_message = function(expr) {
-          matched_call <- xml2::xml_text(xml2::xml_find_first(expr, "expr/SYMBOL_FUNCTION_CALL"))
+          matched_call <- xml2::xml_find_chr(expr, "string(expr/SYMBOL_FUNCTION_CALL)")
           # [1] call; [2] logical condiditon
-          first_arg <- xml2::xml_text(xml2::xml_find_first(expr, "expr[3]/NUM_CONST"))
-          second_arg <- xml2::xml_text(xml2::xml_find_first(expr, "expr[4]/NUM_CONST"))
+          first_arg <- xml2::xml_find_chr(expr, "string(expr[3]/NUM_CONST)")
+          second_arg <- xml2::xml_find_chr(expr, "string(expr[4]/NUM_CONST)")
           replacement <- if (any(c(first_arg, second_arg) %in% c("0", "1"))) "as.numeric" else "as.integer"
           message <- sprintf(
             "Prefer %s(x) to %s(x, %s, %s) if really needed,",

--- a/R/redundant_ifelse_linter.R
+++ b/R/redundant_ifelse_linter.R
@@ -29,7 +29,7 @@ redundant_ifelse_linter <- function(allow10 = FALSE) {
       tf_expr,
       source_expression = source_expression,
       lint_message = function(expr) {
-        matched_call <- xml2::xml_find_chr(expr, "string(expr/SYMBOL_FUNCTION_CALL)")
+        matched_call <- xp_call_name(expr)
         # [1] call; [2] logical condiditon
         first_arg <- xml2::xml_find_chr(expr, "string(expr[3]/NUM_CONST)")
         second_arg <- xml2::xml_find_chr(expr, "string(expr[4]/NUM_CONST)")
@@ -54,7 +54,7 @@ redundant_ifelse_linter <- function(allow10 = FALSE) {
         num_expr,
         source_expression = source_expression,
         lint_message = function(expr) {
-          matched_call <- xml2::xml_find_chr(expr, "string(expr/SYMBOL_FUNCTION_CALL)")
+          matched_call <- xp_call_name(expr)
           # [1] call; [2] logical condiditon
           first_arg <- xml2::xml_find_chr(expr, "string(expr[3]/NUM_CONST)")
           second_arg <- xml2::xml_find_chr(expr, "string(expr[4]/NUM_CONST)")

--- a/R/system_file_linter.R
+++ b/R/system_file_linter.R
@@ -29,7 +29,7 @@ system_file_linter <- function() {
       bad_expr,
       source_expression = source_expression,
       lint_message = function(expr) {
-        outer_call <- xml2::xml_text(xml2::xml_find_first(expr, "expr/SYMBOL_FUNCTION_CALL"))
+        outer_call <- xml2::xml_find_chr(expr, "string(expr/SYMBOL_FUNCTION_CALL)")
         if (outer_call == "system.file") {
           bad_usage <- 'system.file(file.path("data", "model.csv"), package = "myrf")'
         } else {

--- a/R/system_file_linter.R
+++ b/R/system_file_linter.R
@@ -29,7 +29,7 @@ system_file_linter <- function() {
       bad_expr,
       source_expression = source_expression,
       lint_message = function(expr) {
-        outer_call <- xml2::xml_find_chr(expr, "string(expr/SYMBOL_FUNCTION_CALL)")
+        outer_call <- xp_call_name(expr)
         if (outer_call == "system.file") {
           bad_usage <- 'system.file(file.path("data", "model.csv"), package = "myrf")'
         } else {

--- a/R/unused_import_linter.R
+++ b/R/unused_import_linter.R
@@ -78,7 +78,7 @@ unused_import_linter <- function(allow_ns_usage = FALSE, except_packages = c("bi
       import_exprs[is_unused],
       source_expression = source_expression,
       lint_message = function(import_expr) {
-        pkg <- get_r_string(import_expr, xpath = "expr[STR_CONST | SYMBOL]")
+        pkg <- get_r_string(import_expr, xpath = "expr[STR_CONST|SYMBOL]")
         if (is_ns_used[match(pkg, imported_pkgs)]) {
           paste0(
             "package '", pkg, "' is only used by namespace. ",

--- a/R/unused_import_linter.R
+++ b/R/unused_import_linter.R
@@ -33,7 +33,7 @@ unused_import_linter <- function(allow_ns_usage = FALSE, except_packages = c("bi
     if (length(import_exprs) == 0L) {
       return(list())
     }
-    imported_pkgs <- xml2::xml_text(xml2::xml_find_first(import_exprs, "expr[STR_CONST|SYMBOL]"))
+    imported_pkgs <- xml2::xml_find_chr(import_exprs, "string(expr[STR_CONST|SYMBOL])")
     # as.character(parse(...)) returns one entry per expression
     imported_pkgs <- as.character(parse(text = imported_pkgs, keep.source = FALSE))
 
@@ -78,7 +78,7 @@ unused_import_linter <- function(allow_ns_usage = FALSE, except_packages = c("bi
       import_exprs[is_unused],
       source_expression = source_expression,
       lint_message = function(import_expr) {
-        pkg <- get_r_string(xml2::xml_text(xml2::xml_find_first(import_expr, "expr[STR_CONST|SYMBOL]")))
+        pkg <- get_r_string(xml2::xml_find_chr(import_expr, "string(expr[STR_CONST|SYMBOL])"))
         if (is_ns_used[match(pkg, imported_pkgs)]) {
           paste0(
             "package '", pkg, "' is only used by namespace. ",

--- a/R/unused_import_linter.R
+++ b/R/unused_import_linter.R
@@ -78,7 +78,7 @@ unused_import_linter <- function(allow_ns_usage = FALSE, except_packages = c("bi
       import_exprs[is_unused],
       source_expression = source_expression,
       lint_message = function(import_expr) {
-        pkg <- get_r_string(xml2::xml_find_chr(import_expr, "string(expr[STR_CONST|SYMBOL])"))
+        pkg <- get_r_string(import_expr, xpath = "expr[STR_CONST | SYMBOL]")
         if (is_ns_used[match(pkg, imported_pkgs)]) {
           paste0(
             "package '", pkg, "' is only used by namespace. ",

--- a/R/utils.R
+++ b/R/utils.R
@@ -219,7 +219,7 @@ platform_independent_sort <- function(x) x[platform_independent_order(x)]
 #   character literals valid since R 4.0, e.g. R"------[ hello ]------".
 # NB: this is also properly vectorized.
 get_r_string <- function(s, xpath = NULL) {
-  if (inherits(s, "xml_nodeset")) {
+  if (inherits(s, c("xml_node", "xml_nodeset"))) {
     if (is.null(xpath)) {
       s <- xml2::xml_text(s)
     } else {

--- a/R/utils.R
+++ b/R/utils.R
@@ -83,7 +83,7 @@ auto_names <- function(x) {
       paste(deparse(x, 500L), collapse = " ")
     }
   }
-  defaults <- vapply(x[missing], default_name, character(1), USE.NAMES = FALSE)
+  defaults <- vapply(x[missing], default_name, character(1L), USE.NAMES = FALSE)
 
   nms[missing] <- defaults
   nms

--- a/R/utils.R
+++ b/R/utils.R
@@ -220,6 +220,9 @@ platform_independent_sort <- function(x) x[platform_independent_order(x)]
 # NB: this is also properly vectorized.
 get_r_string <- function(s) {
   if (inherits(s, "xml_nodeset")) s <- xml2::xml_text(s)
+  # parse() skips "" elements --> offsets the length of the output,
+  #   but NA in --> NA out
+  is.na(s) <- !nzchar(s)
   out <- as.character(parse(text = s, keep.source = FALSE))
   is.na(out) <- is.na(s)
   out

--- a/R/utils.R
+++ b/R/utils.R
@@ -1,5 +1,5 @@
 `%||%` <- function(x, y) {
-  if (is.null(x) || length(x) <= 0 || is.na(x[[1L]])) {
+  if (is.null(x) || length(x) <= 0L || is.na(x[[1L]])) {
     y
   } else {
     x
@@ -108,7 +108,7 @@ get_content <- function(lines, info) {
 
   if (!missing(info)) {
     lines[length(lines)] <- substr(lines[length(lines)], 1L, info$col2)
-    lines[1] <- substr(lines[1], info$col1, nchar(lines[1]))
+    lines[1L] <- substr(lines[1L], info$col1, nchar(lines[1L]))
   }
   paste0(collapse = "\n", lines)
 }
@@ -122,7 +122,7 @@ logical_env <- function(x) {
 }
 
 # from ?chartr
-rot <- function(ch, k = 13) {
+rot <- function(ch, k = 13L) {
   p0 <- function(...) paste(c(...), collapse = "")
   alphabet <- c(letters, LETTERS, " '")
   idx <- seq_len(k)

--- a/R/utils.R
+++ b/R/utils.R
@@ -218,8 +218,14 @@ platform_independent_sort <- function(x) x[platform_independent_order(x)]
 # convert STR_CONST text() values into R strings. mainly to account for arbitrary
 #   character literals valid since R 4.0, e.g. R"------[ hello ]------".
 # NB: this is also properly vectorized.
-get_r_string <- function(s) {
-  if (inherits(s, "xml_nodeset")) s <- xml2::xml_text(s)
+get_r_string <- function(s, xpath = NULL) {
+  if (inherits(s, "xml_nodeset")) {
+    if (is.null(xpath)) {
+      s <- xml2::xml_text(s)
+    } else {
+      s <- xml2::xml_find_chr(s, sprintf("string(%s)", xpath))
+    }
+  }
   # parse() skips "" elements --> offsets the length of the output,
   #   but NA in --> NA out
   is.na(s) <- !nzchar(s)

--- a/R/xp_utils.R
+++ b/R/xp_utils.R
@@ -121,17 +121,7 @@ xp_call_name <- function(expr, depth = 1L, condition = NULL) {
     node <- sprintf("SYMBOL_FUNCTION_CALL[%s]", condition)
   }
 
-  # use an explicit condition for the most common cases, and an uglier
-  #   expression for full generality
-  if (depth == 0L) {
-    xpath <- node
-  } else if (depth == 1L) {
-    xpath <- sprintf("expr/%s", node)
-  } else if (depth == 2L) {
-    xpath <- sprintf("expr/expr/%s", node)
-  } else {
-    xpath <- do.call(file.path, c(rep(list("expr"), depth), list(node)))
-  }
+  xpath <- paste0("string(", strrep("expr/", depth), node, ")")
 
-  xml2::xml_find_chr(expr, sprintf("string(%s)", xpath))
+  xml2::xml_find_chr(expr, xpath)
 }

--- a/R/xp_utils.R
+++ b/R/xp_utils.R
@@ -113,3 +113,25 @@ xp_and <- function(...) paren_wrap(..., sep = "and")
 #' @param ... Series of conditions
 #' @noRd
 xp_or <- function(...) paren_wrap(..., sep = "or")
+
+xp_call_name <- function(expr, depth = 1L, condition = NULL) {
+  if (is.null(condition)) {
+    node <- "SYMBOL_FUNCTION_CALL"
+  } else {
+    node <- sprintf("SYMBOL_FUNCTION_CALL[%s]", condition)
+  }
+
+  # use an explicit condition for the most common cases, and an uglier
+  #   expression for full generality
+  if (depth == 0L) {
+    xpath <- node
+  } else if (depth == 1L) {
+    xpath <- sprintf("expr/%s", node)
+  } else if (depth == 2L) {
+    xpath <- sprintf("expr/expr/%s", node)
+  } else {
+    xpath <- do.call(file.path, c(rep(list("expr"), depth), list(node)))
+  }
+
+  xml2::xml_find_chr(expr, sprintf("string(%s)", xpath))
+}

--- a/R/yoda_test_linter.R
+++ b/R/yoda_test_linter.R
@@ -41,7 +41,7 @@ yoda_test_linter <- function() {
       bad_expr,
       source_expression = source_expression,
       lint_message = function(expr) {
-        matched_call <- xml2::xml_text(xml2::xml_find_first(expr, "expr/SYMBOL_FUNCTION_CALL"))
+        matched_call <- xml2::xml_find_chr(expr, "string(expr/SYMBOL_FUNCTION_CALL)")
         second_const <- xml2::xml_find_first(expr, glue::glue("expr[position() = 3 and ({const_condition})]"))
         if (is.na(second_const)) {
           paste(

--- a/R/yoda_test_linter.R
+++ b/R/yoda_test_linter.R
@@ -41,7 +41,7 @@ yoda_test_linter <- function() {
       bad_expr,
       source_expression = source_expression,
       lint_message = function(expr) {
-        matched_call <- xml2::xml_find_chr(expr, "string(expr/SYMBOL_FUNCTION_CALL)")
+        matched_call <- xp_call_name(expr)
         second_const <- xml2::xml_find_first(expr, glue::glue("expr[position() = 3 and ({const_condition})]"))
         if (is.na(second_const)) {
           paste(


### PR DESCRIPTION
Closes #1151 

Also introduce a new helper for the very common use case of `xml_find_char(expr, "string(SYMBOL_FUNCTION_CALL)")` (possibly nested at `expr/` or `expr/expr/` etc)

FWIW a quick test suggests it's about 20% faster to use `xml_find_char()` as well.