### PR TITLE
Add a note about &/| dispatch

### DIFF
--- a/R/vector_logic_linter.R
+++ b/R/vector_logic_linter.R
@@ -6,6 +6,11 @@
 #'
 #' This linter covers inputs to `if()` and `while()` conditions and to
 #'   [testthat::expect_true()] and [testthat::expect_false()].
+#'
+#' Note that because `&` and `|` are generics, it is possible that
+#'   `&&` / `||` are not perfect substitutes because `&` is doing
+#'   method dispatch in an incompatible way.
+#'
 #' @evalRd rd_tags("vector_logic_linter")
 #' @seealso
 #'   [linters] for a complete list of linters available in lintr. \cr

--- a/man/vector_logic_linter.Rd
+++ b/man/vector_logic_linter.Rd
@@ -14,6 +14,10 @@ case \code{&&} is to be preferred. Ditto for \code{|} vs. \code{||}.
 \details{
 This linter covers inputs to \verb{if()} and \verb{while()} conditions and to
 \code{\link[testthat:logical-expectations]{testthat::expect_true()}} and \code{\link[testthat:logical-expectations]{testthat::expect_false()}}.
+
+Note that because \code{&} and \code{|} are generics, it is possible that
+\code{&&} / \code{||} are not perfect substitutes because \code{&} is doing
+method dispatch in an incompatible way.
 }
 \seealso{
 \link{linters} for a complete list of linters available in lintr. \cr


### PR DESCRIPTION
Related to #1453. We won't be able to detect such cases statically -- users will just have to disable / turn off the linter if their code heavily relies on some `&` or `|` method inside `if()` statements.