### PR TITLE
Remove false negative in `seq_linter()`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -45,7 +45,7 @@ Suggests:
 License: MIT + file LICENSE
 Encoding: UTF-8
 VignetteBuilder: knitr
-RoxygenNote: 7.2.0
+RoxygenNote: 7.2.1
 Config/testthat/edition: 3
 Collate:
     'T_and_F_symbol_linter.R'

--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,10 @@
 
 ## Changes to defaults
 
+* `seq_linter()` does not produce lints for `1:seq_len(length(x))` and 
+  `1:seq_along(length(x))`, since `seq_len()` and `eq_along()` can properly 
+  handle empty edge cases (, @IndrajeetPatil).
+
 * `seq_linter()` additionally lints on `1:n()` (from {dplyr}) 
   and `1:.N` (from {data.table}) (#1396, @IndrajeetPatil).
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -6,8 +6,7 @@
 
 ## Changes to defaults
 
-* `seq_linter()` does not produce lints for `1:seq_len(length(x))` and 
-  `1:seq_along(length(x))`, since `seq_len()` and `eq_along()` can properly 
+* `seq_linter()` produces lint for `seq(...)`, since it also cannot properly 
   handle empty edge cases (#1468, @IndrajeetPatil).
 
 * `seq_linter()` additionally lints on `1:n()` (from {dplyr}) 

--- a/NEWS.md
+++ b/NEWS.md
@@ -8,7 +8,7 @@
 
 * `seq_linter()` does not produce lints for `1:seq_len(length(x))` and 
   `1:seq_along(length(x))`, since `seq_len()` and `eq_along()` can properly 
-  handle empty edge cases (, @IndrajeetPatil).
+  handle empty edge cases (#1468, @IndrajeetPatil).
 
 * `seq_linter()` additionally lints on `1:n()` (from {dplyr}) 
   and `1:.N` (from {data.table}) (#1396, @IndrajeetPatil).

--- a/R/seq_linter.R
+++ b/R/seq_linter.R
@@ -63,10 +63,18 @@ seq_linter <- function() {
       "seq_along",
       "seq_len"
     )
-    lint_message <- sprintf(
-      "%s:%s is likely to be wrong in the empty edge case. Use %s() instead.",
-      dot_expr1, dot_expr2, replacement
-    )
+
+    if (any(grepl("seq", dot_expr1, fixed = TRUE))) {
+      lint_message <- sprintf(
+        "%s(%s) is likely to be wrong in the empty edge case. Use %s(%s(...)) instead.",
+        dot_expr1, dot_expr2, dot_expr1, replacement
+      )
+    } else {
+      lint_message <- sprintf(
+        "%s:%s is likely to be wrong in the empty edge case. Use %s() instead.",
+        dot_expr1, dot_expr2, replacement
+      )
+    }
 
     xml_nodes_to_lints(badx, source_expression, lint_message, type = "warning")
   })

--- a/R/seq_linter.R
+++ b/R/seq_linter.R
@@ -13,13 +13,19 @@ seq_linter <- function() {
 
   # `.N` from {data.table} is special since it's not a function but a symbol
   xpath <- glue::glue("//expr[
-    expr[NUM_CONST[text() =  '1' or text() =  '1L']]
-    and OP-COLON
-    and (
-          expr[expr[(expr|self::*)[SYMBOL_FUNCTION_CALL[ {xp_text_in_table(bad_funcs)} ]]]]
-          or
-          expr[SYMBOL = '.N']
-        )
+    (
+      expr[SYMBOL_FUNCTION_CALL[text() = 'seq']] and
+      expr[expr[(expr|self::*)[SYMBOL_FUNCTION_CALL[ {xp_text_in_table(bad_funcs)} ]]]]
+    )
+    or (
+      expr[NUM_CONST[text() =  '1' or text() =  '1L']]
+      and OP-COLON
+      and (
+            expr[expr[(expr|self::*)[SYMBOL_FUNCTION_CALL[ {xp_text_in_table(bad_funcs)} ]]]]
+            or
+            expr[SYMBOL = '.N']
+          )
+    )
   ]")
 
   ## The actual order of the nodes is document order

--- a/R/seq_linter.R
+++ b/R/seq_linter.R
@@ -14,21 +14,19 @@
 #' @export
 seq_linter <- function() {
   bad_funcs <- c("length", "n", "nrow", "ncol", "NROW", "NCOL", "dim")
+  bad_func_xpath <- glue::glue(
+    "expr[expr[(expr|self::*)[SYMBOL_FUNCTION_CALL[ {xp_text_in_table(bad_funcs)} ]]]]"
+  )
 
   # `.N` from {data.table} is special since it's not a function but a symbol
   xpath <- glue::glue("//expr[
     (
-      expr[SYMBOL_FUNCTION_CALL[text() = 'seq']] and
-      expr[expr[(expr|self::*)[SYMBOL_FUNCTION_CALL[ {xp_text_in_table(bad_funcs)} ]]]]
-    )
-    or (
+      expr[SYMBOL_FUNCTION_CALL[text() = 'seq']]
+      and {bad_func_xpath}
+    ) or (
       expr[NUM_CONST[text() =  '1' or text() =  '1L']]
       and OP-COLON
-      and (
-            expr[expr[(expr|self::*)[SYMBOL_FUNCTION_CALL[ {xp_text_in_table(bad_funcs)} ]]]]
-            or
-            expr[SYMBOL = '.N']
-          )
+      and ( {bad_func_xpath} or expr[SYMBOL = '.N'] )
     )
   ]")
 

--- a/R/seq_linter.R
+++ b/R/seq_linter.R
@@ -17,7 +17,9 @@ seq_linter <- function() {
 
   # Exact `xpath` depends on whether bad function was used in conjunction with `seq()`
   bad_func_xpath_with_seq <- glue::glue(
-    "expr[1][SYMBOL_FUNCTION_CALL[text() = 'seq']]/following::expr[1]/expr[SYMBOL_FUNCTION_CALL[ {xp_text_in_table(bad_funcs)} ]]"
+    "expr[1][SYMBOL_FUNCTION_CALL[text() = 'seq']]
+    /following::expr[1]
+    /expr[SYMBOL_FUNCTION_CALL[ {xp_text_in_table(bad_funcs)} ]]"
   )
   bad_func_xpath_without_seq <- glue::glue(
     "expr[expr[(expr|self::*)[SYMBOL_FUNCTION_CALL[ {xp_text_in_table(bad_funcs)} ]]]]"

--- a/R/seq_linter.R
+++ b/R/seq_linter.R
@@ -1,7 +1,12 @@
 #' Sequence linter
 #'
-#' Check for `1:length(...)`, `1:nrow(...)`, `1:ncol(...)`, `1:NROW(...)` and `1:NCOL(...)` expressions in base-R.
-#' Additionally check `1:n()` (from dplyr) and `1:.N` (from data.table).
+#' This linter checks for `1:length(...)`, `1:nrow(...)`, `1:ncol(...)`,
+#' `1:NROW(...)` and `1:NCOL(...)` expressions in base-R, or their alternative
+#' usage in conjunction with `seq()` (e.g., `seq(length(...))`,
+#' `seq(nrow(...))`, etc.).
+#'
+#' Additionally, checks for `1:n()` (from dplyr) and `1:.N` (from data.table).
+#'
 #' These often cause bugs when the right-hand side is zero.
 #' It is safer to use [base::seq_len()] or [base::seq_along()] instead.
 #'

--- a/R/seq_linter.R
+++ b/R/seq_linter.R
@@ -1,11 +1,10 @@
 #' Sequence linter
 #'
 #' This linter checks for `1:length(...)`, `1:nrow(...)`, `1:ncol(...)`,
-#' `1:NROW(...)` and `1:NCOL(...)` expressions in base-R, or their alternative
-#' usage in conjunction with `seq()` (e.g., `seq(length(...))`,
-#' `seq(nrow(...))`, etc.).
+#' `1:NROW(...)` and `1:NCOL(...)` expressions in base-R, or their usage in
+#' conjunction with `seq()` (e.g., `seq(length(...))`, `seq(nrow(...))`, etc.).
 #'
-#' Additionally, checks for `1:n()` (from dplyr) and `1:.N` (from data.table).
+#' Additionally, it checks for `1:n()` (from dplyr) and `1:.N` (from data.table).
 #'
 #' These often cause bugs when the right-hand side is zero.
 #' It is safer to use [base::seq_len()] or [base::seq_along()] instead.

--- a/R/seq_linter.R
+++ b/R/seq_linter.R
@@ -66,17 +66,17 @@ seq_linter <- function() {
       "seq_len"
     )
 
-    if (any(grepl("seq", dot_expr1, fixed = TRUE))) {
-      lint_message <- sprintf(
+    lint_message <- ifelse(
+      grepl("seq", dot_expr1, fixed = TRUE),
+       sprintf(
         "%s(%s) is likely to be wrong in the empty edge case. Use %s(...) instead.",
         dot_expr1, dot_expr2, replacement
-      )
-    } else {
-      lint_message <- sprintf(
+      ),
+      sprintf(
         "%s:%s is likely to be wrong in the empty edge case. Use %s() instead.",
         dot_expr1, dot_expr2, replacement
       )
-    }
+    )
 
     xml_nodes_to_lints(badx, source_expression, lint_message, type = "warning")
   })

--- a/R/seq_linter.R
+++ b/R/seq_linter.R
@@ -10,21 +10,16 @@
 #' @export
 seq_linter <- function() {
   bad_funcs <- c("length", "n", "nrow", "ncol", "NROW", "NCOL", "dim")
-  good_funcs <- c("seq_len", "seq_along")
 
   # `.N` from {data.table} is special since it's not a function but a symbol
   xpath <- glue::glue("//expr[
     expr[NUM_CONST[text() =  '1' or text() =  '1L']]
     and OP-COLON
     and (
-        not(expr[expr[(expr|self::*)[SYMBOL_FUNCTION_CALL[ {xp_text_in_table(good_funcs)} ]]]])
-        and
-        (
           expr[expr[(expr|self::*)[SYMBOL_FUNCTION_CALL[ {xp_text_in_table(bad_funcs)} ]]]]
           or
           expr[SYMBOL = '.N']
         )
-    )
   ]")
 
   ## The actual order of the nodes is document order

--- a/R/seq_linter.R
+++ b/R/seq_linter.R
@@ -66,8 +66,8 @@ seq_linter <- function() {
 
     if (any(grepl("seq", dot_expr1, fixed = TRUE))) {
       lint_message <- sprintf(
-        "%s(%s) is likely to be wrong in the empty edge case. Use %s(%s(...)) instead.",
-        dot_expr1, dot_expr2, dot_expr1, replacement
+        "%s(%s) is likely to be wrong in the empty edge case. Use %s(...) instead.",
+        dot_expr1, dot_expr2, replacement
       )
     } else {
       lint_message <- sprintf(

--- a/R/seq_linter.R
+++ b/R/seq_linter.R
@@ -10,16 +10,21 @@
 #' @export
 seq_linter <- function() {
   bad_funcs <- c("length", "n", "nrow", "ncol", "NROW", "NCOL", "dim")
+  good_funcs <- c("seq_len", "seq_along")
 
   # `.N` from {data.table} is special since it's not a function but a symbol
   xpath <- glue::glue("//expr[
     expr[NUM_CONST[text() =  '1' or text() =  '1L']]
     and OP-COLON
     and (
+        not(expr[expr[(expr|self::*)[SYMBOL_FUNCTION_CALL[ {xp_text_in_table(good_funcs)} ]]]])
+        and
+        (
           expr[expr[(expr|self::*)[SYMBOL_FUNCTION_CALL[ {xp_text_in_table(bad_funcs)} ]]]]
           or
           expr[SYMBOL = '.N']
         )
+    )
   ]")
 
   ## The actual order of the nodes is document order

--- a/R/seq_linter.R
+++ b/R/seq_linter.R
@@ -14,19 +14,22 @@
 #' @export
 seq_linter <- function() {
   bad_funcs <- c("length", "n", "nrow", "ncol", "NROW", "NCOL", "dim")
-  bad_func_xpath <- glue::glue(
+  bad_func_xpath_with_seq <- glue::glue(
+    "expr[1][SYMBOL_FUNCTION_CALL[text() = 'seq']]/following::expr[1]/expr[SYMBOL_FUNCTION_CALL[{xp_text_in_table(bad_funcs)}]]"
+  )
+  bad_func_xpath_without_seq <- glue::glue(
     "expr[expr[(expr|self::*)[SYMBOL_FUNCTION_CALL[ {xp_text_in_table(bad_funcs)} ]]]]"
   )
 
   # `.N` from {data.table} is special since it's not a function but a symbol
   xpath <- glue::glue("//expr[
     (
-      expr[SYMBOL_FUNCTION_CALL[text() = 'seq']]
-      and {bad_func_xpath}
+      { bad_func_xpath_with_seq }
+      and count(expr) = 2
     ) or (
-      expr[NUM_CONST[text() =  '1' or text() =  '1L']]
+      expr[NUM_CONST[text() = '1' or text() = '1L']]
       and OP-COLON
-      and ( {bad_func_xpath} or expr[SYMBOL = '.N'] )
+      and ( {bad_func_xpath_without_seq} or expr[SYMBOL = '.N'] )
     )
   ]")
 

--- a/R/seq_linter.R
+++ b/R/seq_linter.R
@@ -14,8 +14,10 @@
 #' @export
 seq_linter <- function() {
   bad_funcs <- c("length", "n", "nrow", "ncol", "NROW", "NCOL", "dim")
+
+  # Exact `xpath` depends on whether bad function was used in conjunction with `seq()`
   bad_func_xpath_with_seq <- glue::glue(
-    "expr[1][SYMBOL_FUNCTION_CALL[text() = 'seq']]/following::expr[1]/expr[SYMBOL_FUNCTION_CALL[{xp_text_in_table(bad_funcs)}]]"
+    "expr[1][SYMBOL_FUNCTION_CALL[text() = 'seq']]/following::expr[1]/expr[SYMBOL_FUNCTION_CALL[ {xp_text_in_table(bad_funcs)} ]]"
   )
   bad_func_xpath_without_seq <- glue::glue(
     "expr[expr[(expr|self::*)[SYMBOL_FUNCTION_CALL[ {xp_text_in_table(bad_funcs)} ]]]]"
@@ -24,9 +26,10 @@ seq_linter <- function() {
   # `.N` from {data.table} is special since it's not a function but a symbol
   xpath <- glue::glue("//expr[
     (
-      { bad_func_xpath_with_seq }
+      {bad_func_xpath_with_seq}
       and count(expr) = 2
-    ) or (
+    ) or
+    (
       expr[NUM_CONST[text() = '1' or text() = '1L']]
       and OP-COLON
       and ( {bad_func_xpath_without_seq} or expr[SYMBOL = '.N'] )

--- a/man/ids_with_token.Rd
+++ b/man/ids_with_token.Rd
@@ -43,7 +43,7 @@ Gets the source IDs (row indices) corresponding to given token.
 }
 \section{Functions}{
 \itemize{
-\item \code{with_id}: Return the row of the \code{parsed_content} entry of the \verb{[get_source_expressions]()} object. Typically used in
+\item \code{with_id()}: Return the row of the \code{parsed_content} entry of the \verb{[get_source_expressions]()} object. Typically used in
 conjunction with \code{ids_with_token} to iterate over rows containing desired tokens.
-}}
 
+}}

--- a/man/lint.Rd
+++ b/man/lint.Rd
@@ -21,8 +21,8 @@ lint_dir(
   ...,
   relative_path = TRUE,
   exclusions = list("renv", "packrat"),
-  pattern = rex::rex(".", one_of("Rr"), or("", "html", "md", "nw", "rst", "tex",
-    "txt"), end),
+  pattern = rex::rex(".", one_of("Rr"), or("", "html", "md", "nw", "rst", "tex", "txt"),
+    end),
   parse_settings = TRUE
 )
 

--- a/man/seq_linter.Rd
+++ b/man/seq_linter.Rd
@@ -7,8 +7,14 @@
 seq_linter()
 }
 \description{
-Check for \code{1:length(...)}, \code{1:nrow(...)}, \code{1:ncol(...)}, \code{1:NROW(...)} and \code{1:NCOL(...)} expressions in base-R.
-Additionally check \code{1:n()} (from dplyr) and \code{1:.N} (from data.table).
+This linter checks for \code{1:length(...)}, \code{1:nrow(...)}, \code{1:ncol(...)},
+\code{1:NROW(...)} and \code{1:NCOL(...)} expressions in base-R, or their alternative
+usage in conjunction with \code{seq()} (e.g., \code{seq(length(...))},
+\code{seq(nrow(...))}, etc.).
+}
+\details{
+Additionally, checks for \code{1:n()} (from dplyr) and \code{1:.N} (from data.table).
+
 These often cause bugs when the right-hand side is zero.
 It is safer to use \code{\link[base:seq]{base::seq_len()}} or \code{\link[base:seq]{base::seq_along()}} instead.
 }

--- a/man/seq_linter.Rd
+++ b/man/seq_linter.Rd
@@ -8,12 +8,11 @@ seq_linter()
 }
 \description{
 This linter checks for \code{1:length(...)}, \code{1:nrow(...)}, \code{1:ncol(...)},
-\code{1:NROW(...)} and \code{1:NCOL(...)} expressions in base-R, or their alternative
-usage in conjunction with \code{seq()} (e.g., \code{seq(length(...))},
-\code{seq(nrow(...))}, etc.).
+\code{1:NROW(...)} and \code{1:NCOL(...)} expressions in base-R, or their usage in
+conjunction with \code{seq()} (e.g., \code{seq(length(...))}, \code{seq(nrow(...))}, etc.).
 }
 \details{
-Additionally, checks for \code{1:n()} (from dplyr) and \code{1:.N} (from data.table).
+Additionally, it checks for \code{1:n()} (from dplyr) and \code{1:.N} (from data.table).
 
 These often cause bugs when the right-hand side is zero.
 It is safer to use \code{\link[base:seq]{base::seq_len()}} or \code{\link[base:seq]{base::seq_along()}} instead.

--- a/man/vector_logic_linter.Rd
+++ b/man/vector_logic_linter.Rd
@@ -25,7 +25,7 @@ vs. \code{if ((a <- foo(x)) || (b <- bar(y))) { ... }}. Because \code{||} exits
 early, if \code{a} is \code{TRUE},  the second condition will never be evaluated
 and \code{b} will not be assigned. Such usage is not allowed by the Tidyverse
 style guide, and the code can easily be refactored by pulling the
-assignment outside of the condition, so using \code{||} is still preferable.
+assignment outside the condition, so using \code{||} is still preferable.
 }
 \seealso{
 \link{linters} for a complete list of linters available in lintr. \cr

--- a/tests/testthat/test-seq_linter.R
+++ b/tests/testthat/test-seq_linter.R
@@ -13,8 +13,6 @@ test_that("seq_len(...) or seq_along(...) expressions are fine", {
 
   expect_lint("function(x) { seq(2, length(x)) }", NULL, linter)
   expect_lint("function(x) { seq(length(x), 2) }", NULL, linter)
-
-  expect_lint("function(x) { seq(dim(x)[1]) }", NULL, linter)
 })
 
 test_that("finds seq(...) expressions", {
@@ -31,6 +29,13 @@ test_that("finds seq(...) expressions", {
     rex("seq(nrow(...))", anything, "Use seq_len(...)"),
     linter
   )
+
+  # FIXME: This test should pass
+  # expect_lint(
+  #   "function(x) { seq(dim(x)[1]) }",
+  #   rex("seq(dim(...))", anything, "Use seq_len(...)"),
+  #   linter
+  # )
 })
 
 test_that("finds 1:length(...) expressions", {

--- a/tests/testthat/test-seq_linter.R
+++ b/tests/testthat/test-seq_linter.R
@@ -16,13 +16,13 @@ test_that("finds seq(...) expressions", {
 
   expect_lint(
     "function(x) { seq(length(x)) }",
-    rex("seq(length(...))", anything, "Use seq(seq_along(...))"),
+    rex("seq(length(...))", anything, "Use seq_along(...)"),
     linter
   )
 
   expect_lint(
     "function(x) { seq(nrow(x)) }",
-    rex("seq(nrow(...))", anything, "Use seq(seq_len(...))"),
+    rex("seq(nrow(...))", anything, "Use seq_len(...)"),
     linter
   )
 })
@@ -108,6 +108,15 @@ test_that("Message vectorization works for multiple lints", {
     list(
       rex::rex("1:length(...)", anything, "seq_along()"),
       rex::rex("1:nrow(...)", anything, "seq_len()")
+    ),
+    seq_linter()
+  )
+
+  expect_lint(
+    "c(seq(length(x)), seq(nrow(y)))",
+    list(
+      rex::rex("seq(length(...))", anything, "seq_along(...)"),
+      rex::rex("seq(nrow(...))", anything, "seq_len(...)")
     ),
     seq_linter()
   )

--- a/tests/testthat/test-seq_linter.R
+++ b/tests/testthat/test-seq_linter.R
@@ -7,6 +7,10 @@ test_that("other : expressions are fine", {
 
 test_that("1:seq_len(...) or 1:seq_along(...) expressions are fine", {
   linter <- seq_linter()
+
+  expect_lint("1:seq_len(x)", NULL, linter)
+  expect_lint("1:seq_along(x)", NULL, linter)
+
   expect_lint("1:seq_len(length(x))", NULL, linter)
   expect_lint("1:seq_along(length(x))", NULL, linter)
 })

--- a/tests/testthat/test-seq_linter.R
+++ b/tests/testthat/test-seq_linter.R
@@ -5,12 +5,24 @@ test_that("other : expressions are fine", {
   expect_lint("function(x) { 1:(length(x) || 1) }", NULL, linter)
 })
 
+test_that("1:seq_len(...) or 1:seq_along(...) expressions are fine", {
+  linter <- seq_linter()
+  expect_lint("1:seq_len(length(x))", NULL, linter)
+  expect_lint("1:seq_along(length(x))", NULL, linter)
+})
+
 test_that("finds 1:length(...) expressions", {
   linter <- seq_linter()
 
   expect_lint(
     "function(x) { 1:length(x) }",
     rex("length(...)", anything, "Use seq_along"),
+    linter
+  )
+
+  expect_lint(
+    "function(x) { 1:seq(length(x)) }",
+    rex("seq(...)", anything, "Use seq_len"),
     linter
   )
 

--- a/tests/testthat/test-seq_linter.R
+++ b/tests/testthat/test-seq_linter.R
@@ -15,8 +15,8 @@ test_that("finds seq(...) expressions", {
   linter <- seq_linter()
 
   expect_lint(
-    "function(x) { seq(x) }",
-    rex("seq(...)", anything, "Use seq_len"),
+    "function(x) { seq(length(x)) }",
+    rex("seq:length(...)", anything, "Use seq_along"),
     linter
   )
 })
@@ -27,12 +27,6 @@ test_that("finds 1:length(...) expressions", {
   expect_lint(
     "function(x) { 1:length(x) }",
     rex("length(...)", anything, "Use seq_along"),
-    linter
-  )
-
-  expect_lint(
-    "function(x) { 1:seq(length(x)) }",
-    rex("seq(...)", anything, "Use seq_len"),
     linter
   )
 

--- a/tests/testthat/test-seq_linter.R
+++ b/tests/testthat/test-seq_linter.R
@@ -13,6 +13,8 @@ test_that("seq_len(...) or seq_along(...) expressions are fine", {
 
   expect_lint("function(x) { seq(2, length(x)) }", NULL, linter)
   expect_lint("function(x) { seq(length(x), 2) }", NULL, linter)
+
+  expect_lint("function(x) { seq(dim(x)[1]) }", NULL, linter)
 })
 
 test_that("finds seq(...) expressions", {

--- a/tests/testthat/test-seq_linter.R
+++ b/tests/testthat/test-seq_linter.R
@@ -16,13 +16,13 @@ test_that("finds seq(...) expressions", {
 
   expect_lint(
     "function(x) { seq(length(x)) }",
-    rex("seq:length(...)", anything, "Use seq_along"),
+    rex("seq(length(...))", anything, "Use seq(seq_along(...))"),
     linter
   )
 
   expect_lint(
     "function(x) { seq(nrow(x)) }",
-    rex("seq:nrow(...)", anything, "Use seq_len"),
+    rex("seq(nrow(...))", anything, "Use seq(seq_len(...))"),
     linter
   )
 })

--- a/tests/testthat/test-seq_linter.R
+++ b/tests/testthat/test-seq_linter.R
@@ -19,6 +19,12 @@ test_that("finds seq(...) expressions", {
     rex("seq:length(...)", anything, "Use seq_along"),
     linter
   )
+
+  expect_lint(
+    "function(x) { seq(nrow(x)) }",
+    rex("seq:nrow(...)", anything, "Use seq_len"),
+    linter
+  )
 })
 
 test_that("finds 1:length(...) expressions", {

--- a/tests/testthat/test-seq_linter.R
+++ b/tests/testthat/test-seq_linter.R
@@ -113,6 +113,15 @@ test_that("Message vectorization works for multiple lints", {
   )
 
   expect_lint(
+    "c(seq(length(x)), 1:nrow(y))",
+    list(
+      rex::rex("seq(length(...))", anything, "seq_along(...)"),
+      rex::rex("1:nrow(...)", anything, "seq_len()")
+    ),
+    seq_linter()
+  )
+
+  expect_lint(
     "c(seq(length(x)), seq(nrow(y)))",
     list(
       rex::rex("seq(length(...))", anything, "seq_along(...)"),

--- a/tests/testthat/test-seq_linter.R
+++ b/tests/testthat/test-seq_linter.R
@@ -5,14 +5,20 @@ test_that("other : expressions are fine", {
   expect_lint("function(x) { 1:(length(x) || 1) }", NULL, linter)
 })
 
-test_that("1:seq_len(...) or 1:seq_along(...) expressions are fine", {
+test_that("seq_len(...) or seq_along(...) expressions are fine", {
+  linter <- seq_linter()
+  expect_lint("function(x) { seq_len(x) }", NULL, linter)
+  expect_lint("function(x) { seq_along(x) }", NULL, linter)
+})
+
+test_that("finds seq(...) expressions", {
   linter <- seq_linter()
 
-  expect_lint("1:seq_len(x)", NULL, linter)
-  expect_lint("1:seq_along(x)", NULL, linter)
-
-  expect_lint("1:seq_len(length(x))", NULL, linter)
-  expect_lint("1:seq_along(length(x))", NULL, linter)
+  expect_lint(
+    "function(x) { seq(x) }",
+    rex("seq(...)", anything, "Use seq_len"),
+    linter
+  )
 })
 
 test_that("finds 1:length(...) expressions", {

--- a/tests/testthat/test-seq_linter.R
+++ b/tests/testthat/test-seq_linter.R
@@ -29,13 +29,6 @@ test_that("finds seq(...) expressions", {
     rex("seq(nrow(...))", anything, "Use seq_len(...)"),
     linter
   )
-
-  # FIXME: This test should pass
-  # expect_lint(
-  #   "function(x) { seq(dim(x)[1]) }",
-  #   rex("seq(dim(...))", anything, "Use seq_len(...)"),
-  #   linter
-  # )
 })
 
 test_that("finds 1:length(...) expressions", {

--- a/tests/testthat/test-seq_linter.R
+++ b/tests/testthat/test-seq_linter.R
@@ -7,8 +7,12 @@ test_that("other : expressions are fine", {
 
 test_that("seq_len(...) or seq_along(...) expressions are fine", {
   linter <- seq_linter()
+
   expect_lint("function(x) { seq_len(x) }", NULL, linter)
   expect_lint("function(x) { seq_along(x) }", NULL, linter)
+
+  expect_lint("function(x) { seq(2, length(x)) }", NULL, linter)
+  expect_lint("function(x) { seq(length(x), 2) }", NULL, linter)
 })
 
 test_that("finds seq(...) expressions", {


### PR DESCRIPTION
Closes #1467

TODO

- [x] Get rid of false negative
- [x] Tests should pass
- [x] Correct lint message should be produced
- [x] Update documentation (needs bumping roxygen2 version)
- [x] Address code review comments

# Example

``` r
library(lintr)

lint(
  text = "seq(length(mtcars))",
  linters = seq_linter()
)
#> <text>:1:1: warning: [seq_linter] seq(length(...)) is likely to be wrong in the empty edge case. Use seq_along(...) instead.
#> seq(length(mtcars))
#> ^~~~~~~~~~~~~~~~~~~

lint(
  text = "seq(nrow(mtcars))",
  linters = seq_linter()
)
#> <text>:1:1: warning: [seq_linter] seq(nrow(...)) is likely to be wrong in the empty edge case. Use seq_len(...) instead.
#> seq(nrow(mtcars))
#> ^~~~~~~~~~~~~~~~~
```

<sup>Created on 2022-07-24 by the [reprex package](https://reprex.tidyverse.org) (v2.0.1)</sup>