### PR TITLE
alias `?lint_file` -> `?lint`

### DIFF
--- a/R/lint.R
+++ b/R/lint.R
@@ -29,6 +29,8 @@
 #' @param text Optional argument for supplying a string or lines directly, e.g. if the file is already in memory or
 #' linting is being done ad hoc.
 #'
+#' @aliases lint_file
+#' @evalRd # TODO(next release after 3.0.0) remove the alias
 #' @return A list of lint objects.
 #'
 #' @examples

--- a/man/lint.Rd
+++ b/man/lint.Rd
@@ -2,6 +2,7 @@
 % Please edit documentation in R/lint.R
 \name{lint}
 \alias{lint}
+\alias{lint_file}
 \alias{lint_dir}
 \alias{lint_package}
 \title{Lint a file, directory, or package}


### PR DESCRIPTION
to preserve old doc links to `lintr::lint()`