### PR TITLE
generate top level parsed content map instead of tree in `get_source_expressions()`

### DIFF
--- a/R/get_source_expressions.R
+++ b/R/get_source_expressions.R
@@ -78,7 +78,7 @@ get_source_expressions <- function(filename, lines = NULL) {
   )
   source_expression$content <- get_content(source_expression$lines)
   parsed_content <- get_source_expression(source_expression, error = function(e) lint_parse_error(e, source_expression))
-  tree <- generate_tree(parsed_content)
+  top_level_map <- generate_top_level_map(parsed_content)
 
   if (inherits(e, "lint") && !nzchar(e$line)) {
     # Don't create expression list if it's unreliable (invalid encoding or unhandled parse error)
@@ -90,7 +90,7 @@ get_source_expressions <- function(filename, lines = NULL) {
       parsed_content,
       source_expression,
       filename,
-      tree
+      top_level_map
     )
 
     # add global expression
@@ -370,15 +370,13 @@ get_single_source_expression <- function(loc,
                                          parsed_content,
                                          source_expression,
                                          filename,
-                                         tree) {
+                                         top_level_map) {
   line_nums <- parsed_content$line1[loc]:parsed_content$line2[loc]
   expr_lines <- source_expression$lines[line_nums]
   names(expr_lines) <- line_nums
   content <- get_content(expr_lines, parsed_content[loc, ])
 
-  id <- as.character(parsed_content$id[loc])
-  edges <- component_edges(tree, id)
-  pc <- parsed_content[c(loc, edges), ]
+  pc <- parsed_content[c(loc, which(top_level_map == loc)), ]
   list(
     filename = filename,
     line = parsed_content[loc, "line1"],

--- a/R/tree-utils.R
+++ b/R/tree-utils.R
@@ -1,32 +1,16 @@
-generate_tree <- function(pc) {
+generate_top_level_map <- function(pc) {
   if (is.null(pc)) {
     return(NULL)
   }
-  edges <- matrix(as.character(c(pc$parent, pc$id)), ncol = 2L)
-  list(edges = edges, adjlist = adjlist_from_edgelist(edges))
-}
-
-## Create an adjacency list from an edge list
-
-adjlist_from_edgelist <- function(edges) {
-  tapply(edges[, 2L], edges[, 1L], c, simplify = FALSE)
-}
-
-## Take the subcomponent of id (mode out), and then all edges
-## that start at these vertices
-
-component_edges <- function(graph, id) {
-  sc <- newv <- unique(id)
-  size <- length(sc)
-  repeat {
-    neis <- unlist(graph$adjlist[newv])
-    newv <- setdiff(neis, sc)
-    sc <- c(sc, newv)
-    if (length(sc) == size) break
-    size <- length(sc)
+  tl_ids <- pc$id[pc$parent <= 0L]
+  tl_parent <- pc$parent
+  tl_parent[pc$parent <= 0L] <- tl_ids
+  i_not_assigned <- which(!tl_parent %in% tl_ids)
+  while (length(i_not_assigned)) {
+    tl_parent[i_not_assigned] <- pc$parent[match(tl_parent[i_not_assigned], pc$id)]
+    i_not_assigned <- which(!tl_parent %in% tl_ids)
   }
-
-  which(graph$edges[, 1L] %in% sc)
+  tl_parent
 }
 
 lag <- function(x) {


### PR DESCRIPTION
I noticed `get_source_expressions()` was very slow on `tools/QC.R` and set out to optimize it.

Instead of computing the parse tree as a graph ahead of time and then recursing this data structure for each and every top level expression, we now generate a mapping from parsed content to top level expression ahead of time and then just index into that mapping.

Results speak for themselves:

```
> system.time(get_source_expressions(test_file))
   user  system elapsed 
  4.420   0.002   4.422 
> devtools::load_all()
ℹ Loading lintr
> system.time(get_source_expressions(test_file))
   user  system elapsed 
  1.651   0.000   1.651 
```