### PR TITLE
use EQ_SUB instead of SYMBOL_SUB to detect named c() calls

### DIFF
--- a/R/unneeded_concatenation_linter.R
+++ b/R/unneeded_concatenation_linter.R
@@ -25,7 +25,7 @@ unneeded_concatenation_linter <- function() {
   xpath_call <- glue::glue("
     //expr[
       expr[SYMBOL_FUNCTION_CALL[text() = 'c']]
-      and not(SYMBOL_SUB)
+      and not(EQ_SUB)
       and not(expr[position() > 1 and {non_constant_cond}])
       and not({to_pipe_xpath}/preceding-sibling::expr[1][{non_constant_cond}])
     ]

--- a/tests/testthat/test-unneeded_concatenation_linter.R
+++ b/tests/testthat/test-unneeded_concatenation_linter.R
@@ -10,6 +10,7 @@ test_that("returns the correct linting", {
   expect_lint("c(1, recursive = FALSE)", NULL, linter)
   expect_lint("lapply(1, c)", NULL, linter)
   expect_lint("c(a = 1)", NULL, linter)
+  expect_lint("c('a' = 1)", NULL, linter)
 
   expect_lint("c()", list(message = msg_e, line_number = 1L, column_number = 1L), linter)
   expect_lint("c(NULL)", list(message = msg_c, line_number = 1L, column_number = 1L), linter)


### PR DESCRIPTION
Fixes #1327 