### PR TITLE
upstream extra spaces_left_parentheses_linter tests

### DIFF
--- a/tests/testthat/test-spaces_left_parentheses_linter.R
+++ b/tests/testthat/test-spaces_left_parentheses_linter.R
@@ -35,6 +35,9 @@ test_that("returns the correct linting", {
   expect_lint("x**(y + z)", NULL, linter)
   expect_lint("a <- -(b)", NULL, linter)
 
+  expect_lint("(3^(3 + 2))", NULL, linter)
+  expect_lint("-(!!!symb)", NULL, linter)
+
   # more complicated cases for parse tree
   expect_lint("y1<-(abs(yn)>90)*1", msg, linter)
   expect_lint("c(a,(a+b))", msg, linter)


### PR DESCRIPTION
Just found a local patch that added edited `spaces_left_parentheses_linter()` and added some tests. Current dev version already passes the tests, so no need for the edit, but can't hurt to add a few regression tests.