### PR TITLE
Update vscode-R link

### DIFF
--- a/vignettes/editors.Rmd
+++ b/vignettes/editors.Rmd
@@ -146,7 +146,7 @@ For more information and bug reports see [Atom linter-lintr](https://github.com/
 
 ## Visual Studio Code
 
-In Visual Studio Code, [vscode-R](https://marketplace.visualstudio.com/items?itemName=Ikuyadeu.r) presents the lintr diagnostics from [languageserver](https://github.com/REditorSupport/languageserver).
+In Visual Studio Code, [vscode-R](https://marketplace.visualstudio.com/items?itemName=REditorSupport.r) presents the lintr diagnostics from [languageserver](https://github.com/REditorSupport/languageserver).
 
 ![VS Code Example](https://user-images.githubusercontent.com/4662568/75946154-3e095500-5ed7-11ea-88e4-2afe09284362.png "VS Code Example")
 


### PR DESCRIPTION
The vscode-R publisher id is changed: https://github.com/REditorSupport/vscode-R/issues/690.