### PR TITLE
prefix [linter_name] to all human-readable output formats

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -226,6 +226,7 @@ of general interest to the broader R community. More will be included in future 
   in source files or named lists of line numbers in `.lintr`.
   Also allows for partial matching as long as the supplied prefix is unique, e.g.
   `# nolint: infix_spaces` works to exclude `infix_spaces_linter` (#660, #872, @AshesITR)
+* Added the linter name to lintrs output to facilitate discovery of the correct name (#1357, @AshesITR)
 * `lint()`: new optional argument `text` for supplying a string or lines directly, e.g. if the file is already 
   in memory or linting is being done _ad hoc_. (#503, @renkun-ken)
 * `lint_dir()` excludes the `renv` and `packrat` directories by default (#697, @AshesITR)

--- a/R/actions.R
+++ b/R/actions.R
@@ -13,7 +13,7 @@ github_actions_log_lints <- function(lints, project_dir = "") {
     )
     cat(sprintf(
       "::warning %s::%s,%s\n",
-      file_line_col, file_line_col, x$message
+      file_line_col, file_line_col, paste0("[", x$linter, "] ", x$message)
     ), sep = "")
   }
 }

--- a/R/actions.R
+++ b/R/actions.R
@@ -12,8 +12,8 @@ github_actions_log_lints <- function(lints, project_dir = "") {
       "file=%s,line=%s,col=%s", x$filename, x$line_number, x$column_number
     )
     cat(sprintf(
-      "::warning %s::%s,%s\n",
-      file_line_col, file_line_col, paste0("[", x$linter, "] ", x$message)
+      "::warning %s::%s,[%s] %s\n",
+      file_line_col, file_line_col, x$linter, x$message
     ), sep = "")
   }
 }

--- a/R/lint.R
+++ b/R/lint.R
@@ -489,7 +489,7 @@ rstudio_source_markers <- function(lints) {
     marker$file <- filename
     marker$line <- x$line_number
     marker$column <- x$column_number
-    marker$message <- x$message
+    marker$message <- paste0("[", x$linter, "] ", x$message)
     marker
   })
 

--- a/R/methods.R
+++ b/R/methods.R
@@ -8,11 +8,13 @@ print.lint <- function(x, ...) {
     crayon::bold
   )
 
-  cat(sep = "",
+  cat(
+    sep = "",
     crayon::bold(x$filename, ":",
     as.character(x$line_number), ":",
     as.character(x$column_number), ": ", sep = ""),
     color(x$type, ": ", sep = ""),
+    "[", x$linter, "]",
     crayon::bold(x$message), "\n",
     # swap tabs for spaces for #528 (sorry Richard Hendricks)
     chartr("\t", " ", x$line), "\n",
@@ -24,25 +26,27 @@ print.lint <- function(x, ...) {
 
 markdown <- function(x, info, ...) {
 
-  cat(sep = "",
-      "[", x$filename, ":",
-      as.character(x$line_number), ":",
-      as.character(x$column_number), ":", "]",
-      "(",
-        paste(sep = "/",
+  cat(
+    sep = "",
+    "[", x$filename, ":",
+    as.character(x$line_number), ":",
+    as.character(x$column_number), ":", "]",
+    "(",
+    paste(sep = "/",
           "https://github.com",
           info$user,
           info$repo,
           "blob",
           info$commit,
           x$filename
-        ), "#L", x$line_number,
-      ")",
+    ), "#L", x$line_number,
+    ")",
     " ",
     "*", x$type, ":", "* ",
+    "[", x$linter, "] ",
     "**", x$message, "**\n",
     "```r\n\U200B", # we use a zero width unicode character here so that Github
-                    # does not strip the leading whitespace
+    # does not strip the leading whitespace
     x$line, "\n",
     highlight_string(x$message, x$column_number, x$ranges),
     "\n```\n"

--- a/R/methods.R
+++ b/R/methods.R
@@ -14,7 +14,7 @@ print.lint <- function(x, ...) {
     as.character(x$line_number), ":",
     as.character(x$column_number), ": ", sep = ""),
     color(x$type, ": ", sep = ""),
-    "[", x$linter, "]",
+    "[", x$linter, "] ",
     crayon::bold(x$message), "\n",
     # swap tabs for spaces for #528 (sorry Richard Hendricks)
     chartr("\t", " ", x$line), "\n",

--- a/tests/testthat/test-rstudio_markers.R
+++ b/tests/testthat/test-rstudio_markers.R
@@ -4,15 +4,18 @@ test_that("it returns markers which match lints", {
 
   lint1 <- structure(
     list(
-      Lint(filename = "test_file",
-           line_number = 1L,
-           column_number = 2L,
-           type = "error",
-           line = "a line",
-           message = "hi")
+      Lint(
+        filename = "test_file",
+        line_number = 1L,
+        column_number = 2L,
+        type = "error",
+        line = "a line",
+        message = "hi"
+      )
     ),
     class = "lints"
   )
+  lint1[[1L]]$linter <- "linter_name"
 
   marker1 <- rstudio_source_markers(lint1)
   expect_equal(marker1$name, "lintr")
@@ -20,31 +23,37 @@ test_that("it returns markers which match lints", {
   expect_equal(marker1$markers[[1L]]$file, lint1[[1L]]$filename)
   expect_equal(marker1$markers[[1L]]$line, lint1[[1L]]$line_number)
   expect_equal(marker1$markers[[1L]]$column, lint1[[1L]]$column_number)
-  expect_equal(marker1$markers[[1L]]$message, lint1[[1L]]$message)
+  expect_equal(marker1$markers[[1L]]$message, paste0("[", lint1[[1L]]$linter, "] ", lint1[[1L]]$message))
 
   lint2 <- structure(
     list(
-      Lint(filename = "test_file",
-           line_number = 1L,
-           column_number = 2L,
-           type = "error",
-           line = "a line",
-           message = "hi"),
-      Lint(filename = "test_file2",
-           line_number = 10L,
-           column_number = 5L,
-           type = "warning",
-           message = "test a message")
+      Lint(
+        filename = "test_file",
+        line_number = 1L,
+        column_number = 2L,
+        type = "error",
+        line = "a line",
+        message = "hi"
+      ),
+      Lint(
+        filename = "test_file2",
+        line_number = 10L,
+        column_number = 5L,
+        type = "warning",
+        message = "test a message"
+      )
     ),
     class = "lints"
   )
+  lint2[[1L]]$linter <- "linter_name"
+  lint2[[2L]]$linter <- "linter_name"
   marker2 <- rstudio_source_markers(lint2)
   expect_equal(marker2$name, "lintr")
   expect_equal(marker2$markers[[1L]]$type, lint2[[1L]]$type)
   expect_equal(marker2$markers[[1L]]$file, lint2[[1L]]$filename)
   expect_equal(marker2$markers[[1L]]$line, lint2[[1L]]$line_number)
   expect_equal(marker2$markers[[1L]]$column, lint2[[1L]]$column_number)
-  expect_equal(marker2$markers[[1L]]$message, lint2[[1L]]$message)
+  expect_equal(marker2$markers[[1L]]$message, paste0("[", lint2[[1L]]$linter, "] ", lint2[[1L]]$message))
 })
 
 test_that("it prepends the package path if it exists", {
@@ -53,16 +62,19 @@ test_that("it prepends the package path if it exists", {
 
   lint3 <- structure(
     list(
-      Lint(filename = "test_file",
-           line_number = 1L,
-           column_number = 2L,
-           type = "error",
-           line = "a line",
-           message = "hi")
+      Lint(
+        filename = "test_file",
+        line_number = 1L,
+        column_number = 2L,
+        type = "error",
+        line = "a line",
+        message = "hi"
+      )
     ),
     class = "lints",
     path = "test"
   )
+  lint3[[1L]]$linter <- "linter_name"
   marker3 <- rstudio_source_markers(lint3)
   expect_equal(marker3$name, "lintr")
   expect_equal(marker3$basePath, "test")
@@ -70,7 +82,7 @@ test_that("it prepends the package path if it exists", {
   expect_equal(marker3$markers[[1L]]$file, file.path("test", lint3[[1L]]$filename))
   expect_equal(marker3$markers[[1L]]$line, lint3[[1L]]$line_number)
   expect_equal(marker3$markers[[1L]]$column, lint3[[1L]]$column_number)
-  expect_equal(marker3$markers[[1L]]$message, lint3[[1L]]$message)
+  expect_equal(marker3$markers[[1L]]$message, paste0("[", lint3[[1L]]$linter, "] ", lint3[[1L]]$message))
 })
 
 test_that("it returns an empty list of markers if there are no lints", {


### PR DESCRIPTION
fixes #1357 

Didn't touch `checkstyle_output()`.

CC @renkun-ken Not sure if this is relevant to the vscode linter support.