### PR TITLE
add `allow_trailing = FALSE` to `missing_argument_linter()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -178,7 +178,8 @@
   @AshesITR).
 * `duplicate_argument_linter()` similarly checks that there are no duplicate arguments supplied to function calls (#850,
   @renkun-ken).
-* `missing_argument_linter()` to check for empty (missing) arguments in function calls (#563, @renkun-ken).
+* `missing_argument_linter()` to check for empty (missing) arguments in function calls (#563, #1152, @renkun-ken and 
+  @AshesITR).
 * `missing_package_linter()` to check if packages in calls to `library()` and friends
   are missing (#536, #1037, @renkun-ken and @MichaelChirico).
 * `namespace_linter()` to check for common mistakes in `pkg::symbol` usages (#548, @renkun-ken).

--- a/man/missing_argument_linter.Rd
+++ b/man/missing_argument_linter.Rd
@@ -4,10 +4,12 @@
 \alias{missing_argument_linter}
 \title{Missing argument linter}
 \usage{
-missing_argument_linter(except = c("switch", "alist"))
+missing_argument_linter(except = c("switch", "alist"), allow_trailing = FALSE)
 }
 \arguments{
 \item{except}{a character vector of function names as exceptions.}
+
+\item{allow_trailing}{always allow trailing empty arguments?}
 }
 \description{
 Check for missing arguments in function calls.

--- a/tests/testthat/test-missing_argument_linter.R
+++ b/tests/testthat/test-missing_argument_linter.R
@@ -1,107 +1,93 @@
 test_that("returns the correct linting", {
-  expect_lint("fun(x, a = 1)",
+  linter <- missing_argument_linter()
+  msg <- rex("Missing argument in function call.")
+
+  expect_lint("fun(x, a = 1)", NULL, linter)
+  expect_lint("fun(x = 1, a = 1)", NULL, linter)
+  expect_lint("dt[, 1]", NULL, linter)
+  expect_lint("dt[, 'col']", NULL, linter)
+  expect_lint("array[, , 1]", NULL, linter)
+  expect_lint("switch(a =, b =, c = 1, 0)", NULL, linter)
+  expect_lint("alist(a =, b =, c = 1, 0)", NULL, linter)
+
+  expect_lint("test(a =, b =, c = 1, 0)", NULL, missing_argument_linter("test"))
+
+  expect_lint("fun(, a = 1)", list(message = msg), linter)
+  expect_lint("f <- function(x, y) x\nf(, y = 1)\n", list(line = "f(, y = 1)"), linter)
+  expect_lint("fun(a = 1,, b = 2)", list(message = msg), linter)
+  expect_lint("fun(a = 1, b =)", list(message = msg), linter)
+  expect_lint("fun(a = 1,)", list(message = msg), linter)
+  expect_lint("fun(a = )", list(message = msg), linter)
+
+  expect_lint(
+    trim_some("
+      list(
+        a = 1,
+        b = 2,
+      )
+    "),
+    list(message = msg),
+    linter
+  )
+
+  expect_lint("stats::median(1:10, na.rm =)", list(message = msg), linter)
+  expect_lint("env$get(1:10, default =)", list(message = msg), linter)
+
+  # except list can be empty
+  expect_lint("switch(a =, b = 1, 0)", list(message = msg), missing_argument_linter(character()))
+  expect_lint("alist(a =)", list(message = msg), missing_argument_linter(character()))
+
+  # allow_trailing can allow trailing empty args also for non-excepted functions
+  expect_lint("fun(a = 1,)", NULL, missing_argument_linter(allow_trailing = TRUE))
+  expect_lint(
+    trim_some("
+      fun(
+        a = 1,
+        # comment
+      )
+    "),
     NULL,
-    missing_argument_linter())
-
-  expect_lint("fun(x = 1, a = 1)",
-    NULL,
-    missing_argument_linter())
-
-  expect_lint("dt[, 1]",
-    NULL,
-    missing_argument_linter())
-
-  expect_lint("dt[, 'col']",
-    NULL,
-    missing_argument_linter())
-
-  expect_lint("array[, , 1]",
-    NULL,
-    missing_argument_linter())
-
-  expect_lint("switch(a =, b =, c = 1, 0)",
-    NULL,
-    missing_argument_linter())
-
-  expect_lint("alist(a =, b =, c = 1, 0)",
-    NULL,
-    missing_argument_linter())
-
-  expect_lint("test(a =, b =, c = 1, 0)",
-    NULL,
-    missing_argument_linter("test"))
-
-  expect_lint("fun(, a = 1)",
-    list(message = rex("Missing argument in function call.")),
-    missing_argument_linter())
-
-  expect_lint("f <- function(x, y) x\nf(, y = 1)\n",
-    list(line = "f(, y = 1)"),
-    missing_argument_linter())
-
-  expect_lint("fun(a = 1,, b = 2)",
-    list(message = rex("Missing argument in function call.")),
-    missing_argument_linter())
-
-  expect_lint("fun(a = 1, b =)",
-    list(message = rex("Missing argument in function call.")),
-    missing_argument_linter())
-
-  expect_lint("fun(a = 1,)",
-    list(message = rex("Missing argument in function call.")),
-    missing_argument_linter())
-
-  expect_lint("fun(a = )",
-    list(message = rex("Missing argument in function call.")),
-    missing_argument_linter())
-
-  expect_lint("list(
-    a = 1,
-    b = 2,
-    )",
-    list(message = rex("Missing argument in function call.")),
-    missing_argument_linter())
-
-  expect_lint("stats::median(1:10, na.rm =)",
-    list(message = rex("Missing argument in function call.")),
-    missing_argument_linter())
-
-  expect_lint("env$get(1:10, default =)",
-    list(message = rex("Missing argument in function call.")),
-    missing_argument_linter())
-
-  expect_lint("switch(a =, b = 1, 0)",
-    list(message = rex("Missing argument in function call.")),
-    missing_argument_linter(character()))
-
-  expect_lint("alist(a =)",
-    list(message = rex("Missing argument in function call.")),
-    missing_argument_linter(character()))
+    missing_argument_linter(allow_trailing = TRUE)
+  )
+  # ... but not if the final argument is named
+  expect_lint("fun(a = 1, b = )", list(message = msg), missing_argument_linter(allow_trailing = TRUE))
 
   # Fixes https://github.com/r-lib/lintr/issues/906
   # Comments should be ignored so that missing arguments could be
   # properly identified in these cases.
-  expect_lint("fun(
-    1,
-    2,
-    # comment
-    )",
-    list(message = rex("Missing argument in function call.")),
-    missing_argument_linter())
+  expect_lint(
+    trim_some("
+      fun(
+        1,
+        2,
+        # comment
+      )
+    "),
+    list(message = msg),
+    linter
+  )
 
-  expect_lint("fun(
-    # comment
-    ,
-    1
-    )",
-    list(message = rex("Missing argument in function call.")),
-    missing_argument_linter())
+  expect_lint(
+    trim_some("
+      fun(
+        # comment
+        ,
+        1
+      )
+    "),
+    list(message = msg),
+    linter
+  )
 
-  expect_lint("fun(
-    a = # comment
-    ,
-    1
-    )",
-    list(message = rex("Missing argument in function call.")),
-    missing_argument_linter())
+  expect_lint(
+    trim_some("
+      fun(
+        a = # comment
+        ,
+        1
+      )
+    "),
+    list(message = msg),
+    linter
+  )
 })


### PR DESCRIPTION
fixes #1152 

deferring the NEWS bullet until #1384 is merged to avoid conflicts.