### PR TITLE
move logic to factory in any_is_na_linter and assignment_linter

### DIFF
--- a/R/any_is_na_linter.R
+++ b/R/any_is_na_linter.R
@@ -8,21 +8,21 @@
 #' @seealso [linters] for a complete list of linters available in lintr.
 #' @export
 any_is_na_linter <- function() {
+  xpath <- "//expr[
+    expr[SYMBOL_FUNCTION_CALL[text() = 'any']]
+    and expr[expr[SYMBOL_FUNCTION_CALL[text() = 'is.na']]]
+    and (
+      count(expr) = 2
+      or (count(expr) = 3 and SYMBOL_SUB[text() = 'na.rm'])
+    )
+  ]"
+
   Linter(function(source_expression) {
     if (!is_lint_level(source_expression, "expression")) {
       return(list())
     }
 
     xml <- source_expression$xml_parsed_content
-
-    xpath <- "//expr[
-      expr[SYMBOL_FUNCTION_CALL[text() = 'any']]
-      and expr[expr[SYMBOL_FUNCTION_CALL[text() = 'is.na']]]
-      and (
-        count(expr) = 2
-        or (count(expr) = 3 and SYMBOL_SUB[text() = 'na.rm'])
-      )
-    ]"
 
     bad_expr <- xml2::xml_find_all(xml, xpath)
 

--- a/R/assignment_linter.R
+++ b/R/assignment_linter.R
@@ -11,6 +11,17 @@
 #'   <https://style.tidyverse.org/syntax.html#assignment-1>
 #' @export
 assignment_linter <- function(allow_cascading_assign = TRUE, allow_right_assign = FALSE) {
+  xpath <- paste(collapse = " | ", c(
+    # always block = (NB: the parser differentiates EQ_ASSIGN, EQ_SUB, and EQ_FORMALS)
+    "//EQ_ASSIGN",
+    # -> and ->> are both 'RIGHT_ASSIGN'
+    if (!allow_right_assign) "//RIGHT_ASSIGN" else if (!allow_cascading_assign) "//RIGHT_ASSIGN[text() = '->>']",
+    # <-, :=, and <<- are all 'LEFT_ASSIGN'; check the text if blocking <<-.
+    # NB: := is not linted because of (1) its common usage in rlang/data.table and
+    #   (2) it's extremely uncommon as a normal assignment operator
+    if (!allow_cascading_assign) "//LEFT_ASSIGN[text() = '<<-']"
+  ))
+
   Linter(function(source_expression) {
     if (!is_lint_level(source_expression, "expression")) {
       return(list())
@@ -18,34 +29,18 @@ assignment_linter <- function(allow_cascading_assign = TRUE, allow_right_assign 
 
     xml <- source_expression$xml_parsed_content
 
-    xpath <- paste(collapse = " | ", c(
-      # always block = (NB: the parser differentiates EQ_ASSIGN, EQ_SUB, and EQ_FORMALS)
-      "//EQ_ASSIGN",
-      # -> and ->> are both 'RIGHT_ASSIGN'
-      if (!allow_right_assign) "//RIGHT_ASSIGN" else if (!allow_cascading_assign) "//RIGHT_ASSIGN[text() = '->>']",
-      # <-, :=, and <<- are all 'LEFT_ASSIGN'; check the text if blocking <<-.
-      # NB: := is not linted because of (1) its common usage in rlang/data.table and
-      #   (2) it's extremely uncommon as a normal assignment operator
-      if (!allow_cascading_assign) "//LEFT_ASSIGN[text() = '<<-']"
-    ))
-
     bad_expr <- xml2::xml_find_all(xml, xpath)
-    xml_nodes_to_lints(
-      bad_expr,
-      source_expression,
-      function(expr) {
-        operator <- xml2::xml_text(expr)
-        if (operator %in% c("<<-", "->>")) {
-          paste(
-            operator,
-            "can have hard-to-predict behavior;",
-            "prefer assigning to a specific environment instead (with assign() or <-)."
-          )
-        } else {
-          paste0("Use <-, not ", operator, ", for assignment.")
-        }
-      },
-      type = "style"
+    if (length(bad_expr) == 0L) {
+      return(list())
+    }
+
+    operator <- xml2::xml_text(bad_expr)
+    lint_message_fmt <- ifelse(
+      operator %in% c("<<-", "->>"),
+      "%s can have hard-to-predict behavior; prefer assigning to a specific environment instead (with assign() or <-).",
+      "Use <-, not %s, for assignment."
     )
+    lint_message <- sprintf(lint_message_fmt, operator)
+    xml_nodes_to_lints(bad_expr, source_expression, lint_message, type = "style")
   })
 }


### PR DESCRIPTION
Part of #1199 

Again pausing to send a separate PR since `assignment_linter()` is not quite trivial -- we've vectorized the lint message here, too.

`any_is_na_linter()` included because that one is trivial and I'm going in order