### PR TITLE
Skip unloadable namespaces when populating imports

### DIFF
--- a/R/namespace.R
+++ b/R/namespace.R
@@ -25,10 +25,10 @@ namespace_imports <- function(path = find_package()) {
 #   typically, users are running this on their own package directories and thus
 #   will have the namespace dependencies installed, but we can't guarantee this.
 safe_get_exports <- function(ns) {
-  exports <- tryCatch(
-    getNamespaceExports(asNamespace(ns)),
-    error = function(cond) character()
-  )
+  exports <- character()
+  if (requireNamespace(ns, quietly = TRUE)) {
+    exports <- getNamespaceExports(asNamespace(ns))
+  }
 
   list(ns, exports)
 }

--- a/R/namespace.R
+++ b/R/namespace.R
@@ -1,23 +1,15 @@
 # Parse namespace files and return imports exports, methods
 namespace_imports <- function(path = find_package()) {
-  imports <- tryCatch({
-    pkg_name <- suppressWarnings(pkg_name(path))
-    data <- parseNamespaceFile(package = basename(path), package.lib = file.path(path, ".."))
-    data$imports
-  }, error = function(e) {
-    list()
-  })
-
-  full_imports <- lengths(imports) == 1L
-
-  imports[full_imports] <- lapply(imports[full_imports], safe_get_exports)
-
-  funs <- lapply(imports, `[[`, 2L)
-  data.frame(
-    pkg = rep(unlist(lapply(imports, `[[`, 1L)), lengths(funs)),
-    fun = unlist(funs),
-    stringsAsFactors = FALSE
+  namespace_data <- tryCatch(
+    parseNamespaceFile(basename(path), package.lib = file.path(path, "..")),
+    error = function(e) NULL
   )
+
+  if (length(namespace_data$imports) == 0L) {
+    return(empty_namespace_data())
+  }
+
+  do.call(rbind, lapply(namespace_data$imports, safe_get_exports))
 }
 
 # this loads the namespaces, but is the easiest way to do it
@@ -25,12 +17,20 @@ namespace_imports <- function(path = find_package()) {
 #   typically, users are running this on their own package directories and thus
 #   will have the namespace dependencies installed, but we can't guarantee this.
 safe_get_exports <- function(ns) {
-  exports <- character()
-  if (requireNamespace(ns, quietly = TRUE)) {
-    exports <- getNamespaceExports(asNamespace(ns))
+  # check package exists for both import(x) and importFrom(x, y) usages
+  if (!requireNamespace(ns[[1L]], quietly = TRUE)) {
+    return(empty_namespace_data())
+  }
+  # importFrom directives appear as list(ns, imported_funs)
+  if (length(ns) > 1L) {
+    return(data.frame(pkg = ns[[1L]], fun = ns[[2L]], stringsAsFactors = FALSE))
   }
 
-  list(ns, exports)
+  data.frame(pkg = ns, fun = getNamespaceExports(ns), stringsAsFactors = FALSE)
+}
+
+empty_namespace_data <- function() {
+  data.frame(pkg = character(), ns = character(), stringsAsFactors = FALSE)
 }
 
 # filter namespace_imports() for S3 generics

--- a/R/object_name_linters.R
+++ b/R/object_name_linters.R
@@ -24,6 +24,25 @@ object_name_xpath <- local({
 #' Check that object names conform to a naming style.
 #' The default naming styles are "snake_case" and "symbols".
 #'
+#' Note when used in a package, in order to ignore objects imported
+#'   from other namespaces, this linter will attempt [getNamespaceExports()]
+#'   whenever an `import(PKG)` statement is found in your NAMESPACE file.
+#'   If this fails (e.g., the package is not yet installed), the linter
+#'   won't be able to ignore such usages.
+#'
+#' Suppose, for example, you have `import(upstream)` in your NAMESPACE,
+#'   which makes available its exported function
+#'   `a_really_quite_long_function_name` that you then use in your package.
+#'   Then, if `upstream` is not installed when this linter runs, a lint
+#'   will be thrown on this object (even though you don't "own" its name).
+#'
+#' There are three workarounds: (1) always namespace-qualify usages,
+#'   because this linter ignores names in `pkg::foo()` form; (2) use
+#'   `@importFrom(pkg, foo)` instead of a blanket `import(pkg)` in your
+#'   NAMESPACE, because this linter takes these imported names as given;
+#'   and of course (3) install the package so that it's available in
+#'   the session where this linter is running.
+#'
 #' @param styles A subset of
 #'   \Sexpr[stage=render, results=rd]{lintr:::regexes_rd}. A name should
 #'   match at least one of these styles.
@@ -150,6 +169,9 @@ regexes_rd <- toString(paste0("\\sQuote{", names(style_regexes), "}"))
 #'  * leading `.`, e.g. `.my_hidden_function` has length 18.
 #'  * "%%" for infix operators, e.g. `%my_op%` has length 5.
 #'  * trailing `<-` for assignment functions, e.g. `my_attr<-` has length 7.
+#'
+#' Note that this behavior relies in part on having packages in your Imports available;
+#'   see the detailed note in [object_name_linter()] for more details.
 #'
 #' @param length maximum variable name length allowed.
 #' @evalRd rd_tags("object_length_linter")

--- a/R/object_name_linters.R
+++ b/R/object_name_linters.R
@@ -26,24 +26,20 @@ object_name_xpath <- local({
 #'
 #' Note when used in a package, in order to ignore objects imported
 #'   from other namespaces, this linter will attempt [getNamespaceExports()]
-#'   whenever an `import(PKG)` statement is found in your NAMESPACE file.
-#'   If this fails (e.g., the package is not yet installed), the linter
-#'   won't be able to ignore such usages.
+#'   whenever an `import(PKG)` or `importFrom(PKG, ...)` statement is found
+#'   in your NAMESPACE file. If [requireNamespace()] fails (e.g., the package
+#'   is not yet installed), the linter won't be able to ignore some usages
+#'   that would otherwise be allowed.
 #'
 #' Suppose, for example, you have `import(upstream)` in your NAMESPACE,
-#'   which makes available its exported function
-#'   `a_really_quite_long_function_name` that you then use in your package.
+#'   which makes available its exported S3 generic function
+#'   `a_really_quite_long_function_name` that you then extend in your package
+#'   by defining a corresponding method for your class `my_class`.
 #'   Then, if `upstream` is not installed when this linter runs, a lint
-#'   will be thrown on this object (even though you don't "own" its name).
+#'   will be thrown on this object (even though you don't "own" its full name).
 #'
-#' There are three options to get lintr to work correctly:
-#'   (1) install the package so that it's available in
-#'   the session where this linter is running; (2) always namespace-qualify
-#'   usages, because this linter ignores names in `pkg::foo()` form; and
-#'   (3) use `importFrom(pkg, foo)` instead of a blanket `import(pkg)` in your
-#'   NAMESPACE, because this linter takes these imported names as given;
-#'   and of course (3) install the package so that it's available in
-#'   the session where this linter is running.
+#' The best way to get lintr to work correctly is to install the package so
+#'   that it's available in the session where this linter is running.
 #'
 #' @param styles A subset of
 #'   \Sexpr[stage=render, results=rd]{lintr:::regexes_rd}. A name should

--- a/R/object_name_linters.R
+++ b/R/object_name_linters.R
@@ -36,9 +36,11 @@ object_name_xpath <- local({
 #'   Then, if `upstream` is not installed when this linter runs, a lint
 #'   will be thrown on this object (even though you don't "own" its name).
 #'
-#' There are three workarounds: (1) always namespace-qualify usages,
-#'   because this linter ignores names in `pkg::foo()` form; (2) use
-#'   `@importFrom(pkg, foo)` instead of a blanket `import(pkg)` in your
+#' There are three options to get lintr to work correctly:
+#'   (1) install the package so that it's available in
+#'   the session where this linter is running; (2) always namespace-qualify
+#'   usages, because this linter ignores names in `pkg::foo()` form; and
+#'   (3) use `importFrom(pkg, foo)` instead of a blanket `import(pkg)` in your
 #'   NAMESPACE, because this linter takes these imported names as given;
 #'   and of course (3) install the package so that it's available in
 #'   the session where this linter is running.

--- a/man/object_length_linter.Rd
+++ b/man/object_length_linter.Rd
@@ -20,6 +20,9 @@ The length of an object name is defined as the length in characters, after remov
 \item "\%\%" for infix operators, e.g. \verb{\%my_op\%} has length 5.
 \item trailing \verb{<-} for assignment functions, e.g. \verb{my_attr<-} has length 7.
 }
+
+Note that this behavior relies in part on having packages in your Imports available;
+see the detailed note in \code{\link[=object_name_linter]{object_name_linter()}} for more details.
 }
 \seealso{
 \link{linters} for a complete list of linters available in lintr.

--- a/man/object_name_linter.Rd
+++ b/man/object_name_linter.Rd
@@ -15,6 +15,26 @@ match at least one of these styles.}
 Check that object names conform to a naming style.
 The default naming styles are "snake_case" and "symbols".
 }
+\details{
+Note when used in a package, in order to ignore objects imported
+from other namespaces, this linter will attempt \code{\link[=getNamespaceExports]{getNamespaceExports()}}
+whenever an \code{import(PKG)} statement is found in your NAMESPACE file.
+If this fails (e.g., the package is not yet installed), the linter
+won't be able to ignore such usages.
+
+Suppose, for example, you have \code{import(upstream)} in your NAMESPACE,
+which makes available its exported function
+\code{a_really_quite_long_function_name} that you then use in your package.
+Then, if \code{upstream} is not installed when this linter runs, a lint
+will be thrown on this object (even though you don't "own" its name).
+
+There are three workarounds: (1) always namespace-qualify usages,
+because this linter ignores names in \code{pkg::foo()} form; (2) use
+\verb{@importFrom(pkg, foo)} instead of a blanket \code{import(pkg)} in your
+NAMESPACE, because this linter takes these imported names as given;
+and of course (3) install the package so that it's available in
+the session where this linter is running.
+}
 \seealso{
 \link{linters} for a complete list of linters available in lintr.
 }

--- a/man/object_name_linter.Rd
+++ b/man/object_name_linter.Rd
@@ -18,24 +18,20 @@ The default naming styles are "snake_case" and "symbols".
 \details{
 Note when used in a package, in order to ignore objects imported
 from other namespaces, this linter will attempt \code{\link[=getNamespaceExports]{getNamespaceExports()}}
-whenever an \code{import(PKG)} statement is found in your NAMESPACE file.
-If this fails (e.g., the package is not yet installed), the linter
-won't be able to ignore such usages.
+whenever an \code{import(PKG)} or \code{importFrom(PKG, ...)} statement is found
+in your NAMESPACE file. If \code{\link[=requireNamespace]{requireNamespace()}} fails (e.g., the package
+is not yet installed), the linter won't be able to ignore some usages
+that would otherwise be allowed.
 
 Suppose, for example, you have \code{import(upstream)} in your NAMESPACE,
-which makes available its exported function
-\code{a_really_quite_long_function_name} that you then use in your package.
+which makes available its exported S3 generic function
+\code{a_really_quite_long_function_name} that you then extend in your package
+by defining a corresponding method for your class \code{my_class}.
 Then, if \code{upstream} is not installed when this linter runs, a lint
-will be thrown on this object (even though you don't "own" its name).
+will be thrown on this object (even though you don't "own" its full name).
 
-There are three options to get lintr to work correctly:
-(1) install the package so that it's available in
-the session where this linter is running; (2) always namespace-qualify
-usages, because this linter ignores names in \code{pkg::foo()} form; and
-(3) use \code{importFrom(pkg, foo)} instead of a blanket \code{import(pkg)} in your
-NAMESPACE, because this linter takes these imported names as given;
-and of course (3) install the package so that it's available in
-the session where this linter is running.
+The best way to get lintr to work correctly is to install the package so
+that it's available in the session where this linter is running.
 }
 \seealso{
 \link{linters} for a complete list of linters available in lintr.

--- a/man/object_name_linter.Rd
+++ b/man/object_name_linter.Rd
@@ -28,9 +28,11 @@ which makes available its exported function
 Then, if \code{upstream} is not installed when this linter runs, a lint
 will be thrown on this object (even though you don't "own" its name).
 
-There are three workarounds: (1) always namespace-qualify usages,
-because this linter ignores names in \code{pkg::foo()} form; (2) use
-\verb{@importFrom(pkg, foo)} instead of a blanket \code{import(pkg)} in your
+There are three options to get lintr to work correctly:
+(1) install the package so that it's available in
+the session where this linter is running; (2) always namespace-qualify
+usages, because this linter ignores names in \code{pkg::foo()} form; and
+(3) use \code{importFrom(pkg, foo)} instead of a blanket \code{import(pkg)} in your
 NAMESPACE, because this linter takes these imported names as given;
 and of course (3) install the package so that it's available in
 the session where this linter is running.

--- a/tests/testthat/dummy_packages/missing_dep/DESCRIPTION
+++ b/tests/testthat/dummy_packages/missing_dep/DESCRIPTION
@@ -1,0 +1,3 @@
+Package: downstream
+Version: 0.0.1
+Imports: myFancyUpstream

--- a/tests/testthat/dummy_packages/missing_dep/NAMESPACE
+++ b/tests/testthat/dummy_packages/missing_dep/NAMESPACE
@@ -1,0 +1,3 @@
+import(myFancyUpstream)
+export(downstream)
+

--- a/tests/testthat/dummy_packages/missing_dep/NAMESPACE
+++ b/tests/testthat/dummy_packages/missing_dep/NAMESPACE
@@ -1,3 +1,4 @@
 import(myFancyUpstream)
+importFrom(aGemOfAPackage, a_veritably_dilettantish_function,
+                           sPoNgEbOb_cAsE.FuNcTiOn)
 export(downstream)
-

--- a/tests/testthat/dummy_packages/missing_dep/R/foo.R
+++ b/tests/testthat/dummy_packages/missing_dep/R/foo.R
@@ -1,0 +1,7 @@
+downstream <- function() {
+  a_really_really_long_local_object_name <- 1
+  aSilLLyObjEctNaME <- 2
+
+  myFancyUpstream::upstreams_really_long_imported_object_name()
+  myFancyUpstream::uPStreams_SilLY.objecT.Name()
+}

--- a/tests/testthat/dummy_packages/missing_dep/R/foo.R
+++ b/tests/testthat/dummy_packages/missing_dep/R/foo.R
@@ -1,7 +1,11 @@
-downstream <- function() {
+downstream <- function(x) {
   a_really_really_long_local_object_name <- 1
   aSilLLyObjEctNaME <- 2
 
   myFancyUpstream::upstreams_really_long_imported_object_name()
   myFancyUpstream::uPStreams_SilLY.objecT.Name()
 }
+
+# importFrom() functions in unknown namespace
+a_veritably_dilettantish_function.my_class <- function(x, ...) x
+sPoNgEbOb_cAsE.FuNcTiOn.my_class <- function(x, ...) x

--- a/tests/testthat/test-object_length_linter.R
+++ b/tests/testthat/test-object_length_linter.R
@@ -40,3 +40,10 @@ test_that("lints S3 generics correctly", {
     list(line_number = 9L)
   ), linter)
 })
+
+test_that("object_length_linter won't fail if an imported namespace is unavailable", {
+  expect_length(
+    lint_package(test_path("dummy_packages", "missing_dep"), linters = object_length_linter(), parse_settings = FALSE),
+    1L
+  )
+})

--- a/tests/testthat/test-object_length_linter.R
+++ b/tests/testthat/test-object_length_linter.R
@@ -44,6 +44,6 @@ test_that("lints S3 generics correctly", {
 test_that("object_length_linter won't fail if an imported namespace is unavailable", {
   expect_length(
     lint_package(test_path("dummy_packages", "missing_dep"), linters = object_length_linter(), parse_settings = FALSE),
-    1L
+    3L
   )
 })

--- a/tests/testthat/test-object_name_linter.R
+++ b/tests/testthat/test-object_name_linter.R
@@ -148,6 +148,6 @@ test_that("assignment targets of compound lhs are correctly identified", {
 test_that("object_name_linter won't fail if an imported namespace is unavailable", {
   expect_length(
     lint_package(test_path("dummy_packages", "missing_dep"), linters = object_name_linter(), parse_settings = FALSE),
-    1L
+    3L
   )
 })

--- a/tests/testthat/test-object_name_linter.R
+++ b/tests/testthat/test-object_name_linter.R
@@ -144,3 +144,10 @@ test_that("assignment targets of compound lhs are correctly identified", {
   expect_lint("`badName`$\"good_name\" <- 42", msg, linter)
   expect_lint("`badName`$'good_name' <- 42", msg, linter)
 })
+
+test_that("object_name_linter won't fail if an imported namespace is unavailable", {
+  expect_length(
+    lint_package(test_path("dummy_packages", "missing_dep"), linters = object_name_linter(), parse_settings = FALSE),
+    1L
+  )
+})

--- a/tests/testthat/test-object_usage_linter.R
+++ b/tests/testthat/test-object_usage_linter.R
@@ -328,7 +328,7 @@ test_that("global variable detection works", {
 
 test_that("package detection works", {
   expect_length(
-    lint_package("dummy_packages/package", linters = object_usage_linter(), parse_settings = FALSE),
+    lint_package(test_path("dummy_packages", "package"), linters = object_usage_linter(), parse_settings = FALSE),
     9L
   )
 })


### PR DESCRIPTION
Closes #1360

The tests are not very satisfying -- they basically just guarantee running `lint()` doesn't fail in this case.

Considered making a little "cache" to throw a warning, but opted for a long explanation in the documentation instead. I think that's a good compromise. See #1366 for a way forward on this.