### PR TITLE
more usage of EQ_SUB condition where appropriate

### DIFF
--- a/R/expect_identical_linter.R
+++ b/R/expect_identical_linter.R
@@ -38,7 +38,7 @@ expect_identical_linter <- function() {
     (
       SYMBOL_FUNCTION_CALL[text() = 'expect_equal']
       and not(
-        following-sibling::SYMBOL_SUB
+        following-sibling::EQ_SUB
         or following-sibling::expr[
           expr[SYMBOL_FUNCTION_CALL[text() = 'c']]
           and expr[NUM_CONST[contains(text(), '.')]]

--- a/R/inner_combine_linter.R
+++ b/R/inner_combine_linter.R
@@ -111,7 +111,7 @@ arg_match_condition <- function(arg) {
 build_arg_condition <- function(calls, arguments) {
   xp_or(
     sprintf("not(expr[SYMBOL_FUNCTION_CALL[%s]])", xp_text_in_table(calls)),
-    "not(SYMBOL_SUB) and not(following-sibling::expr/SYMBOL_SUB)",
+    "not(EQ_SUB) and not(following-sibling::expr/EQ_SUB)",
    xp_and(vapply(arguments, arg_match_condition, character(1L)))
   )
 }

--- a/R/outer_negation_linter.R
+++ b/R/outer_negation_linter.R
@@ -21,7 +21,7 @@ outer_negation_linter <- function() {
     and not(expr[
       position() > 1
       and not(OP-EXCLAMATION)
-      and not(preceding-sibling::*[2][self::SYMBOL_SUB])
+      and not(preceding-sibling::*[1][self::EQ_SUB])
     ])
   ]"
 

--- a/tests/testthat/test-expect_identical_linter.R
+++ b/tests/testthat/test-expect_identical_linter.R
@@ -6,6 +6,8 @@ test_that("expect_identical_linter skips allowed usages", {
 
   # expect_equal calls with explicit tolerance= are OK
   expect_lint("expect_equal(x, y, tolerance = 1e-6)", NULL, expect_identical_linter())
+  # ditto if the argument is passed quoted
+  expect_lint("expect_equal(x, y, 'tolerance' = 1e-6)", NULL, expect_identical_linter())
 
   # ditto for check.attributes = FALSE
   expect_lint("expect_equal(x, y, check.attributes = FALSE)", NULL, expect_identical_linter())

--- a/tests/testthat/test-inner_combine_linter.R
+++ b/tests/testthat/test-inner_combine_linter.R
@@ -45,8 +45,8 @@ patrick::with_parameters_test_that(
     rex::rex("Combine inputs to vectorized functions first"),
     inner_combine_linter()
   ),
-  .test_name = c("format", "origin", "tz", "tryFormats", "non-literal"),
-  arg = c("format = '%F'", "origin = '1900-01-01'", "tz = 'Asia/Jakarta'", "tryFormats = '%F'", "tz = tz")
+  .test_name = c("format", "origin", "tz", "tryFormats", "non-literal", "quoted arg name"),
+  arg = c("format = '%F'", "origin = '1900-01-01'", "tz = 'Asia/Jakarta'", "tryFormats = '%F'", "tz = tz", "'tz' = tz")
 )
 
 patrick::with_parameters_test_that(

--- a/tests/testthat/test-outer_negation_linter.R
+++ b/tests/testthat/test-outer_negation_linter.R
@@ -11,6 +11,8 @@ test_that("outer_negation_linter skips allowed usages", {
   expect_lint("any(!a, b)", NULL, outer_negation_linter())
   expect_lint("all(a, !b)", NULL, outer_negation_linter())
   expect_lint("any(a, !b, na.rm = TRUE)", NULL, outer_negation_linter())
+  # ditto when na.rm is passed quoted
+  expect_lint("any(a, !b, 'na.rm' = TRUE)", NULL, outer_negation_linter())
 })
 
 test_that("outer_negation_linter blocks simple disallowed usages", {


### PR DESCRIPTION
Ignoring any linters where we test for the argument name with `SYMBOL_SUB[text() = '%s']` (i.e, for a known argument name). In principle we could strengthen the linters to include cases like `sum(x, "na.rm" = TRUE)` more generally, but I think that's a lot of added complexity for little benefit -- quoted args are only required when using non-syntactic names, which is not the case for anything I'm excluding.

Also, in the pipeline we've got `keyword_quote_linter()`, which will throw a lint whenever a `SYMBOL_SUB` _could_ have been used, i.e., whenever a quoted argument is passed that has a syntactic name. That would eliminate the need for the added robustness here.