### PR TITLE
use expect_length for xml_missing test

### DIFF
--- a/R/make_linter_from_regex.R
+++ b/R/make_linter_from_regex.R
@@ -51,7 +51,7 @@ make_linter_from_regex <- function(regex,
         line_numbers
       )
 
-      lapply(lints, function(x) x[lengths(x) > 0L])
+      Filter(function(x) any(lengths(x) > 0L), lints)
     })
   }
 }

--- a/tests/testthat/test-get_source_expressions.R
+++ b/tests/testthat/test-get_source_expressions.R
@@ -269,9 +269,8 @@ patrick::with_parameters_test_that(
   {
     linter <- eval(call(linter))
     expression <- expressions[[expression_idx]]
-    # TODO(#1160): try and simplify this to expect_length(linter(.), 0L)
     expect_warning(lints <- linter(expression), NA)
-    expect_identical(length(flatten_lints(lints)), 0L)
+    expect_length(lints, 0L)
   },
   .test_name = param_df$.test_name,
   linter = param_df$linter,


### PR DESCRIPTION
Closes #1160 

Also fix `make_linter_from_regex` again -- we need to drop outer elements, not inner elements