### PR TITLE
Handle NULL full_parsed_content --> missing full_xml_parsed_content

### DIFF
--- a/R/is_lint_level.R
+++ b/R/is_lint_level.R
@@ -14,5 +14,5 @@ is_lint_level <- function(source_expression, level = c("expression", "file")) {
   stopifnot(!missing(level))
   level <- match.arg(level)
   required_key <- paste0(if (level == "file") "full_", "parsed_content")
-  !is.null(source_expression[[required_key]])
+  required_key %in% names(source_expression)
 }

--- a/R/spaces_left_parentheses_linter.R
+++ b/R/spaces_left_parentheses_linter.R
@@ -9,7 +9,6 @@
 #' @export
 spaces_left_parentheses_linter <- function() {
   Linter(function(source_expression) {
-    # browser()
     # else/if structure for trees that are missing XML content (both global & local)
     if (is_lint_level(source_expression, "file")) {
       # 'x = 1;(x + 2)' can't be detected from the expression-level tree

--- a/R/spaces_left_parentheses_linter.R
+++ b/R/spaces_left_parentheses_linter.R
@@ -9,7 +9,7 @@
 #' @export
 spaces_left_parentheses_linter <- function() {
   Linter(function(source_expression) {
-
+    # browser()
     # else/if structure for trees that are missing XML content (both global & local)
     if (is_lint_level(source_expression, "file")) {
       # 'x = 1;(x + 2)' can't be detected from the expression-level tree

--- a/R/utils.R
+++ b/R/utils.R
@@ -96,7 +96,7 @@ names2 <- function(x) {
 }
 
 safe_parse_to_xml <- function(parsed_content) {
-  if (is.null(parsed_content)) return(xml2::xml_missing())
+  if (is.null(parsed_content)) return(NULL)
   tryCatch(
     xml2::read_xml(xmlparsedata::xml_parse_data(parsed_content)),
     # use xml_missing so that code doesn't always need to condition on XML existing

--- a/R/utils.R
+++ b/R/utils.R
@@ -96,7 +96,9 @@ names2 <- function(x) {
 }
 
 safe_parse_to_xml <- function(parsed_content) {
-  if (is.null(parsed_content)) return(NULL)
+  if (is.null(parsed_content)) {
+    return(xml2::xml_missing())
+  }
   tryCatch(
     xml2::read_xml(xmlparsedata::xml_parse_data(parsed_content)),
     # use xml_missing so that code doesn't always need to condition on XML existing

--- a/R/utils.R
+++ b/R/utils.R
@@ -96,7 +96,7 @@ names2 <- function(x) {
 }
 
 safe_parse_to_xml <- function(parsed_content) {
-  if (is.null(parsed_content)) return(NULL)
+  if (is.null(parsed_content)) return(xml2::xml_missing())
   tryCatch(
     xml2::read_xml(xmlparsedata::xml_parse_data(parsed_content)),
     # use xml_missing so that code doesn't always need to condition on XML existing

--- a/tests/testthat/test-error.R
+++ b/tests/testthat/test-error.R
@@ -1,8 +1,8 @@
 test_that("returns the correct linting", {
   msg_escape_char <- rex("is an unrecognized escape in character string")
-  expect_lint("\"\\R\"", msg_escape_char)
-  expect_lint("\"\\A\"", msg_escape_char)
-  expect_lint("\"\\z\"", msg_escape_char)
+  expect_lint('"\\R"', msg_escape_char)
+  expect_lint('"\\A"', msg_escape_char)
+  expect_lint('"\\z"', msg_escape_char)
   expect_lint(
     "a <- 1
     function() {

--- a/tests/testthat/test-get_source_expressions.R
+++ b/tests/testthat/test-get_source_expressions.R
@@ -237,6 +237,15 @@ test_that("returned data structure is complete", {
   expect_identical(exprs$lines, lines_with_attr)
 })
 
+test_that("#1262: xml_parsed_content gets returned as missing even if there's no parsed_content", {
+  tempfile <- withr::local_tempfile()
+  writeLines('"\\R"', tempfile)
+
+  source_expressions <- get_source_expressions(tempfile)
+  expect_null(source_expressions$expressions[[1L]]$full_parsed_content)
+  expect_identical(source_expressions$expressions[[1L]]$full_xml_parsed_content, xml2::xml_missing())
+})
+
 skip_if_not_installed("patrick")
 # NB: this is just a cursory test for linters not to
 #   fail on files where the XML content is xml_missing;


### PR DESCRIPTION
Closes #1262

 - I think `key %in% names()` is a better test than `is.null()`
 - But that's not enough -- both of these tests fail without also returning `xml2::xml_null()` from `safe_parse_to_xml()`:

https://github.com/r-lib/lintr/blob/53fd047406ea8e498e5f252578d6bc1741fa861a/tests/testthat/test-error.R#L3

https://github.com/r-lib/lintr/blob/53fd047406ea8e498e5f252578d6bc1741fa861a/tests/testthat/test-duplicate_argument_linter.R#L79