### PR TITLE
refactor closed_curly_linter() to XPath (reduces cyclocomp to 4)

### DIFF
--- a/R/closed_curly_linter.R
+++ b/R/closed_curly_linter.R
@@ -1,6 +1,6 @@
 #' Closed curly linter
 #'
-#' Check that closed curly braces are on their own line unless they follow an else.
+#' Check that closed curly braces are on their own line unless they follow an else, comma, or closing bracket.
 #'
 #' @param allow_single_line if `TRUE`, allow an open and closed curly pair on the same line.
 #' @evalRd rd_tags("closed_curly_linter")

--- a/R/closed_curly_linter.R
+++ b/R/closed_curly_linter.R
@@ -10,66 +10,43 @@
 #' @export
 closed_curly_linter <- function(allow_single_line = FALSE) {
   lintr_deprecated("closed_curly_linter", new = "brace_linter", version = "2.0.1.9001", type = "Linter")
+  xp_cond_closed <- xp_and(c(
+    # matching { is on same line
+    if (isTRUE(allow_single_line)) {
+      "(@line1 != preceding-sibling::OP-LEFT-BRACE/@line1)"
+    },
+    # immediately followed by ",", "]" or ")"
+    "not(
+      @line1 = ancestor::expr/following-sibling::*[1][
+        self::OP-COMMA or self::OP-RIGHT-BRACKET or self::OP-RIGHT-PAREN
+      ]/@line1
+    )",
+    # double curly
+    "not(
+      (@line1 = parent::expr/following-sibling::OP-RIGHT-BRACE/@line1) or
+      (@line1 = preceding-sibling::expr/OP-RIGHT-BRACE/@line1)
+    )"
+  ))
+
+  xpath <- glue::glue("//OP-RIGHT-BRACE[
+    { xp_cond_closed } and (
+      (@line1 = preceding-sibling::*[1]/@line2) or
+      (@line1 = parent::expr/following-sibling::*[1][not(self::ELSE)]/@line1)
+    )
+  ]")
+
   Linter(function(source_expression) {
-    lapply(ids_with_token(source_expression, "'}'"),
-           function(id) {
+    if (!is_lint_level(source_expression, "expression")) {
+      return(list())
+    }
 
-        parsed <- with_id(source_expression, id)
-        parsed_content <- source_expression[["parsed_content"]]
-
-        tokens_before <- parsed_content$token[
-          parsed_content$line1 == parsed$line1 &
-            parsed_content$col1 < parsed$col1
-        ]
-
-        tokens_after <- parsed_content$token[
-          parsed_content$line1 == parsed$line1 &
-            parsed_content$col1 > parsed$col1
-        ]
-        if (isTRUE(allow_single_line) &&
-            "'{'" %in% tokens_before) {
-          return()
-        }
-
-        if (length(tokens_after) &&
-            tokens_after[[1L]] %in% c("')'", "','")) {
-          return()
-        }
-
-        has_expression_before <- any(tokens_before %in% "expr")
-
-        has_expression_after <- any(tokens_after %in% "expr")
-
-        has_else_after <- any(tokens_after %in% "ELSE")
-
-        line <- source_expression$lines[as.character(parsed$line1)]
-        content_after <- unname(substr(line, parsed$col1 + 1L, nchar(line)))
-        content_before <- unname(substr(line, 1L, parsed$col1 - 1L))
-
-        double_curly <- rex::re_matches(content_after, rex::rex(start, "}")) ||
-          rex::re_matches(content_before, rex::rex("}", end))
-
-        if (double_curly) {
-          return()
-        }
-
-        # If the closing curly has an expression on the same line, and there is
-        # not also an else
-        if (has_expression_before ||
-            has_expression_after && !has_else_after) {
-          Lint(
-            filename = source_expression$filename,
-            line_number = parsed$line1,
-            column_number = parsed$col1,
-            type = "style",
-            message = paste(
-              "Closing curly-braces should always be on their own line,",
-              "unless they are followed by an else."
-            ),
-            line = source_expression$lines[as.character(parsed$line1)]
-          )
-        }
-      }
+    xml_nodes_to_lints(
+      xml2::xml_find_all(source_expression$xml_parsed_content, xpath),
+      source_expression = source_expression,
+      lint_message = paste(
+        "Closing curly-braces should always be on their own line,",
+        "unless they are followed by an else."
+      )
     )
   })
 }

--- a/man/closed_curly_linter.Rd
+++ b/man/closed_curly_linter.Rd
@@ -10,7 +10,7 @@ closed_curly_linter(allow_single_line = FALSE)
 \item{allow_single_line}{if \code{TRUE}, allow an open and closed curly pair on the same line.}
 }
 \description{
-Check that closed curly braces are on their own line unless they follow an else.
+Check that closed curly braces are on their own line unless they follow an else, comma, or closing bracket.
 }
 \seealso{
 \link{linters} for a complete list of linters available in lintr. \cr


### PR DESCRIPTION
Part of #1186 

I just copied the refactored XPath logic from `brace_linter()`.