### PR TITLE
finish expect_*_linter migration to XPath logic in factory

### DIFF
--- a/R/expect_named_linter.R
+++ b/R/expect_named_linter.R
@@ -8,6 +8,14 @@
 #' @seealso [linters] for a complete list of linters available in lintr.
 #' @export
 expect_named_linter <- function() {
+   xpath <- "//expr[
+    SYMBOL_FUNCTION_CALL[text() = 'expect_equal' or text() = 'expect_identical']
+    and following-sibling::expr[
+      expr[SYMBOL_FUNCTION_CALL[text() = 'names']]
+      and (position() = 1 or preceding-sibling::expr[STR_CONST])
+    ]
+  ]"
+
   Linter(function(source_expression) {
     if (!is_lint_level(source_expression, "expression")) {
       return(list())
@@ -15,23 +23,10 @@ expect_named_linter <- function() {
 
     xml <- source_expression$xml_parsed_content
 
-    xpath <- "//expr[
-      SYMBOL_FUNCTION_CALL[text() = 'expect_equal' or text() = 'expect_identical']
-      and following-sibling::expr[
-        expr[SYMBOL_FUNCTION_CALL[text() = 'names']]
-        and (position() = 1 or preceding-sibling::expr[STR_CONST])
-      ]
-    ]"
-
     bad_expr <- xml2::xml_find_all(xml, xpath)
-    xml_nodes_to_lints(
-      bad_expr,
-      source_expression = source_expression,
-      lint_message = function(expr) {
-        matched_function <- xp_call_name(expr, depth = 0L)
-        sprintf("expect_named(x, n) is better than %s(names(x), n)", matched_function)
-      },
-      type = "warning"
-    )
+    matched_function <- xp_call_name(bad_expr, depth = 0L)
+    lint_message <- sprintf("expect_named(x, n) is better than %s(names(x), n)", matched_function)
+
+    xml_nodes_to_lints(bad_expr, source_expression = source_expression, lint_message, type = "warning")
   })
 }

--- a/R/expect_not_linter.R
+++ b/R/expect_not_linter.R
@@ -10,17 +10,17 @@
 #' @seealso [linters] for a complete list of linters available in lintr.
 #' @export
 expect_not_linter <- function() {
+  xpath <- "//expr[
+    SYMBOL_FUNCTION_CALL[text() = 'expect_true' or text() = 'expect_false']
+    and following-sibling::expr[1][OP-EXCLAMATION]
+  ]"
+
   Linter(function(source_expression) {
     if (!is_lint_level(source_expression, "expression")) {
       return(list())
     }
 
     xml <- source_expression$xml_parsed_content
-
-    xpath <- "//expr[
-      SYMBOL_FUNCTION_CALL[text() = 'expect_true' or text() = 'expect_false']
-      and following-sibling::expr[1][OP-EXCLAMATION]
-    ]"
 
     bad_expr <- xml2::xml_find_all(xml, xpath)
 

--- a/R/expect_null_linter.R
+++ b/R/expect_null_linter.R
@@ -12,6 +12,19 @@
 #' @seealso [linters] for a complete list of linters available in lintr.
 #' @export
 expect_null_linter <- function() {
+  # two cases two match:
+  #  (1) expect_{equal,identical}(x, NULL) (or NULL, x)
+  #  (2) expect_true(is.null(x))
+  xpath <- "//expr[
+    (
+      SYMBOL_FUNCTION_CALL[text() = 'expect_equal' or text() = 'expect_identical']
+      and following-sibling::expr[position() <= 2 and NULL_CONST]
+    ) or (
+      SYMBOL_FUNCTION_CALL[text() = 'expect_true']
+      and following-sibling::expr[1][expr[SYMBOL_FUNCTION_CALL[text() = 'is.null']]]
+    )
+  ]"
+
   Linter(function(source_expression) {
     if (!is_lint_level(source_expression, "expression")) {
       return(list())
@@ -19,32 +32,18 @@ expect_null_linter <- function() {
 
     xml <- source_expression$xml_parsed_content
 
-    # two cases two match:
-    #  (1) expect_{equal,identical}(x, NULL) (or NULL, x)
-    #  (2) expect_true(is.null(x))
-    xpath <- "//expr[
-      (
-        SYMBOL_FUNCTION_CALL[text() = 'expect_equal' or text() = 'expect_identical']
-        and following-sibling::expr[position() <= 2 and NULL_CONST]
-      ) or (
-        SYMBOL_FUNCTION_CALL[text() = 'expect_true']
-        and following-sibling::expr[1][expr[SYMBOL_FUNCTION_CALL[text() = 'is.null']]]
-      )
-    ]"
-
     bad_expr <- xml2::xml_find_all(xml, xpath)
 
+    matched_function <- xp_call_name(bad_expr, depth = 0L)
+    lint_message_fmt <- ifelse(
+      matched_function %in% c("expect_equal", "expect_identical"),
+      "expect_null(x) is better than %s(x, NULL)",
+      "expect_null(x) is better than expect_true(is.null(x))"
+    )
     xml_nodes_to_lints(
       bad_expr,
       source_expression,
-      function(expr) {
-        matched_function <- xp_call_name(expr, depth = 0L)
-        if (matched_function %in% c("expect_equal", "expect_identical")) {
-          sprintf("expect_null(x) is better than %s(x, NULL)", matched_function)
-        } else {
-          "expect_null(x) is better than expect_true(is.null(x))"
-        }
-      },
+      lint_message = sprintf(lint_message_fmt, matched_function),
       type = "warning"
     )
   })

--- a/R/expect_s3_class_linter.R
+++ b/R/expect_s3_class_linter.R
@@ -9,6 +9,25 @@
 #' @seealso [linters] for a complete list of linters available in lintr.
 #' @export
 expect_s3_class_linter <- function() {
+  # (1) expect_{equal,identical}(class(x), C)
+  # (2) expect_true(is.<class>(x)) and expect_true(inherits(x, C))
+  is_class_call <- xp_text_in_table(c(is_s3_class_calls, "inherits"))
+  xpath <- glue::glue("//expr[
+    (
+      (
+        expr[SYMBOL_FUNCTION_CALL[text() = 'expect_equal' or text() = 'expect_identical']]
+        and expr[
+          expr[SYMBOL_FUNCTION_CALL[text() = 'class']]
+          and (position() = 2 or preceding-sibling::expr[STR_CONST])
+        ]
+      ) or (
+        expr[SYMBOL_FUNCTION_CALL[text() = 'expect_true']]
+        and expr[2][expr[SYMBOL_FUNCTION_CALL[ {is_class_call} ]]]
+      )
+    )
+    and not(SYMBOL_SUB[text() = 'info' or contains(text(), 'label')])
+  ]")
+
   Linter(function(source_expression) {
     if (!is_lint_level(source_expression, "expression")) {
       return(list())
@@ -16,38 +35,20 @@ expect_s3_class_linter <- function() {
 
     xml <- source_expression$xml_parsed_content
 
-    # (1) expect_{equal,identical}(class(x), C)
-    # (2) expect_true(is.<class>(x)) and expect_true(inherits(x, C))
-    is_class_call <- xp_text_in_table(c(is_s3_class_calls, "inherits"))
-    xpath <- glue::glue("//expr[
-      (
-        (
-          expr[SYMBOL_FUNCTION_CALL[text() = 'expect_equal' or text() = 'expect_identical']]
-          and expr[
-            expr[SYMBOL_FUNCTION_CALL[text() = 'class']]
-            and (position() = 2 or preceding-sibling::expr[STR_CONST])
-          ]
-        ) or (
-          expr[SYMBOL_FUNCTION_CALL[text() = 'expect_true']]
-          and expr[2][expr[SYMBOL_FUNCTION_CALL[ {is_class_call} ]]]
-        )
-      )
-      and not(SYMBOL_SUB[text() = 'info' or contains(text(), 'label')])
-    ]")
-
     bad_expr <- xml2::xml_find_all(xml, xpath)
+    matched_function <- xp_call_name(bad_expr)
+    lint_message_fmt <- ifelse(
+      matched_function %in% c("expect_equal", "expect_identical"),
+      "expect_s3_class(x, k) is better than %s(class(x), k).",
+      "expect_s3_class(x, k) is better than expect_true(is.<k>(x)) or expect_true(inherits(x, k))."
+    )
     xml_nodes_to_lints(
       bad_expr,
       source_expression,
-      function(expr) {
-        matched_function <- xp_call_name(expr)
-        if (matched_function %in% c("expect_equal", "expect_identical")) {
-          lint_msg <- sprintf("expect_s3_class(x, k) is better than %s(class(x), k).", matched_function)
-        } else {
-          lint_msg <- "expect_s3_class(x, k) is better than expect_true(is.<k>(x)) or expect_true(inherits(x, k))."
-        }
-        paste(lint_msg, "Note also expect_s4_class() available for testing S4 objects.")
-      },
+      lint_message = paste(
+        sprintf(lint_message_fmt, matched_function),
+        "Note also expect_s4_class() available for testing S4 objects."
+      ),
       type = "warning"
     )
   })
@@ -81,6 +82,14 @@ is_s3_class_calls <- paste0("is.", c(
 #' @seealso [linters] for a complete list of linters available in lintr.
 #' @export
 expect_s4_class_linter <- function() {
+  # require 2 expressions because methods::is(x) alone is a valid call, even
+  #   though the character output wouldn't make any sense for expect_true().
+  xpath <- "//expr[
+    expr[SYMBOL_FUNCTION_CALL[text() = 'expect_true']]
+    and expr[2][count(expr) = 3 and expr[SYMBOL_FUNCTION_CALL[text() = 'is']]]
+    and not(SYMBOL_SUB[text() = 'info' or text() = 'label'])
+  ]"
+
   Linter(function(source_expression) {
     if (!is_lint_level(source_expression, "expression")) {
       return(list())
@@ -89,15 +98,7 @@ expect_s4_class_linter <- function() {
     xml <- source_expression$xml_parsed_content
 
     # TODO(michaelchirico): also catch expect_{equal,identical}(methods::is(x), k).
-    #   there are no hits for this on google3 as of now.
-
-    # require 2 expressions because methods::is(x) alone is a valid call, even
-    #   though the character output wouldn't make any sense for expect_true().
-    xpath <- "//expr[
-      expr[SYMBOL_FUNCTION_CALL[text() = 'expect_true']]
-      and expr[2][count(expr) = 3 and expr[SYMBOL_FUNCTION_CALL[text() = 'is']]]
-      and not(SYMBOL_SUB[text() = 'info' or text() = 'label'])
-    ]"
+    #   this seems empirically rare, but didn't check many S4-heavy packages.
 
     bad_expr <- xml2::xml_find_all(xml, xpath)
     xml_nodes_to_lints(

--- a/R/expect_true_false_linter.R
+++ b/R/expect_true_false_linter.R
@@ -9,6 +9,11 @@
 #' @seealso [linters] for a complete list of linters available in lintr.
 #' @export
 expect_true_false_linter <- function() {
+  xpath <- "//expr[expr[
+    SYMBOL_FUNCTION_CALL[text() = 'expect_equal' or text() = 'expect_identical']
+    and following-sibling::expr[position() <= 2 and NUM_CONST[text() = 'TRUE' or text() = 'FALSE']]
+  ]]"
+
   Linter(function(source_expression) {
     if (!is_lint_level(source_expression, "expression")) {
       return(list())
@@ -16,26 +21,16 @@ expect_true_false_linter <- function() {
 
     xml <- source_expression$xml_parsed_content
 
-    xpath <- "//expr[expr[
-      SYMBOL_FUNCTION_CALL[text() = 'expect_equal' or text() = 'expect_identical']
-      and following-sibling::expr[position() <= 2 and NUM_CONST[text() = 'TRUE' or text() = 'FALSE']]
-    ]]"
-
     bad_expr <- xml2::xml_find_all(xml, xpath)
-    xml_nodes_to_lints(
-      bad_expr,
-      source_expression,
-      function(expr) {
-        # NB: use expr/$node, not expr[$node], to exclude other things (especially ns:: parts of the call)
-        call_name <- xp_call_name(expr, condition = "starts-with(text(), 'expect_')")
-        truth_value <- xml2::xml_find_chr(expr, "string(expr/NUM_CONST[text() = 'TRUE' or text() = 'FALSE'])")
-        if (truth_value == "TRUE") {
-          sprintf("expect_true(x) is better than %s(x, TRUE)", call_name)
-        } else {
-          sprintf("expect_false(x) is better than %s(x, FALSE)", call_name)
-        }
-      },
-      type = "warning"
+
+    # NB: use expr/$node, not expr[$node], to exclude other things (especially ns:: parts of the call)
+    call_name <- xp_call_name(bad_expr, condition = "starts-with(text(), 'expect_')")
+    truth_value <- xml2::xml_find_chr(bad_expr, "string(expr/NUM_CONST[text() = 'TRUE' or text() = 'FALSE'])")
+    lint_message <- sprintf(
+      "expect_%s(x) is better than %s(x, %s)",
+      tolower(truth_value), call_name, truth_value
     )
+
+    xml_nodes_to_lints(bad_expr, source_expression, lint_message, type = "warning")
   })
 }

--- a/R/expect_type_linter.R
+++ b/R/expect_type_linter.R
@@ -9,6 +9,23 @@
 #' @seealso [linters] for a complete list of linters available in lintr.
 #' @export
 expect_type_linter <- function() {
+  base_type_tests <- xp_text_in_table(paste0("is.", base_types))
+  xpath <- glue::glue("//expr[
+    (
+      (
+        expr[SYMBOL_FUNCTION_CALL[text() = 'expect_equal' or text() = 'expect_identical']]
+        and expr[
+          expr[SYMBOL_FUNCTION_CALL[text() = 'typeof']]
+          and (position() = 2 or preceding-sibling::expr[STR_CONST])
+        ]
+      ) or (
+        expr[SYMBOL_FUNCTION_CALL[text() = 'expect_true']]
+        and expr[2][expr[SYMBOL_FUNCTION_CALL[ {base_type_tests} ]]]
+      )
+    )
+    and not(SYMBOL_SUB[text() = 'info' or contains(text(), 'label')])
+  ]")
+
   Linter(function(source_expression) {
     if (!is_lint_level(source_expression, "expression")) {
       return(list())
@@ -16,35 +33,17 @@ expect_type_linter <- function() {
 
     xml <- source_expression$xml_parsed_content
 
-    base_type_tests <- xp_text_in_table(paste0("is.", base_types))
-    xpath <- glue::glue("//expr[
-      (
-        (
-          expr[SYMBOL_FUNCTION_CALL[text() = 'expect_equal' or text() = 'expect_identical']]
-          and expr[
-            expr[SYMBOL_FUNCTION_CALL[text() = 'typeof']]
-            and (position() = 2 or preceding-sibling::expr[STR_CONST])
-          ]
-        ) or (
-          expr[SYMBOL_FUNCTION_CALL[text() = 'expect_true']]
-          and expr[2][expr[SYMBOL_FUNCTION_CALL[ {base_type_tests} ]]]
-        )
-      )
-      and not(SYMBOL_SUB[text() = 'info' or contains(text(), 'label')])
-    ]")
-
     bad_expr <- xml2::xml_find_all(xml, xpath)
+    matched_function <- xp_call_name(bad_expr)
+    lint_message_fmt <- ifelse(
+      matched_function %in% c("expect_equal", "expect_identical"),
+      "expect_type(x, t) is better than %s(typeof(x), t)",
+      "expect_type(x, t) is better than expect_true(is.<t>(x))"
+    )
     xml_nodes_to_lints(
       bad_expr,
       source_expression,
-      function(expr) {
-        matched_function <- xp_call_name(expr)
-        if (matched_function %in% c("expect_equal", "expect_identical")) {
-          sprintf("expect_type(x, t) is better than %s(typeof(x), t)", matched_function)
-        } else {
-          "expect_type(x, t) is better than expect_true(is.<t>(x))"
-        }
-      },
+      lint_message = sprintf(lint_message_fmt, matched_function),
       type = "warning"
     )
   })


### PR DESCRIPTION
Part of #1199 

Giving up on only putting one vectorized lint per PR -- if you are reviewing sequentially, it should be pretty standard by now. I'll split off separate PRs again later if there's something unique or unusual.