### PR TITLE
Bump needed `{withr}` version

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -41,7 +41,7 @@ Suggests:
     rstudioapi (>= 0.2),
     testthat (>= 3.0.0),
     tibble,
-    withr
+    withr (>= 2.5.0)
 License: MIT + file LICENSE
 Encoding: UTF-8
 VignetteBuilder: knitr

--- a/NEWS.md
+++ b/NEWS.md
@@ -3,7 +3,7 @@
 ## Changes to defaults
 
 * `seq_linter()` additionally lints on `1:n()` (from dplyr) 
-  and `1:.N` (from data.table)  (#1396, @IndrajeetPatil).
+  and `1:.N` (from data.table) (#1396, @IndrajeetPatil).
 
 ## Bug fixes
 
@@ -15,6 +15,11 @@
   newlines.
 * The `vignette("lintr")` incorrectly cited `exclude` as the key for setting file exclusions in `.lintr` when it is 
   actually `exclusions`. (#1401, @AshesITR)
+
+## Other changes
+
+* The minimum needed version for soft dependency `{withr}` has been bumped to `2.5.0`
+  (#1404, @IndrajeetPatil).
 
 # lintr 3.0.0
 

--- a/tests/testthat/test-ci.R
+++ b/tests/testthat/test-ci.R
@@ -2,9 +2,7 @@ test_that("GitHub Actions functionality works", {
   # imitate being on GHA whether or not we are
   withr::local_envvar(list(GITHUB_ACTIONS = "true"))
   withr::local_options(lintr.rstudio_source_markers = FALSE)
-  tmp <- withr::local_tempfile()
-
-  writeLines("x <- 1:nrow(y)", tmp)
+  tmp <- withr::local_tempfile(lines = "x <- 1:nrow(y)")
 
   l <- lint(tmp)
   expect_output(print(l), "::warning file", fixed = TRUE)
@@ -31,8 +29,7 @@ test_that("GitHub Actions functionality works in a subdirectory", {
 test_that("Printing works for Travis", {
   withr::local_envvar(list(GITHUB_ACTIONS = "false", TRAVIS_REPO_SLUG = "test/repo", LINTR_COMMENT_BOT = "true"))
   withr::local_options(lintr.rstudio_source_markers = FALSE)
-  tmp <- withr::local_tempfile()
-  writeLines("x <- 1:nrow(y)", tmp)
+  tmp <- withr::local_tempfile(lines = "x <- 1:nrow(y)")
 
   l <- lint(tmp)
 
@@ -43,8 +40,7 @@ test_that("Printing works for Travis", {
 test_that("Printing works for Wercker", {
   withr::local_envvar(list(GITHUB_ACTIONS = "false", WERCKER_GIT_BRANCH = "test/repo", LINTR_COMMENT_BOT = "true"))
   withr::local_options(lintr.rstudio_source_markers = FALSE)
-  tmp <- withr::local_tempfile()
-  writeLines("x <- 1:nrow(y)", tmp)
+  tmp <- withr::local_tempfile(lines = "x <- 1:nrow(y)")
 
   l <- lint(tmp)
 

--- a/tests/testthat/test-get_source_expressions.R
+++ b/tests/testthat/test-get_source_expressions.R
@@ -196,13 +196,12 @@ test_that("1- or 2-width octal expressions give the right STR_CONST values", {
 })
 
 test_that("returned data structure is complete", {
-  temp_file <- withr::local_tempfile()
-
   lines <- c("line_1", "line_2", "line_3")
+  temp_file <- withr::local_tempfile(lines = lines)
+
   lines_with_attr <- setNames(lines, seq_along(lines))
   attr(lines_with_attr, "terminal_newline") <- TRUE
 
-  writeLines(lines, con = temp_file)
   exprs <- get_source_expressions(temp_file)
   expect_named(exprs, c("expressions", "error", "lines"))
   expect_length(exprs$expressions, length(lines) + 1L)
@@ -243,8 +242,7 @@ test_that("returned data structure is complete", {
 })
 
 test_that("#1262: xml_parsed_content gets returned as missing even if there's no parsed_content", {
-  tempfile <- withr::local_tempfile()
-  writeLines('"\\R"', tempfile)
+  tempfile <- withr::local_tempfile(lines = '"\\R"')
 
   source_expressions <- get_source_expressions(tempfile)
   expect_null(source_expressions$expressions[[1L]]$full_parsed_content)
@@ -256,8 +254,7 @@ skip_if_not_installed("patrick")
 #   fail on files where the XML content is xml_missing;
 #   the main linter test files provide more thorough
 #   evidence that things are working as intended.
-bad_source <- withr::local_tempfile()
-writeLines("a <- 1L\nb <- 2L", bad_source)
+bad_source <- withr::local_tempfile(lines = "a <- 1L\nb <- 2L")
 expressions <- get_source_expressions(bad_source)$expressions
 
 # "zap" the xml_parsed_content to be xml_missing -- this gets

--- a/tests/testthat/test-get_source_expressions.R
+++ b/tests/testthat/test-get_source_expressions.R
@@ -250,20 +250,23 @@ test_that("#1262: xml_parsed_content gets returned as missing even if there's no
 
 test_that("#743, #879, #1406: get_source_expressions works on R files matching a knitr pattern", {
   # from #743
-  tempfile <- withr::local_tempfile(lines = trim_some('
+  tempfile <- withr::local_tempfile(
+    lines = trim_some('
       create_template <- function(x) {
         sprintf("
       ```{r code}
       foo <- function(x) x+%d
       foo(5)
       ```", x)
-      }')
+      }
+    ')
   )
   source_expressions <- get_source_expressions(tempfile)
   expect_null(source_expressions$error)
 
   # from #879
-  tempfile <- withr::local_tempfile(lines = trim_some('
+  tempfile <- withr::local_tempfile(
+    lines = trim_some('
       # `r print("7")`
       function() 2<=3
     ')

--- a/tests/testthat/test-get_source_expressions.R
+++ b/tests/testthat/test-get_source_expressions.R
@@ -250,29 +250,23 @@ test_that("#1262: xml_parsed_content gets returned as missing even if there's no
 
 test_that("#743, #879, #1406: get_source_expressions works on R files matching a knitr pattern", {
   # from #743
-  tempfile <- withr::local_tempfile()
-  writeLines(
-    trim_some('
+  tempfile <- withr::local_tempfile(lines = trim_some('
       create_template <- function(x) {
         sprintf("
       ```{r code}
       foo <- function(x) x+%d
       foo(5)
       ```", x)
-      }'),
-    tempfile
+      }')
   )
   source_expressions <- get_source_expressions(tempfile)
   expect_null(source_expressions$error)
 
   # from #879
-  tempfile <- withr::local_tempfile()
-  writeLines(
-    trim_some('
+  tempfile <- withr::local_tempfile(lines = trim_some('
       # `r print("7")`
       function() 2<=3
-    '),
-    tempfile
+    ')
   )
   source_expressions <- get_source_expressions(tempfile)
   expect_null(source_expressions$error)

--- a/tests/testthat/test-get_source_expressions.R
+++ b/tests/testthat/test-get_source_expressions.R
@@ -289,7 +289,7 @@ skip_if_not_installed("patrick")
 #   fail on files where the XML content is xml_missing;
 #   the main linter test files provide more thorough
 #   evidence that things are working as intended.
-bad_source <- withr::local_tempfile(lines = "a <- 1L\nb <- 2L")
+bad_source <- withr::local_tempfile(lines = c("a <- 1L", "b <- 2L"))
 expressions <- get_source_expressions(bad_source)$expressions
 
 # "zap" the xml_parsed_content to be xml_missing -- this gets

--- a/tests/testthat/test-parse_exclusions.R
+++ b/tests/testthat/test-parse_exclusions.R
@@ -4,14 +4,12 @@ old_ops <- options(lintr.exclude = "#TeSt_NoLiNt",
 
 test_that("it returns an empty list if there are no exclusions", {
   read_settings(NULL)
-  t1 <- tempfile()
-  on.exit(unlink(t1))
-  writeLines(trim_some("
+  t1 <- withr::local_tempfile(lines = trim_some("
     this
     is
     a
     test
-  "), t1)
+   "))
   expect_equal(parse_exclusions(t1), list())
 })
 

--- a/tests/testthat/test-parse_exclusions.R
+++ b/tests/testthat/test-parse_exclusions.R
@@ -4,12 +4,14 @@ old_ops <- options(lintr.exclude = "#TeSt_NoLiNt",
 
 test_that("it returns an empty list if there are no exclusions", {
   read_settings(NULL)
-  t1 <- withr::local_tempfile(lines = trim_some("
+  t1 <- tempfile()
+  on.exit(unlink(t1))
+  writeLines(trim_some("
     this
     is
     a
     test
-  "))
+  "), t1)
   expect_equal(parse_exclusions(t1), list())
 })
 

--- a/tests/testthat/test-parse_exclusions.R
+++ b/tests/testthat/test-parse_exclusions.R
@@ -4,14 +4,12 @@ old_ops <- options(lintr.exclude = "#TeSt_NoLiNt",
 
 test_that("it returns an empty list if there are no exclusions", {
   read_settings(NULL)
-  t1 <- tempfile()
-  on.exit(unlink(t1))
-  writeLines(trim_some("
+  t1 <- withr::local_tempfile(lines = trim_some("
     this
     is
     a
     test
-  "), t1)
+  "))
   expect_equal(parse_exclusions(t1), list())
 })
 

--- a/tests/testthat/test-rstudio_markers.R
+++ b/tests/testthat/test-rstudio_markers.R
@@ -102,7 +102,7 @@ test_that("rstudio_source_markers apply to print within rstudio", {
   withr::local_options(lintr.rstudio_source_markers = TRUE)
 
   tmp <- withr::local_tempfile(lines = "1:ncol(x)")
-  empty <- withr::local_tempfile(lines = "")
+  empty <- withr::local_tempfile(lines = character(0L))
 
   mockery::stub(print.lints, "rstudioapi::hasFun", function(x, ...) TRUE)
   mockery::stub(print.lints, "rstudio_source_markers", function(x) cat("matched\n"))

--- a/tests/testthat/test-rstudio_markers.R
+++ b/tests/testthat/test-rstudio_markers.R
@@ -100,11 +100,9 @@ test_that("it returns an empty list of markers if there are no lints", {
 
 test_that("rstudio_source_markers apply to print within rstudio", {
   withr::local_options(lintr.rstudio_source_markers = TRUE)
-  # TODO(@michaelchirico): Recent (as of this writing) withr v2.5.0 supports local_tempfile(lines = l) to simplify this
-  tmp <- withr::local_tempfile()
-  writeLines("1:ncol(x)", tmp)
-  empty <- withr::local_tempfile()
-  file.create(empty)
+
+  tmp <- withr::local_tempfile(lines = "1:ncol(x)")
+  empty <- withr::local_tempfile(lines = "")
 
   mockery::stub(print.lints, "rstudioapi::hasFun", function(x, ...) TRUE)
   mockery::stub(print.lints, "rstudio_source_markers", function(x) cat("matched\n"))

--- a/tests/testthat/test-trailing_blank_lines_linter.R
+++ b/tests/testthat/test-trailing_blank_lines_linter.R
@@ -17,10 +17,8 @@ test_that("returns the correct linting", {
 
   # Construct a test file without terminal newline
   # cf. test-get_source_expressions.R
-  tmp <- withr::local_tempfile()
-  tmp2 <- withr::local_tempfile()
-  cat("lm(y ~ x)\n", file = tmp)
-  cat("lm(y ~ x)", file = tmp2)
+  tmp <- withr::local_tempfile(lines = c("lm(y ~ x)", character(0L)))
+  tmp2 <- withr::local_tempfile(lines = "lm(y ~ x)")
 
   expect_lint(content = NULL, file = tmp, NULL, linter)
   expect_lint(content = NULL, file = tmp2, list(
@@ -30,9 +28,9 @@ test_that("returns the correct linting", {
   ), linter)
 
   # Construct an Rmd file without terminal newline
-  tmp3 <- withr::local_tempfile(fileext = ".Rmd")
-  cat(
-    trim_some(
+  tmp3 <- withr::local_tempfile(
+    fileext = ".Rmd",
+    lines = trim_some(
       '---
       title: "Some file"
       ---
@@ -43,8 +41,7 @@ test_that("returns the correct linting", {
 
       ```{r child="some-file.Rmd"}
       ```'
-    ),
-    file = tmp3
+    )
   )
   expect_lint(content = NULL, file = tmp3, list(
     message = msg2,
@@ -54,16 +51,15 @@ test_that("returns the correct linting", {
   ), linter)
 
   # Construct an Rmd file without R code (#1415)
-  tmp4 <- withr::local_tempfile(fileext = ".Rmd")
-  cat(
-    trim_some(
+  tmp4 <- withr::local_tempfile(
+    fileext = ".Rmd",
+    lines = trim_some(
       '---
       title: "Some file"
       ---
 
       No code and no terminal newline'
-    ),
-    file = tmp4
+    )
   )
   expect_lint(content = NULL, file = tmp4, list(
     message = msg2,

--- a/tests/testthat/test-trailing_blank_lines_linter.R
+++ b/tests/testthat/test-trailing_blank_lines_linter.R
@@ -17,8 +17,10 @@ test_that("returns the correct linting", {
 
   # Construct a test file without terminal newline
   # cf. test-get_source_expressions.R
-  tmp <- withr::local_tempfile(lines = c("lm(y ~ x)", character(0L)))
-  tmp2 <- withr::local_tempfile(lines = "lm(y ~ x)")
+  tmp <- withr::local_tempfile()
+  tmp2 <- withr::local_tempfile()
+  cat("lm(y ~ x)\n", file = tmp)
+  cat("lm(y ~ x)", file = tmp2)
 
   expect_lint(content = NULL, file = tmp, NULL, linter)
   expect_lint(content = NULL, file = tmp2, list(
@@ -28,9 +30,9 @@ test_that("returns the correct linting", {
   ), linter)
 
   # Construct an Rmd file without terminal newline
-  tmp3 <- withr::local_tempfile(
-    fileext = ".Rmd",
-    lines = trim_some(
+  tmp3 <- withr::local_tempfile(fileext = ".Rmd")
+  cat(
+    trim_some(
       '---
       title: "Some file"
       ---
@@ -41,7 +43,8 @@ test_that("returns the correct linting", {
 
       ```{r child="some-file.Rmd"}
       ```'
-    )
+    ),
+    file = tmp3
   )
   expect_lint(content = NULL, file = tmp3, list(
     message = msg2,
@@ -51,15 +54,16 @@ test_that("returns the correct linting", {
   ), linter)
 
   # Construct an Rmd file without R code (#1415)
-  tmp4 <- withr::local_tempfile(
-    fileext = ".Rmd",
-    lines = trim_some(
+  tmp4 <- withr::local_tempfile(fileext = ".Rmd")
+  cat(
+    trim_some(
       '---
       title: "Some file"
       ---
 
       No code and no terminal newline'
-    )
+    ),
+    file = tmp4
   )
   expect_lint(content = NULL, file = tmp4, list(
     message = msg2,

--- a/tests/testthat/test-xml_nodes_to_lints.R
+++ b/tests/testthat/test-xml_nodes_to_lints.R
@@ -1,7 +1,6 @@
 test_that("it creates basic lints", {
-  tmpfile <- withr::local_tempfile()
   code <- "before   %+%   after"
-  writeLines(code, tmpfile)
+  tmpfile <- withr::local_tempfile(lines = code)
   expr <- get_source_expressions(tmpfile)$expressions[[2L]]
   xml <- expr$full_xml_parsed_content
   node <- xml2::xml_find_first(xml, "//SPECIAL")
@@ -65,9 +64,8 @@ test_that("it creates basic lints", {
 })
 
 test_that("it handles multi-line lints correctly", {
-  tmpfile <- withr::local_tempfile()
   code <- c("before %+%", "  after")
-  writeLines(code, tmpfile)
+  tmpfile <- withr::local_tempfile(lines = code)
   expr <- get_source_expressions(tmpfile)$expressions[[2L]]
   xml <- expr$full_xml_parsed_content
   node <- xml2::xml_find_first(xml, "/exprlist/expr")


### PR DESCRIPTION
In order to use the `lines` parameter from `withr::local_tempfile()`.

Closes #1404