### PR TITLE
skip test if xml2 attached

### DIFF
--- a/tests/testthat/test-object_usage_linter.R
+++ b/tests/testthat/test-object_usage_linter.R
@@ -411,6 +411,7 @@ test_that("definitions below top level are ignored (for now)", {
 
 # reported as #1127
 test_that("package imports are detected if present in file", {
+  skip_if("package:xml2" %in% search())
   expect_lint(
     trim_some("
       dog <- function(url) {


### PR DESCRIPTION
Test fails if `library(xml2)` is run before the suite starts, so just skip if it's attached to this session.