### PR TITLE
generate expression xml parse data from full xml parse data

### DIFF
--- a/R/get_source_expressions.R
+++ b/R/get_source_expressions.R
@@ -84,7 +84,7 @@ get_source_expressions <- function(filename, lines = NULL) {
     # Don't create expression list if it's unreliable (invalid encoding or unhandled parse error)
     expressions <- list()
   } else {
-     xml_parsed_content <- safe_parse_to_xml(parsed_content)
+    xml_parsed_content <- safe_parse_to_xml(parsed_content)
 
     expressions <- lapply(
       X = top_level_expressions(parsed_content),
@@ -95,14 +95,16 @@ get_source_expressions <- function(filename, lines = NULL) {
       top_level_map
     )
 
-    expression_xmls <- lapply(
-      xml2::xml_find_all(xml_parsed_content, "/exprlist/*"),
-      function(top_level_expr) xml2::xml_add_parent(xml2::xml_new_root(top_level_expr), "exprlist")
-    )
-    expressions[] <- Map(function(expr, xml) {
-      expr$xml_parsed_content <- xml
-      expr
-    }, expr = expressions, xml = expression_xmls)
+    if (!is.null(xml_parsed_content)) {
+      expression_xmls <- lapply(
+        xml2::xml_find_all(xml_parsed_content, "/exprlist/*"),
+        function(top_level_expr) xml2::xml_add_parent(xml2::xml_new_root(top_level_expr), "exprlist")
+      )
+      expressions[] <- Map(function(expr, xml) {
+        expr$xml_parsed_content <- xml
+        expr
+      }, expr = expressions, xml = expression_xmls)
+    }
 
     # add global expression
     expressions[[length(expressions) + 1L]] <-

--- a/R/get_source_expressions.R
+++ b/R/get_source_expressions.R
@@ -84,6 +84,8 @@ get_source_expressions <- function(filename, lines = NULL) {
     # Don't create expression list if it's unreliable (invalid encoding or unhandled parse error)
     expressions <- list()
   } else {
+     xml_parsed_content <- safe_parse_to_xml(parsed_content)
+
     expressions <- lapply(
       X = top_level_expressions(parsed_content),
       FUN = get_single_source_expression,
@@ -93,6 +95,15 @@ get_source_expressions <- function(filename, lines = NULL) {
       top_level_map
     )
 
+    expression_xmls <- lapply(
+      xml2::xml_find_all(xml_parsed_content, "/exprlist/*"),
+      function(top_level_expr) xml2::xml_add_parent(xml2::xml_new_root(top_level_expr), "exprlist")
+    )
+    expressions[] <- Map(function(expr, xml) {
+      expr$xml_parsed_content <- xml
+      expr
+    }, expr = expressions, xml = expression_xmls)
+
     # add global expression
     expressions[[length(expressions) + 1L]] <-
       list(
@@ -100,7 +111,7 @@ get_source_expressions <- function(filename, lines = NULL) {
         file_lines = source_expression$lines,
         content = source_expression$lines,
         full_parsed_content = parsed_content,
-        full_xml_parsed_content = safe_parse_to_xml(parsed_content),
+        full_xml_parsed_content = xml_parsed_content,
         terminal_newline = terminal_newline
       )
   }
@@ -383,7 +394,7 @@ get_single_source_expression <- function(loc,
     column = parsed_content[loc, "col1"],
     lines = expr_lines,
     parsed_content = pc,
-    xml_parsed_content = safe_parse_to_xml(pc),
+    xml_parsed_content = NULL,
     content = content,
     find_line = find_line_fun(content),
     find_column = find_column_fun(content)

--- a/R/get_source_expressions.R
+++ b/R/get_source_expressions.R
@@ -100,10 +100,9 @@ get_source_expressions <- function(filename, lines = NULL) {
         xml2::xml_find_all(xml_parsed_content, "/exprlist/*"),
         function(top_level_expr) xml2::xml_add_parent(xml2::xml_new_root(top_level_expr), "exprlist")
       )
-      expressions[] <- Map(function(expr, xml) {
-        expr$xml_parsed_content <- xml
-        expr
-      }, expr = expressions, xml = expression_xmls)
+      for (i in seq_along(expressions)) {
+        expressions[[i]]$xml_parsed_content <- expression_xmls[[i]]
+      }
     }
 
     # add global expression

--- a/R/get_source_expressions.R
+++ b/R/get_source_expressions.R
@@ -95,7 +95,7 @@ get_source_expressions <- function(filename, lines = NULL) {
       top_level_map
     )
 
-    if (!is.null(xml_parsed_content)) {
+    if (!is.null(xml_parsed_content) && !is.na(xml_parsed_content)) {
       expression_xmls <- lapply(
         xml2::xml_find_all(xml_parsed_content, "/exprlist/*"),
         function(top_level_expr) xml2::xml_add_parent(xml2::xml_new_root(top_level_expr), "exprlist")
@@ -395,7 +395,7 @@ get_single_source_expression <- function(loc,
     column = parsed_content[loc, "col1"],
     lines = expr_lines,
     parsed_content = pc,
-    xml_parsed_content = NULL,
+    xml_parsed_content = xml2::xml_missing(),
     content = content,
     find_line = find_line_fun(content),
     find_column = find_column_fun(content)


### PR DESCRIPTION
Another 20% performance improvement by parsing the XML only once and creating the expression documents from the full document.

```
> system.time(get_source_expressions(test_file))
   user  system elapsed 
  2.099   0.001   2.099 
> devtools::load_all()
ℹ Loading lintr
> system.time(get_source_expressions(test_file))
   user  system elapsed 
  1.635   0.001   1.636 
```