### PR TITLE
with_defaults(default=NULL continues to work

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -54,7 +54,9 @@
   adopted the `source_file` naming and want to adapt to keep in sync.
 * Deprecated `with_defaults()` in favor of `linters_with_defaults()`, and add `modify_defaults()` which is intended to be used
   more generally to modify (i.e., extend, trim, and/or update) a list of defaults. Note that the argument corresponding to
-  `with_defaults()`'s `default=` is called `defaults=` (i.e., pluralized) in both of these (#1029, #1336, @AshesITR and @michaelchirico)
+  `with_defaults()`'s `default=` is called `defaults=` (i.e., pluralized) in both of these, and that usage like
+  `with_defaults(default = NULL, ...)` should be converted to `linters_with_defaults(defaults = list(), ...)`
+  (#1029, #1336, #1361, @AshesITR and @michaelchirico)
 
 ## Other changes to defaults
 

--- a/R/with.R
+++ b/R/with.R
@@ -170,6 +170,8 @@ linters_with_defaults <- function(..., defaults = default_linters) {
 #' @export
 with_defaults <- function(..., default = default_linters) {
   lintr_deprecated("with_defaults", "linters_with_defaults", "2.0.9001")
+  # to ease the burden of transition -- default = NULL used to behave like defaults = list() now does
+  if (is.null(default)) default <- list()
   linters_with_defaults(..., defaults = default)
 }
 

--- a/tests/testthat/test-with.R
+++ b/tests/testthat/test-with.R
@@ -49,7 +49,15 @@ test_that("with_defaults is supported with a deprecation warning", {
     old_defaults <- with_defaults(),
     rex::rex("Use linters_with_defaults instead.")
   )
-  expect_equal(defaults, old_defaults)
+  expect_identical(defaults, old_defaults)
+
+  # linters_with_defaults only accepts `defaults = list()` to start from blank
+  defaults <- linters_with_defaults(defaults = list(), no_tab_linter())
+  expect_warning(
+    old_defaults <- with_defaults(default = NULL, no_tab_linter()),
+    rex::rex("Use linters_with_defaults instead.")
+  )
+  expect_identical(defaults, old_defaults)
 })
 
 test_that("modify_defaults works", {


### PR DESCRIPTION
Closes #1361 

Alternatively, we could just support `defaults = NULL` in `modify_defaults()` directly.