### PR TITLE
unneeded_concatentation_linter skips named constants

### DIFF
--- a/R/unneeded_concatenation_linter.R
+++ b/R/unneeded_concatenation_linter.R
@@ -13,23 +13,24 @@ unneeded_concatenation_linter <- function() {
   )
   msg_const <- 'Unneeded concatenation of a constant. Remove the "c" call.'
 
-  constant_nodes_in_c <- paste0("self::", c("STR_CONST", "NUM_CONST", "NULL_CONST"))
-  non_constant_cond <- glue::glue("not(descendant::*[{xp_or(constant_nodes_in_c)}])")
+  constant_nodes_in_c <- paste0("descendant::", c("STR_CONST", "NUM_CONST", "NULL_CONST"))
+  non_constant_cond <- glue::glue("not( {xp_or(constant_nodes_in_c)} )")
 
   to_pipe_xpath <- "
-    ./parent::expr/preceding-sibling::*[1][
+    ./preceding-sibling::*[1][
       self::PIPE or
       self::SPECIAL[text() = '%>%']
     ]
   "
   xpath_call <- glue::glue("
     //expr[
-      SYMBOL_FUNCTION_CALL[text() = 'c'] and
-      not(following-sibling::expr[{non_constant_cond}]) and
-      not({to_pipe_xpath}/preceding-sibling::expr[1][{non_constant_cond}])
+      expr[SYMBOL_FUNCTION_CALL[text() = 'c']]
+      and not(SYMBOL_SUB)
+      and not(expr[position() > 1 and {non_constant_cond}])
+      and not({to_pipe_xpath}/preceding-sibling::expr[1][{non_constant_cond}])
     ]
   ")
-  num_args_xpath <- "count(./following-sibling::expr)"
+  num_args_xpath <- "count(./expr) - 1"
 
   Linter(function(source_expression) {
     if (!is_lint_level(source_expression, "expression")) {

--- a/tests/testthat/test-unneeded_concatenation_linter.R
+++ b/tests/testthat/test-unneeded_concatenation_linter.R
@@ -9,6 +9,7 @@ test_that("returns the correct linting", {
   expect_lint("c(x, recursive = TRUE)", NULL, linter)
   expect_lint("c(1, recursive = FALSE)", NULL, linter)
   expect_lint("lapply(1, c)", NULL, linter)
+  expect_lint("c(a = 1)", NULL, linter)
 
   expect_lint("c()", list(message = msg_e, line_number = 1L, column_number = 1L), linter)
   expect_lint("c(NULL)", list(message = msg_c, line_number = 1L, column_number = 1L), linter)


### PR DESCRIPTION
Closes #1301 

Also switched the XPath to be relative to the `parent::expr` of the current XPath. That's more consistent with some other XPaths and also makes things easier to write as we don't need as many `preceding-sibling::`/`following-sibling::`/`parent::` paths