### PR TITLE
backports_linter logic into factory, vectorize message

### DIFF
--- a/tests/testthat/test-backport_linter.R
+++ b/tests/testthat/test-backport_linter.R
@@ -13,21 +13,21 @@ test_that("backport_linter detects backwards-incompatibility", {
 
   expect_lint(
     "numToBits(2)",
-    rex("numToBits (R 4.1.0) is not available for dependency R >= 4.0.0."),
+    rex::rex("numToBits (R 4.1.0) is not available for dependency R >= 4.0.0."),
     backport_linter("4.0.0")
   )
   # symbols as well as calls
   expect_lint(
     "lapply(1:10, numToBits)",
-    rex("numToBits (R 4.1.0) is not available for dependency R >= 4.0.0."),
+    rex::rex("numToBits (R 4.1.0) is not available for dependency R >= 4.0.0."),
     backport_linter("4.0.0")
   )
 
   expect_lint(
     "trimws(...names())",
     list(
-      rex("trimws (R 3.2.0) is not available for dependency R >= 3.0.0."),
-      rex("...names (R 4.1.0) is not available for dependency R >= 3.0.0.")
+      rex::rex("trimws (R 3.2.0) is not available for dependency R >= 3.0.0."),
+      rex::rex("...names (R 4.1.0) is not available for dependency R >= 3.0.0.")
     ),
     backport_linter("3.0.0")
   )
@@ -35,7 +35,7 @@ test_that("backport_linter detects backwards-incompatibility", {
   # oldrel specification
   expect_lint(
     "numToBits(2)",
-    rex("numToBits (R 4.1.0) is not available for dependency R >= 4.0.0."),
+    rex::rex("numToBits (R 4.1.0) is not available for dependency R >= 4.0.0."),
     backport_linter("oldrel")
   )
 
@@ -44,7 +44,7 @@ test_that("backport_linter detects backwards-incompatibility", {
   # NB: oldrel-1 could be 3.6.3, but we don't have any backports listed for 3.6.3
   expect_lint(
     "numToBits(2)",
-    rex("numToBits (R 4.1.0) is not available for dependency R >= 3.6.0."),
+    rex::rex("numToBits (R 4.1.0) is not available for dependency R >= 3.6.0."),
     backport_linter("oldrel-1")
   )
 })


### PR DESCRIPTION
Part of #1199 

Refactored a bit in order to vectorize the `lint_message` more cleanly -- see comment. Also switched to `xml_nodes_to_lints()`