### PR TITLE
use @eval magic to avoid # nolint warning

### DIFF
--- a/R/exclude.R
+++ b/R/exclude.R
@@ -4,18 +4,23 @@
 #' @param exclusions manually specified exclusions
 #' @param linter_names character vector of names of the active linters, used for parsing inline exclusions.
 #' @param ... additional arguments passed to [parse_exclusions()]
-#' @details
-#' Exclusions can be specified in three different ways.
-#'
-#'  1. single line in the source file. default: `# nolint`, possibly followed by a listing of linters to exclude.
-#'     If the listing is missing, all linters are excluded on that line. The default listing format is
-#'     `# nolint: linter_name, linter2_name.`. There may not be anything between the colon and the line exclusion tag
-#'     and the listing must be terminated with a full stop (`.`) for the linter list to be respected.
-#'  2. line range in the source file. default: `# nolint start`, `# nolint end`. `# nolint start` accepts linter
-#'     lists in the same form as `# nolint`.
-#'  3. exclusions parameter, a named list of files with named lists of linters and lines to exclude them on, a named
-#'     list of the files and lines to exclude, or just the filenames if you want to exclude the entire file, or the
-#'     directory names if you want to exclude all files in a directory.
+#' @eval c(
+#'   "@details",
+#'   "Exclusions can be specified in three different ways.",
+#'   "",
+#'   "1. single line in the source file. default: `# nolint`, possibly followed by a listing of linters to exclude.",
+#'   "   If the listing is missing, all linters are excluded on that line. The default listing format is",
+#'   paste(
+#'     "   `#",
+#'     "nolint: linter_name, linter2_name.`. There may not be anything between the colon and the line exclusion tag"
+#'   ),
+#'   "   and the listing must be terminated with a full stop (`.`) for the linter list to be respected.",
+#'   "2. line range in the source file. default: `# nolint start`, `# nolint end`. `# nolint start` accepts linter",
+#'   "   lists in the same form as `# nolint`.",
+#'   "3. exclusions parameter, a named list of files with named lists of linters and lines to exclude them on, a named",
+#'   "   list of the files and lines to exclude, or just the filenames if you want to exclude the entire file, or the",
+#'   "   directory names if you want to exclude all files in a directory."
+#' )
 exclude <- function(lints, exclusions = settings$exclusions, linter_names = NULL, ...) {
   if (length(lints) <= 0L) {
     return(lints)

--- a/R/exclude.R
+++ b/R/exclude.R
@@ -5,6 +5,8 @@
 #' @param linter_names character vector of names of the active linters, used for parsing inline exclusions.
 #' @param ... additional arguments passed to [parse_exclusions()]
 #' @eval c(
+#'   # we use @eval for the details section to avoid a literal nolint exclusion tag with non-existing linter names
+#'   # those produce a warning from [parse_exclusions()] otherwise.
 #'   "@details",
 #'   "Exclusions can be specified in three different ways.",
 #'   "",

--- a/R/exclude.R
+++ b/R/exclude.R
@@ -6,7 +6,7 @@
 #' @param ... additional arguments passed to [parse_exclusions()]
 #' @eval c(
 #'   # we use @eval for the details section to avoid a literal nolint exclusion tag with non-existing linter names
-#'   # those produce a warning from [parse_exclusions()] otherwise.
+#'   # those produce a warning from [parse_exclusions()] otherwise. See #1219 for details.
 #'   "@details",
 #'   "Exclusions can be specified in three different ways.",
 #'   "",

--- a/tests/testthat/test-unneeded_concatenation_linter.R
+++ b/tests/testthat/test-unneeded_concatenation_linter.R
@@ -39,7 +39,7 @@ test_that("Correctly handles concatenation within magrittr pipes", {
   )
 })
 
-test_that("Correctly handles concatenation within native pipes" , {
+test_that("Correctly handles concatenation within native pipes", {
   skip_if_not_r_version("4.1.0")
   linter <- unneeded_concatenation_linter()
   expect_lint('"a" |> c("b")', NULL, linter)


### PR DESCRIPTION
fixes #1219  and a small lint introduced by refactoring unneeded_concatenation_linter().