### PR TITLE
remove package prefix from auto-generated names

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -63,10 +63,11 @@ names2 <- function(x) {
 linter_auto_name <- function(which = -3L) {
   call <- sys.call(which = which)
   nm <- paste(deparse(call, 500L), collapse = " ")
-  regex <- rex(start, one_or_more(alnum %or% "." %or% "_"))
+  regex <- rex(start, one_or_more(alnum %or% "." %or% "_" %or% ":"))
   if (re_matches(nm, regex)) {
     match <- re_matches(nm, regex, locations = TRUE)
     nm <- substr(nm, start = 1L, stop = match[1L, "end"])
+    nm <- re_substitutes(nm, rex::rex(start, alnums, "::"), "")
   }
   nm
 }

--- a/R/with.R
+++ b/R/with.R
@@ -34,7 +34,7 @@ modify_defaults <- function(defaults, ...) {
           # Very long input might have newlines which are not caught
           #  by . in a perl regex; see #774
         re_substitutes(args, rex("(", anything), "", options = "s"),
-        rex(start, anything, '["'),
+        rex(start, anything, '["' %or% "::"),
         ""
       ),
       rex('"]', anything, end),

--- a/tests/testthat/test-settings.R
+++ b/tests/testthat/test-settings.R
@@ -114,7 +114,7 @@ test_that("linters_with_defaults doesn't break on very long input", {
         )
       ))
     ),
-    "lintr::undesirable_function_linter"
+    "undesirable_function_linter"
   )
 })
 


### PR DESCRIPTION
Partially fixes #1193

```
lintr::lint(text = "a = 1 # nolint: implicit_integer.", linters = lintr::implicit_integer_linter())
```

is silent with this fix because `lintr::implicit_integer_linter()` is correctly named `"implicit_integer_linter"`.