### PR TITLE
improve performance of XPath linters using //* predicates

### DIFF
--- a/R/assignment_linter.R
+++ b/R/assignment_linter.R
@@ -18,7 +18,6 @@ assignment_linter <- function(allow_cascading_assign = TRUE, allow_right_assign 
 
     xml <- source_expression$xml_parsed_content
 
-    # TODO: is there any performance consideration for //*[self::a or self::b] vs. //a|//b ?
     xpath <- paste(collapse = " | ", c(
       # always block = (NB: the parser differentiates EQ_ASSIGN, EQ_SUB, and EQ_FORMALS)
       "//EQ_ASSIGN",

--- a/R/backport_linter.R
+++ b/R/backport_linter.R
@@ -19,7 +19,7 @@ backport_linter <- function(r_version = getRversion()) {
 
     xml <- source_expression$xml_parsed_content
 
-    names_xpath <- "//*[self::SYMBOL or self::SYMBOL_FUNCTION_CALL]"
+    names_xpath <- "//SYMBOL | //SYMBOL_FUNCTION_CALL"
     all_names_nodes <- xml2::xml_find_all(xml, names_xpath)
     all_names <- xml2::xml_text(all_names_nodes)
 

--- a/R/infix_spaces_linter.R
+++ b/R/infix_spaces_linter.R
@@ -84,43 +84,44 @@ infix_spaces_linter <- function(exclude_operators = NULL, allow_multiple_spaces 
     op <- "!="
     lint_message <- "Put exactly one space on each side of infix operators."
   }
+
+  infix_tokens <- infix_metadata[
+    infix_metadata$low_precedence & !infix_metadata$string_value %in% exclude_operators,
+    "xml_tag"
+  ]
+
+  # NB: preceding-sibling::* and not preceding-sibling::expr because
+  #   of the foo(a=1) case, where the tree is <SYMBOL_SUB><EQ_SUB><expr>
+  # NB: preceding-sibling::* for the unary case, e.g. x[-1]
+  # NB: the last not() disables lints inside box::use() declarations
+  xp_condition <- glue::glue("
+    preceding-sibling::*
+    and (
+      (
+        @line1 = preceding-sibling::*[1]/@line1
+        and @col1 {op} preceding-sibling::*[1]/@col2 + 2
+      ) or (
+        @line1 = following-sibling::*[1]/@line1
+        and following-sibling::*[1]/@col1 {op} @col2 + 2
+      )
+    )
+    and not(
+      self::OP-SLASH[
+        ancestor::expr/preceding-sibling::OP-LEFT-PAREN/preceding-sibling::expr[
+          ./SYMBOL_PACKAGE[text() = 'box'] and
+          ./SYMBOL_FUNCTION_CALL[text() = 'use']
+        ]
+      ]
+    )
+  ")
+  xpath <- paste(glue::glue("//{infix_tokens}[{xp_condition}]"), collapse = " | ")
+
   Linter(function(source_expression) {
     if (!is_lint_level(source_expression, "expression")) {
       return(list())
     }
 
     xml <- source_expression$xml_parsed_content
-    infix_tokens <- infix_metadata[
-      infix_metadata$low_precedence & !infix_metadata$string_value %in% exclude_operators,
-      "xml_tag"
-    ]
-
-    # NB: preceding-sibling::* and not preceding-sibling::expr because
-    #   of the foo(a=1) case, where the tree is <SYMBOL_SUB><EQ_SUB><expr>
-    # NB: preceding-sibling::* for the unary case, e.g. x[-1]
-    # NB: the last not() disables lints inside box::use() declarations
-    xp_condition <- glue::glue("
-      preceding-sibling::*
-      and (
-        (
-          @line1 = preceding-sibling::*[1]/@line1
-          and @col1 {op} preceding-sibling::*[1]/@col2 + 2
-        ) or (
-          @line1 = following-sibling::*[1]/@line1
-          and following-sibling::*[1]/@col1 {op} @col2 + 2
-        )
-      )
-      and not(
-        self::OP-SLASH[
-          ancestor::expr/preceding-sibling::OP-LEFT-PAREN/preceding-sibling::expr[
-            ./SYMBOL_PACKAGE[text() = 'box'] and
-            ./SYMBOL_FUNCTION_CALL[text() = 'use']
-          ]
-        ]
-      )
-    ")
-    xpath <- paste(glue::glue("//{infix_tokens}[{xp_condition}]"), collapse = " | ")
-
     bad_expr <- xml2::xml_find_all(xml, xpath)
 
     xml_nodes_to_lints(bad_expr, source_expression = source_expression, lint_message = lint_message, type = "style")

--- a/R/infix_spaces_linter.R
+++ b/R/infix_spaces_linter.R
@@ -97,11 +97,10 @@ infix_spaces_linter <- function(exclude_operators = NULL, allow_multiple_spaces 
 
     # NB: preceding-sibling::* and not preceding-sibling::expr because
     #   of the foo(a=1) case, where the tree is <SYMBOL_SUB><EQ_SUB><expr>
-    # NB: position() > 1 for the unary case, e.g. x[-1]
+    # NB: not(preceding-sibling::expr) for the unary case, e.g. x[-1]
     # NB: the last not() disables lints inside box::use() declarations
-    xpath <- glue::glue("//*[
-      ({xp_or(paste0('self::', infix_tokens))})
-      and position() > 1
+    xp_condition <- glue::glue("
+      preceding-sibling::*
       and (
         (
           @line1 = preceding-sibling::*[1]/@line1
@@ -119,7 +118,8 @@ infix_spaces_linter <- function(exclude_operators = NULL, allow_multiple_spaces 
           ]
         ]
       )
-    ]")
+    ")
+    xpath <- paste(glue::glue("//{infix_tokens}[{xp_condition}]"), collapse = " | ")
 
     bad_expr <- xml2::xml_find_all(xml, xpath)
 

--- a/R/infix_spaces_linter.R
+++ b/R/infix_spaces_linter.R
@@ -97,7 +97,7 @@ infix_spaces_linter <- function(exclude_operators = NULL, allow_multiple_spaces 
 
     # NB: preceding-sibling::* and not preceding-sibling::expr because
     #   of the foo(a=1) case, where the tree is <SYMBOL_SUB><EQ_SUB><expr>
-    # NB: not(preceding-sibling::expr) for the unary case, e.g. x[-1]
+    # NB: preceding-sibling::* for the unary case, e.g. x[-1]
     # NB: the last not() disables lints inside box::use() declarations
     xp_condition <- glue::glue("
       preceding-sibling::*

--- a/R/infix_spaces_linter.R
+++ b/R/infix_spaces_linter.R
@@ -100,10 +100,11 @@ infix_spaces_linter <- function(exclude_operators = NULL, allow_multiple_spaces 
 
   # NB: preceding-sibling::* and not preceding-sibling::expr because
   #   of the foo(a=1) case, where the tree is <SYMBOL_SUB><EQ_SUB><expr>
-  # NB: preceding-sibling::* for the unary case, e.g. x[-1]
+  # NB: position() > 1 for the unary case, e.g. x[-1]
   # NB: the last not() disables lints inside box::use() declarations
-  xp_condition <- glue::glue("
-    preceding-sibling::*
+  xpath <- glue::glue("//*[
+    ({xp_or(paste0('self::', infix_tokens))})
+    and position() > 1
     and (
       (
         @line1 = preceding-sibling::*[1]/@line1
@@ -121,9 +122,7 @@ infix_spaces_linter <- function(exclude_operators = NULL, allow_multiple_spaces 
         ]
       ]
     )
-  ")
-  xpath <- paste(glue::glue("//{infix_tokens}[{xp_condition}]"), collapse = " | ")
-
+  ]")
   Linter(function(source_expression) {
     if (!is_lint_level(source_expression, "expression")) {
       return(list())

--- a/R/object_usage_linter.R
+++ b/R/object_usage_linter.R
@@ -195,20 +195,14 @@ get_assignment_symbols <- function(xml) {
 get_function_assignments <- function(xml) {
   # NB: difference across R versions in how EQ_ASSIGN is represented in the AST
   #   (under <expr_or_assign_or_help> or <equal_assign>)
-  # TODO(#1106): use //*[...] to capture assignments in more scopes
+  # TODO(#1106): use //[...] to capture assignments in more scopes
   funs <- xml2::xml_find_all(
     xml,
     paste(
       # direct assignments
-      "*[
-        (
-          (self::expr and (LEFT_ASSIGN or EQ_ASSIGN))
-          or ((self::expr_or_assign_or_help or self::equal_assign) and EQ_ASSIGN)
-        )
-        and expr[2][FUNCTION]
-      ]
-      /expr[2]
-      ",
+      "expr[LEFT_ASSIGN or EQ_ASSIGN]/expr[2][FUNCTION]",
+      "expr_or_assign_or_help[EQ_ASSIGN]/expr[2][FUNCTION]",
+      "equal_assign[EQ_ASSIGN]/expr[2][FUNCTION]",
       # assign() and setMethod() assignments
       "//expr[expr[SYMBOL_FUNCTION_CALL[text() = 'assign' or text() = 'setMethod']]]/expr[3]",
       sep = " | "

--- a/R/object_usage_linter.R
+++ b/R/object_usage_linter.R
@@ -195,6 +195,8 @@ get_assignment_symbols <- function(xml) {
 get_function_assignments <- function(xml) {
   # NB: difference across R versions in how EQ_ASSIGN is represented in the AST
   #   (under <expr_or_assign_or_help> or <equal_assign>)
+  # NB: the repeated expr[2][FUNCTION] XPath has no performance impact, so the different direct assignment XPaths are
+  #   split for better readability, see PR#1197
   # TODO(#1106): use //[...] to capture assignments in more scopes
   funs <- xml2::xml_find_all(
     xml,

--- a/R/package_hooks_linter.R
+++ b/R/package_hooks_linter.R
@@ -91,10 +91,14 @@ package_hooks_linter <- function() {
     # NB: base only checks the SYMBOL_FUNCTION_CALL version, not SYMBOL.
     library_require_xpath <- "
     //expr[SYMBOL[text() = '.onAttach' or text() = '.onLoad']]
-    /following-sibling::expr//*[
-      (self::SYMBOL or self::SYMBOL_FUNCTION_CALL)
-      and (text() = 'require' or text() = 'library' or text() = 'installed.packages')
-    ]
+    /following-sibling::expr
+    /descendant::SYMBOL[text() = 'require' or text() = 'library' or text() = 'installed.packages']
+
+    |
+
+    //expr[SYMBOL[text() = '.onAttach' or text() = '.onLoad']]
+    /following-sibling::expr
+    /descendant::SYMBOL_FUNCTION_CALL[text() = 'require' or text() = 'library' or text() = 'installed.packages']
     "
 
     library_require_expr <- xml2::xml_find_all(xml, library_require_xpath)

--- a/R/package_hooks_linter.R
+++ b/R/package_hooks_linter.R
@@ -91,14 +91,10 @@ package_hooks_linter <- function() {
     # NB: base only checks the SYMBOL_FUNCTION_CALL version, not SYMBOL.
     library_require_xpath <- "
     //expr[SYMBOL[text() = '.onAttach' or text() = '.onLoad']]
-    /following-sibling::expr
-    /descendant::SYMBOL[text() = 'require' or text() = 'library' or text() = 'installed.packages']
-
-    |
-
-    //expr[SYMBOL[text() = '.onAttach' or text() = '.onLoad']]
-    /following-sibling::expr
-    /descendant::SYMBOL_FUNCTION_CALL[text() = 'require' or text() = 'library' or text() = 'installed.packages']
+    /following-sibling::expr//*[
+      (self::SYMBOL or self::SYMBOL_FUNCTION_CALL)
+      and (text() = 'require' or text() = 'library' or text() = 'installed.packages')
+    ]
     "
 
     library_require_expr <- xml2::xml_find_all(xml, library_require_xpath)

--- a/R/undesirable_function_linter.R
+++ b/R/undesirable_function_linter.R
@@ -14,26 +14,27 @@ undesirable_function_linter <- function(fun = default_undesirable_functions,
                                         symbol_is_undesirable = TRUE) {
   stopifnot(is.logical(symbol_is_undesirable))
 
+  if (symbol_is_undesirable) {
+    tokens <- c("SYMBOL_FUNCTION_CALL", "SYMBOL")
+  } else {
+    tokens <- "SYMBOL_FUNCTION_CALL"
+  }
+
+  xp_condition <- xp_and(
+    xp_text_in_table(names(fun)),
+    paste0(
+      "not(parent::expr/preceding-sibling::expr[SYMBOL_FUNCTION_CALL[",
+      xp_text_in_table(c("library", "require")),
+      "]])"
+    ),
+    "not(preceding-sibling::OP-DOLLAR)"
+  )
+  xpath <- paste(glue::glue("//{tokens}[{xp_condition}]"), collapse = " | ")
+
   Linter(function(source_expression) {
     if (!is_lint_level(source_expression, "expression")) {
       return(list())
     }
-    if (symbol_is_undesirable) {
-      tokens <- c("SYMBOL_FUNCTION_CALL", "SYMBOL")
-    } else {
-      tokens <- "SYMBOL_FUNCTION_CALL"
-    }
-
-    xp_condition <- xp_and(
-      xp_text_in_table(names(fun)),
-      paste0(
-        "not(parent::expr/preceding-sibling::expr[SYMBOL_FUNCTION_CALL[",
-        xp_text_in_table(c("library", "require")),
-        "]])"
-      ),
-      "not(preceding-sibling::OP-DOLLAR)"
-    )
-    xpath <- paste(glue::glue("//{tokens}[{xp_condition}]"), collapse = " | ")
     matched_nodes <- xml2::xml_find_all(source_expression$xml_parsed_content, xpath)
 
     lapply(

--- a/R/undesirable_function_linter.R
+++ b/R/undesirable_function_linter.R
@@ -24,8 +24,7 @@ undesirable_function_linter <- function(fun = default_undesirable_functions,
       tokens <- "SYMBOL_FUNCTION_CALL"
     }
 
-    xpath <- paste0("//*[", xp_and(
-      paste0("self::", tokens, collapse = " or "),
+    xp_condition <- xp_and(
       xp_text_in_table(names(fun)),
       paste0(
         "not(parent::expr/preceding-sibling::expr[SYMBOL_FUNCTION_CALL[",
@@ -33,8 +32,8 @@ undesirable_function_linter <- function(fun = default_undesirable_functions,
         "]])"
       ),
       "not(preceding-sibling::OP-DOLLAR)"
-    ), "]")
-
+    )
+    xpath <- paste(glue::glue("//{tokens}[{xp_condition}]"), collapse = " | ")
     matched_nodes <- xml2::xml_find_all(source_expression$xml_parsed_content, xpath)
 
     lapply(

--- a/R/undesirable_function_linter.R
+++ b/R/undesirable_function_linter.R
@@ -14,12 +14,6 @@ undesirable_function_linter <- function(fun = default_undesirable_functions,
                                         symbol_is_undesirable = TRUE) {
   stopifnot(is.logical(symbol_is_undesirable))
 
-  if (symbol_is_undesirable) {
-    tokens <- c("SYMBOL_FUNCTION_CALL", "SYMBOL")
-  } else {
-    tokens <- "SYMBOL_FUNCTION_CALL"
-  }
-
   xp_condition <- xp_and(
     xp_text_in_table(names(fun)),
     paste0(
@@ -29,7 +23,13 @@ undesirable_function_linter <- function(fun = default_undesirable_functions,
     ),
     "not(preceding-sibling::OP-DOLLAR)"
   )
-  xpath <- paste(glue::glue("//{tokens}[{xp_condition}]"), collapse = " | ")
+
+  if (symbol_is_undesirable) {
+    xpath <- glue::glue("//SYMBOL_FUNCTION_CALL[{xp_condition}] | //SYMBOL[{xp_condition}]")
+  } else {
+    xpath <- glue::glue("//SYMBOL_FUNCTION_CALL[{xp_condition}]")
+  }
+
 
   Linter(function(source_expression) {
     if (!is_lint_level(source_expression, "expression")) {

--- a/R/vector_logic_linter.R
+++ b/R/vector_logic_linter.R
@@ -12,6 +12,7 @@
 #'   <https://style.tidyverse.org/syntax.html#if-statements>
 #' @export
 vector_logic_linter <- function() {
+
   # ensures the expr is in the cond part of `if/while (cond) expr` --
   #   if on the XML parse tree is structured like
   #   <expr>
@@ -24,22 +25,21 @@ vector_logic_linter <- function() {
   #     <expr> ... </expr>
   #  </expr>
   #  we _don't_ want to match anything on the second expr, hence this
-
-  xp_condition <- "
-    ancestor::expr[
+  xpath <- "//*[
+    (self::AND or self::OR)
+    and ancestor::expr[
       not(preceding-sibling::OP-RIGHT-PAREN)
-      and (
-        preceding-sibling::IF or
-        preceding-sibling::WHILE or
-        preceding-sibling::expr[SYMBOL_FUNCTION_CALL[text() = 'expect_true' or text() = 'expect_false']]
-      )
+      and preceding-sibling::*[
+        self::IF
+        or self::WHILE
+        or self::expr[SYMBOL_FUNCTION_CALL[text() = 'expect_true' or text() = 'expect_false']]
+      ]
     ]
     and not(ancestor::expr[
       preceding-sibling::expr[SYMBOL_FUNCTION_CALL[not(text() = 'expect_true' or text() = 'expect_false')]]
       or preceding-sibling::OP-LEFT-BRACKET
     ])
-  "
-  xpath <- glue::glue("//AND[{xp_condition}] | //OR[{xp_condition}]")
+  ]"
 
   Linter(function(source_expression) {
     if (!is_lint_level(source_expression, "expression")) {

--- a/R/vector_logic_linter.R
+++ b/R/vector_logic_linter.R
@@ -31,21 +31,22 @@ vector_logic_linter <- function() {
     #     <expr> ... </expr>
     #  </expr>
     #  we _don't_ want to match anything on the second expr, hence this
-    xpath <- "//*[
-      (self::AND or self::OR)
-      and ancestor::expr[
+
+    xp_condition <- "
+      ancestor::expr[
         not(preceding-sibling::OP-RIGHT-PAREN)
-        and preceding-sibling::*[
-          self::IF
-          or self::WHILE
-          or self::expr[SYMBOL_FUNCTION_CALL[text() = 'expect_true' or text() = 'expect_false']]
-        ]
+        and (
+          preceding-sibling::IF or
+          preceding-sibling::WHILE or
+          preceding-sibling::expr[SYMBOL_FUNCTION_CALL[text() = 'expect_true' or text() = 'expect_false']]
+        )
       ]
       and not(ancestor::expr[
         preceding-sibling::expr[SYMBOL_FUNCTION_CALL[not(text() = 'expect_true' or text() = 'expect_false')]]
         or preceding-sibling::OP-LEFT-BRACKET
       ])
-    ]"
+    "
+    xpath <- glue::glue("//AND[{xp_condition}] | //OR[{xp_condition}]")
     bad_expr <- xml2::xml_find_all(xml, xpath)
 
     xml_nodes_to_lints(


### PR DESCRIPTION
Rewrote all `//*[(self::xxx or self::yyy) and zzz]` constructs to the faster `//xxx[zzz] | //xxx[zzz]` XPath representation.