### PR TITLE
add version requirement for OP-LAMBDA

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -29,7 +29,7 @@ Imports:
     stats,
     utils,
     xml2 (>= 1.0.0),
-    xmlparsedata (>= 1.0.3),
+    xmlparsedata (>= 1.0.5),
     backports
 Suggests:
     covr,

--- a/tests/testthat/test-paren_body_linter.R
+++ b/tests/testthat/test-paren_body_linter.R
@@ -45,8 +45,6 @@ testthat::test_that("paren_body_linter returns correct lints", {
 
   # No space after the closing parenthesis of an anonymous function prompts a lint
   skip_if_not_r_version("4.1.0")
-  # OP-LAMBDA support added in 1.0.5
-  skip_if_not_installed("xmlparsedata", "1.0.5")
   expect_lint("\\()test", msg, linter)
 })
 
@@ -77,7 +75,6 @@ test_that("multi-line versions are caught", {
   )
 
   skip_if_not_r_version("4.1.0")
-  skip_if_not_installed("xmlparsedata", "1.0.5")
   expect_lint(
     trim_some("
       \\(var

--- a/tests/testthat/test-paren_body_linter.R
+++ b/tests/testthat/test-paren_body_linter.R
@@ -45,6 +45,8 @@ testthat::test_that("paren_body_linter returns correct lints", {
 
   # No space after the closing parenthesis of an anonymous function prompts a lint
   skip_if_not_r_version("4.1.0")
+  # OP-LAMBDA support added in 1.0.5
+  skip_if_not_installed("xmlparsedata", "1.0.5")
   expect_lint("\\()test", msg, linter)
 })
 
@@ -75,6 +77,7 @@ test_that("multi-line versions are caught", {
   )
 
   skip_if_not_r_version("4.1.0")
+  skip_if_not_installed("xmlparsedata", "1.0.5")
   expect_lint(
     trim_some("
       \\(var


### PR DESCRIPTION
Alternatively, we could just bump the version requirement to 1.0.5