### PR TITLE
pull any_duplicated xpaths into factory, and customize message

### DIFF
--- a/tests/testthat/test-any_duplicated_linter.R
+++ b/tests/testthat/test-any_duplicated_linter.R
@@ -59,18 +59,18 @@ test_that("any_duplicated_linter catches length(unique()) equivalencies too", {
   # nrow-style equivalency
   expect_lint(
     "nrow(DF) == length(unique(DF$col))",
-    rex::rex("anyDuplicated(x) == 0L is better than length(unique(x)) == length(x)"),
+    rex::rex("anyDuplicated(DF$col) == 0L is better than length(unique(DF$col)) == nrow(DF)"),
     any_duplicated_linter()
   )
   expect_lint(
     "nrow(DF) == length(unique(DF[['col']]))",
-    rex::rex("anyDuplicated(x) == 0L is better than length(unique(x)) == length(x)"),
+    rex::rex("anyDuplicated(DF$col) == 0L is better than length(unique(DF$col)) == nrow(DF)"),
     any_duplicated_linter()
   )
   # match with nesting too
   expect_lint(
     "nrow(l$DF) == length(unique(l$DF[['col']]))",
-    rex::rex("anyDuplicated(x) == 0L is better than length(unique(x)) == length(x)"),
+    rex::rex("anyDuplicated(DF$col) == 0L is better than length(unique(DF$col)) == nrow(DF)"),
     any_duplicated_linter()
   )
 
@@ -101,7 +101,20 @@ test_that("any_duplicated_linter catches length(unique()) equivalencies too", {
 test_that("any_duplicated_linter catches expression with two types of lint", {
   expect_lint(
     "table(any(duplicated(x)), length(unique(DF$col)) == nrow(DF))",
-    list(rex::rex("anyDuplicated(x, ...) > 0 is better"), rex::rex("anyDuplicated(x) == 0L is better")),
+    list(
+      rex::rex("anyDuplicated(x, ...) > 0 is better"),
+      rex::rex("anyDuplicated(DF$col) == 0L is better than length(unique(DF$col)) == nrow(DF)")
+    ),
+    any_duplicated_linter()
+  )
+
+  # ditto for different messages within the length(unique()) tests
+  expect_lint(
+    "table(length(unique(x)) == length(x), length(unique(DF$col)) == nrow(DF))",
+    list(
+      rex::rex("anyDuplicated(x) == 0L is better than length(unique(x)) == length(x)"),
+      rex::rex("anyDuplicated(DF$col) == 0L is better than length(unique(DF$col)) == nrow(DF)")
+    ),
     any_duplicated_linter()
   )
 })


### PR DESCRIPTION
Part of #1199 

Filed separately because it's not a trivial refactor -- in addition to pulling the xpaths into the factory, I (1) deleted duplicate leftover code; (2) customized the lint to whether it's a lint on `length(unique(x$col)) == nrow(x)` or `length(unique(x)) == length(x)`; and (3) vectorized the `xml_nodes_to_lints()` call