### PR TITLE
use consistent linter class, add membership helper

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # lintr (development version)
 
+* `modify_defaults()` no longer uses the mistaken `"lintr_function"` S3 class, instead applying the
+  `"linter"` class also common to `Linter()`. `Linter()` also includes `"function"` in the S3
+  class of its output to facilitate S3 dispatch to `function` methods where appropriate (#1392, @MichaelChirico).
+
 # lintr 3.0.0
 
 ## Breaking changes
@@ -26,7 +30,7 @@
    + `trailing_semicolons_linter()`
 * Removed `return()` from `all_undesirable_functions` because early returns (which often improve
   readability and reduce code complexity) require explicit use of `return()`. Follow #1100 for
-  an upcoming `return_linter()` to lint unnecessary `return()` statements (#1146, @AshesITR).  
+  an upcoming `return_linter()` to lint unnecessary `return()` statements (#1146, @AshesITR).
   Note that you can replicate old behavior by supplying `return` as a custom undesirable function:
   `undesirable_function_linter(c(all_undesirable_functions, list(return = NA)))`
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -53,6 +53,7 @@
 * Removed `return()` from `all_undesirable_functions` because early returns (which often improve
   readability and reduce code complexity) require explicit use of `return()`. Follow #1100 for
   an upcoming `return_linter()` to lint unnecessary `return()` statements (#1146, @AshesITR).
+
   Note that you can replicate old behavior by supplying `return` as a custom undesirable function:
   `undesirable_function_linter(c(all_undesirable_functions, list(return = NA)))`
 

--- a/R/lint.R
+++ b/R/lint.R
@@ -311,7 +311,7 @@ define_linters <- function(linters = NULL) {
   if (is.null(linters)) {
     linters <- settings$linters
     names(linters) <- auto_names(linters)
-  } else if (inherits(linters, "linter")) {
+  } else if (is_linter(linters)) {
     linters <- list(linters)
     names(linters) <- attr(linters[[1L]], "name", exact = TRUE)
   } else if (!is.list(linters)) {
@@ -325,7 +325,7 @@ define_linters <- function(linters = NULL) {
 }
 
 validate_linter_object <- function(linter, name) {
-  if (!inherits(linter, "linter") && is.function(linter)) {
+  if (!is_linter(linter) && is.function(linter)) {
     if (is_linter_factory(linter)) {
       old <- "Passing linters as variables"
       new <- "a call to the linters (see ?linters)"

--- a/R/utils.R
+++ b/R/utils.R
@@ -70,7 +70,7 @@ auto_names <- function(x) {
   if (!any(missing)) return(nms)
 
   default_name <- function(x) {
-    if (inherits(x, "linter")) {
+    if (is_linter(x)) {
       attr(x, "name", exact = TRUE)
     } else {
       paste(deparse(x, 500L), collapse = " ")
@@ -178,7 +178,7 @@ Linter <- function(fun, name = linter_auto_name()) { # nolint: object_name.
     stop("`fun` must be a function taking exactly one argument.", call. = FALSE)
   }
   force(name)
-  structure(fun, class = "linter", name = name)
+  structure(fun, class = c("linter", "function"), name = name)
 }
 
 read_lines <- function(file, encoding = settings$encoding, ...) {
@@ -261,3 +261,5 @@ get_r_code <- function(xml) {
   }, character(1L))
   paste(lines, collapse = "\n")
 }
+
+is_linter <- function(x) inherits(x, "linter")

--- a/R/with.R
+++ b/R/with.R
@@ -46,8 +46,8 @@ modify_defaults <- function(defaults, ...) {
 
   res[] <- lapply(res, function(x) {
     prev_class <- class(x)
-    if (is.function(x) && !inherits(x, "lintr_function")) {
-      class(x) <- c(prev_class, "lintr_function")
+    if (is.function(x) && !is_linter(x)) {
+      class(x) <- c("linter", prev_class)
     }
     x
   })

--- a/tests/testthat/test-linter_tags.R
+++ b/tests/testthat/test-linter_tags.R
@@ -55,7 +55,7 @@ test_that("warnings occur only for deprecated linters", {
 
 test_that("available_linters matches the set of linters available from lintr", {
   lintr_db <- available_linters(exclude_tags = NULL)
-  linters_in_namespace <- ls(asNamespace("lintr"), pattern = "_linter$")
+  linters_in_namespace <- setdiff(ls(asNamespace("lintr"), pattern = "_linter$"), "is_linter")
   # ensure that the contents of inst/lintr/linters.csv covers all _linter objects in our namespace
   expect_identical(sort(lintr_db$linter), sort(linters_in_namespace))
   # ensure that all _linter objects in our namespace are also exported

--- a/tests/testthat/test-with.R
+++ b/tests/testthat/test-with.R
@@ -22,7 +22,9 @@ test_that("all default linters are tagged default", {
   # linters_with_tags() constructs the linters at runtime.
   skip_if(covr::in_covr())
 
-  expect_true(all.equal(linters_with_tags("default"), linters_with_defaults()))
+  # all.equal.default warns on some releases of R if the input is a function, see #1392
+  expect_silent(result <- all.equal(linters_with_tags("default"), linters_with_defaults()))
+  expect_true(result)
   expect_length(linters_with_tags("default", exclude_tags = "default"), 0L)
 
   # Check that above test also trips on default arguments.


### PR DESCRIPTION
Closes #1392 

I don't see any references to the `lintr_function` class anywhere, but elsewhere we test `inherits(x, "linter")`. So I assume that's an oversight and we only want one `"linter"` class.