### PR TITLE
don't lint `a[NULL]` in `extraction_operator_linter()`

### DIFF
--- a/R/extraction_operator_linter.R
+++ b/R/extraction_operator_linter.R
@@ -7,7 +7,7 @@
 #' @seealso [linters] for a complete list of linters available in lintr.
 #' @export
 extraction_operator_linter <- function() {
-  constant_nodes_in_brackets <- paste0("self::", c("expr", "OP-PLUS", "NUM_CONST", "STR_CONST", "NULL_CONST"))
+  constant_nodes_in_brackets <- paste0("self::", c("expr", "OP-PLUS", "NUM_CONST", "STR_CONST"))
   xpath <- glue::glue("
     //OP-DOLLAR[not(preceding-sibling::expr[1]/SYMBOL[text() = 'self' or text() = '.self'])] |
     //OP-LEFT-BRACKET[

--- a/tests/testthat/test-extraction_operator_linter.R
+++ b/tests/testthat/test-extraction_operator_linter.R
@@ -8,9 +8,9 @@ test_that("linter returns the correct linting", {
   expect_lint("x[1, 'a']", NULL, linter)
   expect_lint("self$a", NULL, linter)
   expect_lint(".self $\na", NULL, linter)
+  expect_lint("x[NULL]", NULL, linter)
   expect_lint("x$a", list(message = msg_d, line_number = 1L, column_number = 2L), linter)
   expect_lint("x $\na", list(message = msg_d, line_number = 1L, column_number = 3L), linter)
-  expect_lint("x[NULL]", list(message = msg_b, line_number = 1L, column_number = 2L), linter)
   expect_lint("x[++ + 3]", list(message = msg_b, line_number = 1L, column_number = 2L), linter)
   expect_lint(
     "c(x['a'], x [ 1 ])",


### PR DESCRIPTION
fixes #1273

needs a news bullet in #834 once merged