### PR TITLE
anchor to start/stop, not columns, for multi-line expr

### DIFF
--- a/R/infix_spaces_linter.R
+++ b/R/infix_spaces_linter.R
@@ -107,11 +107,11 @@ infix_spaces_linter <- function(exclude_operators = NULL, allow_multiple_spaces 
     and position() > 1
     and (
       (
-        @line1 = preceding-sibling::*[1]/@line1
-        and @col1 {op} preceding-sibling::*[1]/@col2 + 2
+        @line1 = preceding-sibling::*[1]/@line2
+        and @start {op} preceding-sibling::*[1]/@end + 2
       ) or (
         @line1 = following-sibling::*[1]/@line1
-        and following-sibling::*[1]/@col1 {op} @col2 + 2
+        and following-sibling::*[1]/@start {op} @end + 2
       )
     )
     and not(

--- a/tests/testthat/test-infix_spaces_linter.R
+++ b/tests/testthat/test-infix_spaces_linter.R
@@ -154,3 +154,15 @@ test_that("exception for box::use()", {
     linter
   )
 })
+
+test_that("multi-line, multi-expression case is caught", {
+  expect_lint(
+    trim_some("
+      x +
+        y+
+        z
+    "),
+    rex::rex("Put spaces around all infix operators."),
+    infix_spaces_linter()
+  )
+})


### PR DESCRIPTION
Closes #1342

The issue with

```
x +
  y+
  z
```

is that operator precedence means the tree looks like `(x + y)+ z`, and the `expr/@line1` != `+/@line1`, so the linter thought they were on different lines. Corrected to use `expr/@line2` instead, and switched to `@start`/`@end` which should be more reliable anyway.