### PR TITLE
refactor unneeded_concatenation_linter() to XPath

### DIFF
--- a/R/unneeded_concatenation_linter.R
+++ b/R/unneeded_concatenation_linter.R
@@ -13,62 +13,44 @@ unneeded_concatenation_linter <- function() {
   )
   msg_const <- 'Unneeded concatenation of a constant. Remove the "c" call.'
 
+  constant_nodes_in_c <- paste0("self::", c("STR_CONST", "NUM_CONST", "NULL_CONST"))
+  non_constant_cond <- glue::glue("not(descendant::*[{xp_or(constant_nodes_in_c)}])")
+
+  to_pipe_xpath <- "
+    ./parent::expr/preceding-sibling::*[1][
+      self::PIPE or
+      self::SPECIAL[text() = '%>%']
+    ]
+  "
+  xpath_call <- glue::glue("
+    //expr[
+      SYMBOL_FUNCTION_CALL[text() = 'c'] and
+      not(following-sibling::expr[{non_constant_cond}]) and
+      not({to_pipe_xpath}/preceding-sibling::expr[1][{non_constant_cond}])
+    ]
+  ")
+  num_args_xpath <- "count(./following-sibling::expr)"
+
   Linter(function(source_expression) {
-    tokens <- source_expression[["parsed_content"]] <-
-      filter_out_token_type(source_expression[["parsed_content"]], "expr")
-    lapply(
-      ids_with_token(source_expression, "SYMBOL_FUNCTION_CALL"),
-      function(token_num) {
-        num_args <- get_num_concat_args(token_num, tokens)
-        if (num_args == 0L || num_args == 1L) {
-          token <- with_id(source_expression, token_num)
-          start_col_num <- token[["col1"]]
-          end_col_num <- token[["col2"]]
-          line_num <- token[["line1"]]
-          line <- source_expression[["lines"]][[as.character(line_num)]]
-          Lint(
-            filename = source_expression[["filename"]],
-            line_number = line_num,
-            column_number = start_col_num,
-            type = "warning",
-            message = if (num_args) msg_const else msg_empty,
-            line = line,
-            ranges = list(c(start_col_num, end_col_num))
-          )
-        }
-      }
+    if (!is_lint_level(source_expression, "expression")) {
+      return(list())
+    }
+
+    xml <- source_expression$xml_parsed_content
+    c_calls <- xml2::xml_find_all(xml, xpath_call)
+    num_args <- as.integer(!is.na(xml2::xml_find_first(c_calls, to_pipe_xpath))) +
+      as.integer(xml2::xml_find_num(c_calls, num_args_xpath))
+    msg <- ifelse(num_args == 0L, msg_empty, msg_const)
+
+    xml_nodes_to_lints(
+      c_calls[num_args <= 1L],
+      source_expression = source_expression,
+      lint_message = msg[num_args <= 1L]
     )
   })
 }
 
-get_num_concat_args <- function(token_num, tokens) {
-  # Detect the sequence "c" + "(" + optional constant + ")" and return a number:
-  #   -1 if not a concatenation call
-  #    0 if a concatenation without arguments
-  #    1 if a concatenation with a single constant argument
-  #    2 if a concatenation in other cases
-  open_paren_num <- token_num + 1L
-  if (tokens[token_num, "text"] == "c" &&
-    tokens[open_paren_num, "token"] == "'('") {
-    token_args <- get_tokens_in_parentheses(open_paren_num, tokens)
-    preceding_pipe <- check_for_pipe(token_num, tokens)
-    num_token_args <- nrow(token_args)
-    if (!num_token_args) {
-      0L + preceding_pipe
-    } else if (num_token_args == 1L) {
-      if (token_args[1L, "token"] %in% c("STR_CONST", "NUM_CONST", "NULL_CONST")) {
-        1L + preceding_pipe
-      } else {
-        2L
-      }
-    } else {
-      2L
-    }
-  } else {
-    -1L
-  }
-}
-
+# TODO remove all these helpers once extraction_operator_linter is refactored (#1260)
 get_tokens_in_parentheses <- function(open_paren_line_num, tokens) {
   # Return the tokens enclosed by the opening parenthesis/bracket at the given line, or NA.
   open_paren_token <- tokens[open_paren_line_num, ]
@@ -103,16 +85,4 @@ get_sibling_tokens <- function(child, tokens) {
 
 filter_out_token_type <- function(tokens, type) {
   tokens[tokens[["token"]] != type, ]
-}
-
-
-check_for_pipe <- function(token_num, tokens) {
-  # Checks for concatenation in a magrittr pipeline. If found the argument
-  # count should be incremented by one, thanks to magrittr's implicit first
-  # argument.
-  if (token_num < 2L) {
-    0L
-  } else {
-    as.integer(tokens$text[token_num - 1L] == "%>%")
-  }
 }

--- a/tests/testthat/test-unneeded_concatenation_linter.R
+++ b/tests/testthat/test-unneeded_concatenation_linter.R
@@ -37,4 +37,17 @@ test_that("Correctly handles concatenation within pipes", {
     "Unneeded concatenation without arguments",
     linter
   )
+
+  skip_if_not_r_version("4.1.0")
+  expect_lint('"a" |> c("b")', NULL, linter)
+  expect_lint(
+    '"a" |> c()',
+    "Unneeded concatenation of a constant",
+    linter
+  )
+  expect_lint(
+    '"a" |> list("b", c())',
+    "Unneeded concatenation without arguments",
+    linter
+  )
 })


### PR DESCRIPTION
fixes #1270 

upgraded to support the R 4.1.0 native pipe as well.
added a TODO to remove the remaining helpers that are also used by extraction_operator_linter()