### PR TITLE
fix object_usage_linter() XPath for `assign()` and `setMethod()`

### DIFF
--- a/R/object_usage_linter.R
+++ b/R/object_usage_linter.R
@@ -21,7 +21,7 @@ object_usage_linter <- function(interpret_glue = TRUE) {
     "expr_or_assign_or_help[EQ_ASSIGN]/expr[2][FUNCTION]",
     "equal_assign[EQ_ASSIGN]/expr[2][FUNCTION]",
     # assign() and setMethod() assignments
-    "//expr[expr[SYMBOL_FUNCTION_CALL[text() = 'assign' or text() = 'setMethod']]]/expr[3]",
+    "//expr[expr[SYMBOL_FUNCTION_CALL[text() = 'assign' or text() = 'setMethod']]]/expr[3][FUNCTION]",
     sep = " | "
   )
 

--- a/R/object_usage_linter.R
+++ b/R/object_usage_linter.R
@@ -21,7 +21,8 @@ object_usage_linter <- function(interpret_glue = TRUE) {
     "expr_or_assign_or_help[EQ_ASSIGN]/expr[2][FUNCTION]",
     "equal_assign[EQ_ASSIGN]/expr[2][FUNCTION]",
     # assign() and setMethod() assignments
-    "//expr[expr[SYMBOL_FUNCTION_CALL[text() = 'assign' or text() = 'setMethod']]]/expr[3][FUNCTION]",
+    "//expr[expr[SYMBOL_FUNCTION_CALL[text() = 'assign']]]/expr[3][FUNCTION]",
+    "//expr[expr[SYMBOL_FUNCTION_CALL[text() = 'setMethod']]]/expr[4][FUNCTION]",
     sep = " | "
   )
 

--- a/tests/testthat/test-object_usage_linter.R
+++ b/tests/testthat/test-object_usage_linter.R
@@ -104,6 +104,30 @@ test_that("returns the correct linting", {
     rex("no visible global function definition for ", anything),
     linter
   )
+
+  # setMethod and assign also checked
+
+  expect_lint(
+    trim_some("
+      assign('fun', function() {
+        a <- 1
+        1
+      })
+    "),
+    rex("local variable", anything, "assigned but may not be used"),
+    linter
+  )
+
+  expect_lint(
+    trim_some("
+      setMethod('plot', 'numeric', function() {
+        a <- 1
+        1
+      })
+    "),
+    rex("local variable", anything, "assigned but may not be used"),
+    linter
+  )
 })
 
 test_that("replace_functions_stripped", {
@@ -227,6 +251,11 @@ test_that("used symbols are detected correctly", {
     NULL,
     object_usage_linter()
   )
+
+
+
+  # regression #1322
+  expect_silent(expect_lint("assign('x', 42)", NULL, object_usage_linter()))
 })
 
 test_that("object_usage_linter finds lints spanning multiple lines", {


### PR DESCRIPTION
fixes #1322 