### PR TITLE
extraction_operator_linter to XPath

### DIFF
--- a/R/extraction_operator_linter.R
+++ b/R/extraction_operator_linter.R
@@ -7,11 +7,13 @@
 #' @seealso [linters] for a complete list of linters available in lintr.
 #' @export
 extraction_operator_linter <- function() {
+  constant_nodes_in_brackets <- paste0("self::", c("expr", "OP-PLUS", "NUM_CONST", "STR_CONST", "NULL_CONST"))
   xpath <- "
     //OP-DOLLAR[not(preceding-sibling::expr[1]/SYMBOL[text() = 'self' or text() = '.self'])] |
-    //OP-LEFT-BRACKET[not(following-sibling::expr[1]/descendant::*[not(
-      self::expr or self::OP-PLUS or self::NUM_CONST or self::STR_CONST or self::NULL_CONST
-    )]) and not(following-sibling::OP-COMMA)]
+    //OP-LEFT-BRACKET[
+      not(following-sibling::expr[1]/descendant::*[not({xp_or(constant_nodes_in_brackets)})]) and
+      not(following-sibling::OP-COMMA)
+    ]
   "
 
   Linter(function(source_expression) {

--- a/R/extraction_operator_linter.R
+++ b/R/extraction_operator_linter.R
@@ -8,13 +8,13 @@
 #' @export
 extraction_operator_linter <- function() {
   constant_nodes_in_brackets <- paste0("self::", c("expr", "OP-PLUS", "NUM_CONST", "STR_CONST", "NULL_CONST"))
-  xpath <- "
+  xpath <- glue::glue("
     //OP-DOLLAR[not(preceding-sibling::expr[1]/SYMBOL[text() = 'self' or text() = '.self'])] |
     //OP-LEFT-BRACKET[
       not(following-sibling::expr[1]/descendant::*[not({xp_or(constant_nodes_in_brackets)})]) and
       not(following-sibling::OP-COMMA)
     ]
-  "
+  ")
 
   Linter(function(source_expression) {
     if (!is_lint_level(source_expression, "expression")) {

--- a/R/extraction_operator_linter.R
+++ b/R/extraction_operator_linter.R
@@ -7,53 +7,27 @@
 #' @seealso [linters] for a complete list of linters available in lintr.
 #' @export
 extraction_operator_linter <- function() {
+  xpath <- "
+    //OP-DOLLAR[not(preceding-sibling::expr[1]/SYMBOL[text() = 'self' or text() = '.self'])] |
+    //OP-LEFT-BRACKET[not(following-sibling::expr[1]/descendant::*[not(
+      self::expr or self::OP-PLUS or self::NUM_CONST or self::STR_CONST or self::NULL_CONST
+    )]) and not(following-sibling::OP-COMMA)]
+  "
+
   Linter(function(source_expression) {
-    tokens <- source_expression[["parsed_content"]] <-
-      filter_out_token_type(source_expression[["parsed_content"]], "expr")
+    if (!is_lint_level(source_expression, "expression")) {
+      return(list())
+    }
 
-    lapply(
-      ids_with_token(source_expression, c("'$'", "'['"), fun = `%in%`),
-      function(token_num) {
-        if (is_dollar_extract(token_num, tokens) || is_bracket_extract(token_num, tokens)) {
-          token <- with_id(source_expression, token_num)
-          start_col_num <- token[["col1"]]
-          end_col_num <- token[["col2"]]
-          line_num <- token[["line1"]]
-          line <- source_expression[["lines"]][[as.character(line_num)]]
+    xml <- source_expression$xml_parsed_content
+    bad_exprs <- xml2::xml_find_all(xml, xpath)
+    msgs <- sprintf("Use `[[` instead of `%s` to extract an element.", xml2::xml_text(bad_exprs))
 
-          Lint(
-            filename = source_expression[["filename"]],
-            line_number = line_num,
-            column_number = start_col_num,
-            type = "warning",
-            message = sprintf("Use `[[` instead of `%s` to extract an element.", token[["text"]]),
-            line = line,
-            ranges = list(c(start_col_num, end_col_num))
-          )
-        }
-      }
+    xml_nodes_to_lints(
+      bad_exprs,
+      source_expression = source_expression,
+      lint_message = msgs,
+      type = "warning"
     )
   })
-}
-
-is_dollar_extract <- function(token_line_num, tokens) {
-  # A "$" that is not preceded by a ReferenceClass ".self" or R6 class "self" object.
-  tokens[token_line_num, "text"] == "$" &&
-    re_substitutes(tokens[token_line_num - 1L, "text"], rex(start, maybe(dot)), "") != "self"
-}
-
-is_bracket_extract <- function(token_line_num, tokens) {
-  # The sequence "[" + zero or more "+" symbols + a constant + "]".
-  inside_tokens <- get_tokens_in_parentheses(token_line_num, tokens)
-  if (all(is.na(inside_tokens))) {
-    FALSE
-  } else {
-    start_line <- 1L
-    while (inside_tokens[start_line, "text"] == "+") {
-      start_line <- start_line + 1L
-    }
-    inside_tokens <- inside_tokens[start_line:nrow(inside_tokens), ]
-    nrow(inside_tokens) == 1L &&
-      inside_tokens[1L, "token"] %in% c("STR_CONST", "NUM_CONST", "NULL_CONST")
-  }
 }


### PR DESCRIPTION
fixes #1260 

Why do we lint `NULL_CONST` at all?

```r
letters[NULL]
#> character(0)
letters[[NULL]]
#> Error in letters[[NULL]]: attempt to select less than one element in get1index
```

LMK if I should remove `NULL_CONST` from the list of allowed children.