### PR TITLE
anchor to right paren to ensure better lint markers in spaces_inside_linter

### DIFF
--- a/R/spaces_inside_linter.R
+++ b/R/spaces_inside_linter.R
@@ -13,7 +13,7 @@ spaces_inside_linter <- function() {
   left_xpath_condition <- "
     not(following-sibling::*[1][self::COMMENT])
     and @end != following-sibling::*[1]/@start - 1
-    and @line1 = following-sibling::*[1]/@line2
+    and @line1 = following-sibling::*[1]/@line1
   "
   left_xpath <- glue::glue("//OP-LEFT-BRACKET[{left_xpath_condition}] | //OP-LEFT-PAREN[{left_xpath_condition}]")
 
@@ -22,10 +22,7 @@ spaces_inside_linter <- function() {
     and @start != preceding-sibling::*[1]/@end + 1
     and @line1 = preceding-sibling::*[1]/@line2
   "
-  right_xpath <- glue::glue("
-    //OP-RIGHT-BRACKET[{right_xpath_condition}]/preceding-sibling::*[1] |
-    //OP-RIGHT-PAREN[{right_xpath_condition}]/preceding-sibling::*[1]
-  ")
+  right_xpath <- glue::glue("//OP-RIGHT-BRACKET[{right_xpath_condition}] | //OP-RIGHT-PAREN[{right_xpath_condition}]")
 
   Linter(function(source_expression) {
     if (!is_lint_level(source_expression, "file")) {
@@ -41,19 +38,29 @@ spaces_inside_linter <- function() {
       "Do not place spaces after parentheses."
     )
 
+    left_lints <- xml_nodes_to_lints(
+      left_expr,
+      source_expression = source_expression,
+      lint_message = left_msg,
+      range_start_xpath = "number(./@col2 + 1)", # start after ( or [
+      range_end_xpath = "number(./following-sibling::*[1]/@col1 - 1)" # end before following expr
+    )
+
     right_expr <- xml2::xml_find_all(xml, right_xpath)
     right_msg <- ifelse(
-      xml2::xml_find_chr(right_expr, "string(./following-sibling::*[1])") == "]",
+      xml2::xml_text(right_expr) == "]",
       "Do not place spaces before square brackets.",
       "Do not place spaces before parentheses."
     )
 
-    xml_nodes_to_lints(
-      c(left_expr, right_expr),
+    right_lints <- xml_nodes_to_lints(
+      right_expr,
       source_expression = source_expression,
-      lint_message = c(left_msg, right_msg),
-      range_start_xpath = "number(./@col2 + 1)", # start after expression
-      range_end_xpath = "number(./following-sibling::*[1]/@col1 - 1)" # end before following ]
+      lint_message = right_msg,
+      range_start_xpath = "number(./preceding-sibling::*[1]/@col2 + 1)", # start after preceding expression
+      range_end_xpath = "number(./@col1 - 1)" # end before ) or ]
     )
+
+    c(left_lints, right_lints)
   })
 }

--- a/tests/testthat/test-spaces_inside_linter.R
+++ b/tests/testthat/test-spaces_inside_linter.R
@@ -92,3 +92,17 @@ test_that("returns the correct linting", {
     linter
   )
 })
+
+test_that("mutli-line expressions have good markers", {
+  expect_lint(
+    trim_some("
+      ( x |
+        y )
+    "),
+    list(
+      list(line_number = 1L, ranges = list(c(2L, 2L)), message = "Do not place spaces after parentheses"),
+      list(line_number = 2L, ranges = list(c(4L, 4L)), message = "Do not place spaces before parentheses")
+    ),
+    spaces_inside_linter()
+  )
+})


### PR DESCRIPTION
Closes #1343 

Issue was because we landed on the previous `<expr>` and used its `@line1`, which is wrong.