### PR TITLE
Edits to docs for linters

### DIFF
--- a/R/aaa.R
+++ b/R/aaa.R
@@ -12,7 +12,7 @@ NULL
 #' Available linters
 #' @name linters
 #'
-#' @description A variety of linters is available in \pkg{lintr}. The most popular ones are readily
+#' @description A variety of linters are available in \pkg{lintr}. The most popular ones are readily
 #' accessible through [default_linters()].
 #'
 #' Within a [lint()] function call, the linters in use are initialized with the provided

--- a/R/any_duplicated_linter.R
+++ b/R/any_duplicated_linter.R
@@ -1,7 +1,7 @@
 #' Require usage of `anyDuplicated(x) > 0` over `any(duplicated(x))`
 #'
 #' [anyDuplicated()] exists as a replacement for `any(duplicated(.))`, which is
-#'   more efficient for simple objects, and is equally efficient in the worst case scenario.
+#'   more efficient for simple objects, and is at worst equally efficient.
 #'   Therefore, it should be used in all situations instead of the latter.
 #'
 #' Also match usage like `length(unique(x$col)) == nrow(x)`, which can

--- a/R/any_duplicated_linter.R
+++ b/R/any_duplicated_linter.R
@@ -1,4 +1,4 @@
-#' Require usage of anyDuplicated() > 0 over any(duplicated(.))
+#' Require usage of `anyDuplicated(x) > 0` over `any(duplicated(x))`
 #'
 #' [anyDuplicated()] exists as a replacement for `any(duplicated(.))`, which is
 #'   more efficient for simple objects, and is equally efficient in the worst case scenario.

--- a/R/any_duplicated_linter.R
+++ b/R/any_duplicated_linter.R
@@ -1,9 +1,8 @@
 #' Require usage of anyDuplicated() > 0 over any(duplicated(.))
 #'
-#' [anyDuplicated()] exists as a replacement for `any(duplicated(.))` which is
-#'   more efficient for simple objects, and in the worst case is the same
-#'   efficiency. Therefore it should be used in all situations instead of the
-#'   latter.
+#' [anyDuplicated()] exists as a replacement for `any(duplicated(.))`, which is
+#'   more efficient for simple objects, and is equally efficient in the worst case scenario.
+#'   Therefore, it should be used in all situations instead of the latter.
 #'
 #' Also match usage like `length(unique(x$col)) == nrow(x)`, which can
 #'   be replaced by `anyDuplicated(x$col) == 0L`.

--- a/R/any_is_na_linter.R
+++ b/R/any_is_na_linter.R
@@ -1,7 +1,7 @@
 #' Require usage of `anyNA(x)` over `any(is.na(x))`
 #'
 #' [anyNA()] exists as a replacement for `any(is.na(x))` which is more efficient
-#'   for simple objects, and has the same efficiency in the worst case scenario.
+#'   for simple objects, and is at worst equally efficient.
 #'   Therefore, it should be used in all situations instead of the latter.
 #'
 #' @evalRd rd_tags("any_is_na_linter")

--- a/R/any_is_na_linter.R
+++ b/R/any_is_na_linter.R
@@ -1,4 +1,4 @@
-#' Require usage of anyNA over any(is.na(.))
+#' Require usage of `anyNA()` over `any(is.na(.))`
 #'
 #' [anyNA()] exists as a replacement for `any(is.na(.))` which is more efficient
 #'   for simple objects, and has the same efficiency in the worst case scenario.

--- a/R/any_is_na_linter.R
+++ b/R/any_is_na_linter.R
@@ -1,6 +1,6 @@
-#' Require usage of `anyNA()` over `any(is.na(.))`
+#' Require usage of `anyNA(x)` over `any(is.na(x))`
 #'
-#' [anyNA()] exists as a replacement for `any(is.na(.))` which is more efficient
+#' [anyNA(x)] exists as a replacement for `any(is.na(x))` which is more efficient
 #'   for simple objects, and has the same efficiency in the worst case scenario.
 #'   Therefore, it should be used in all situations instead of the latter.
 #'

--- a/R/any_is_na_linter.R
+++ b/R/any_is_na_linter.R
@@ -1,8 +1,8 @@
 #' Require usage of anyNA over any(is.na(.))
 #'
 #' [anyNA()] exists as a replacement for `any(is.na(.))` which is more efficient
-#'   for simple objects, and in the worst case is the same efficiency. Therefore
-#'   it should be used in all situations instead of the latter.
+#'   for simple objects, and has the same efficiency in the worst case scenario.
+#'   Therefore, it should be used in all situations instead of the latter.
 #'
 #' @evalRd rd_tags("any_is_na_linter")
 #' @seealso [linters] for a complete list of linters available in lintr.

--- a/R/any_is_na_linter.R
+++ b/R/any_is_na_linter.R
@@ -1,6 +1,6 @@
 #' Require usage of `anyNA(x)` over `any(is.na(x))`
 #'
-#' [anyNA(x)] exists as a replacement for `any(is.na(x))` which is more efficient
+#' [anyNA()] exists as a replacement for `any(is.na(x))` which is more efficient
 #'   for simple objects, and has the same efficiency in the worst case scenario.
 #'   Therefore, it should be used in all situations instead of the latter.
 #'

--- a/R/class_equals_linter.R
+++ b/R/class_equals_linter.R
@@ -1,4 +1,4 @@
-#' Block comparison of class with ==
+#' Block comparison of class with `==`
 #'
 #' Usage like `class(x) == "character"` is prone to error since class in R
 #'   is in general a vector. The correct version for S3 classes is [inherits()]:

--- a/R/closed_curly_linter.R
+++ b/R/closed_curly_linter.R
@@ -1,6 +1,7 @@
 #' Closed curly linter
 #'
-#' Check that closed curly braces are on their own line unless they follow an else, comma, or closing bracket.
+#' Check that closed curly braces are on their own line unless they follow
+#' an else, a comma, or a closing bracket.
 #'
 #' @param allow_single_line if `TRUE`, allow an open and closed curly pair on the same line.
 #' @evalRd rd_tags("closed_curly_linter")

--- a/R/commas_linter.R
+++ b/R/commas_linter.R
@@ -1,7 +1,6 @@
 #' Commas linter
 #'
-#' Check that all commas are followed by spaces (e.g. `c(a = 4, b = 5)`),
-#' but do not have spaces before them (e.g. `c(a = 4 , b = 5)`).
+#' Check that all commas are followed by spaces, but do not have spaces before them.
 #'
 #' @evalRd rd_tags("commas_linter")
 #' @seealso

--- a/R/commas_linter.R
+++ b/R/commas_linter.R
@@ -1,6 +1,7 @@
 #' Commas linter
 #'
-#' Check that all commas are followed by spaces, but do not have spaces before them.
+#' Check that all commas are followed by spaces (e.g. `c(a = 4, b = 5)`),
+#' but do not have spaces before them (e.g. `c(a = 4 , b = 5)`).
 #'
 #' @evalRd rd_tags("commas_linter")
 #' @seealso

--- a/R/condition_message_linter.R
+++ b/R/condition_message_linter.R
@@ -1,4 +1,4 @@
-#' Block usage of paste() and paste0() with messaging functions using ...
+#' Block usage of `paste()` and `paste0()` with messaging functions using `...`
 #'
 #' `stop(paste0(...))` is strictly redundant -- `stop(...)` is equivalent.
 #'   `stop(...)` is also preferable to `stop(paste(...))`. The same applies to

--- a/R/conjunct_test_linter.R
+++ b/R/conjunct_test_linter.R
@@ -1,4 +1,4 @@
-#' Force `&&` conditions in `expect_true()`, `expect_false()` to be written separately
+#' Force `&&` conditions in `expect_true()` and `expect_false()` to be written separately
 #'
 #' For readability of test outputs, testing only one thing per call to
 #'   [testthat::expect_true()] is preferable, i.e.,

--- a/R/conjunct_test_linter.R
+++ b/R/conjunct_test_linter.R
@@ -1,4 +1,4 @@
-#' Force && conditions in expect_true(), expect_false() to be written separately
+#' Force `&&` conditions in `expect_true()`, `expect_false()` to be written separately
 #'
 #' For readability of test outputs, testing only one thing per call to
 #'   [testthat::expect_true()] is preferable, i.e.,

--- a/R/cyclocomp_linter.R
+++ b/R/cyclocomp_linter.R
@@ -2,9 +2,8 @@
 #'
 #' Check for overly complicated expressions. See [cyclocomp::cyclocomp()].
 #'
-#' @param complexity_limit expressions with a cyclomatic complexity higher than
-#' this limit are linted, defaults to 15.
-#' See [cyclocomp::cyclocomp()].
+#' @param complexity_limit Maximum cyclomatic complexity, default 15. Expressions more complex
+#' than this are linted. See [cyclocomp::cyclocomp()].
 #' @evalRd rd_tags("cyclocomp_linter")
 #' @seealso [linters] for a complete list of linters available in lintr.
 #' @importFrom cyclocomp cyclocomp

--- a/R/cyclocomp_linter.R
+++ b/R/cyclocomp_linter.R
@@ -2,7 +2,8 @@
 #'
 #' Check for overly complicated expressions. See [cyclocomp::cyclocomp()].
 #'
-#' @param complexity_limit expressions with a cyclomatic complexity higher than this are linted, defaults to 15.
+#' @param complexity_limit expressions with a cyclomatic complexity higher than
+#' this limit are linted, defaults to 15.
 #' See [cyclocomp::cyclocomp()].
 #' @evalRd rd_tags("cyclocomp_linter")
 #' @seealso [linters] for a complete list of linters available in lintr.

--- a/R/duplicate_argument_linter.R
+++ b/R/duplicate_argument_linter.R
@@ -1,9 +1,6 @@
 #' Duplicate argument linter
 #'
-#' Check for duplicate arguments in function calls. Some of these cases will be
-#' blocked by R's syntax itself (e.g. `mean(x = 1:5, x = 2:3)`), but even when
-#' such usage *is* allowed, it is rarely desirable and should be used sparingly
-#' (e.g. `data.frame(x = 1, x = 2)`).
+#' Check for duplicate arguments in function calls.
 #'
 #' @param except a character vector of function names as exceptions.
 #' @evalRd rd_tags("duplicate_argument_linter")

--- a/R/duplicate_argument_linter.R
+++ b/R/duplicate_argument_linter.R
@@ -1,6 +1,9 @@
 #' Duplicate argument linter
 #'
-#' Check for duplicate arguments in function calls.
+#' Check for duplicate arguments in function calls. Some of these cases will be
+#' blocked by R's syntax itself (e.g. `mean(x = 1:5, x = 2:3)`), but even when
+#' such usage *is* allowed, it is rarely desirable and should be used sparingly
+#' (e.g. `data.frame(x = 1, x = 2)`).
 #'
 #' @param except a character vector of function names as exceptions.
 #' @evalRd rd_tags("duplicate_argument_linter")

--- a/R/duplicate_argument_linter.R
+++ b/R/duplicate_argument_linter.R
@@ -1,6 +1,10 @@
 #' Duplicate argument linter
 #'
-#' Check for duplicate arguments in function calls.
+#' Check for duplicate arguments in function calls. Some cases are run-time errors
+#' (e.g. `mean(x = 1:5, x = 2:3)`), otherwise this linter is used to discourage
+#'  explicitly providing duplicate names to objects (e.g. `c(a = 1, a = 2)`).
+#'  Duplicate-named objects are hard to work with programmatically and
+#'  should typically be avoided.
 #'
 #' @param except a character vector of function names as exceptions.
 #' @evalRd rd_tags("duplicate_argument_linter")

--- a/R/equals_na_linter.R
+++ b/R/equals_na_linter.R
@@ -1,6 +1,7 @@
 #' Equality check with NA linter
 #'
-#' Check for `x == NA` and `x != NA`
+#' Check for `x == NA` and `x != NA`. One should instead use `is.na()` function
+#' for such comparisons.
 #'
 #' @evalRd rd_tags("equals_na_linter")
 #' @seealso [linters] for a complete list of linters available in lintr.

--- a/R/equals_na_linter.R
+++ b/R/equals_na_linter.R
@@ -1,8 +1,7 @@
 #' Equality check with NA linter
 #'
-#' Check for `x == NA` and `x != NA`. One should instead use `is.na()` function
-#' for such comparisons.
-#'
+#' Check for `x == NA` and `x != NA`. Such usage is almost surely incorrect --
+#' checks for missing values should be done with [is.na()].
 #' @evalRd rd_tags("equals_na_linter")
 #' @seealso [linters] for a complete list of linters available in lintr.
 #' @export

--- a/R/expect_comparison_linter.R
+++ b/R/expect_comparison_linter.R
@@ -1,4 +1,4 @@
-#' Require usage of expect_gt(x, y) over expect_true(x > y) (and similar)
+#' Require usage of `expect_gt(x, y)` over `expect_true(x > y)` (and similar)
 #'
 #' [testthat::expect_gt()], [testthat::expect_gte()], [testthat::expect_lt()],
 #'   [testthat::expect_lte()], and [testthat::expect_equal()] exist specifically

--- a/R/expect_identical_linter.R
+++ b/R/expect_identical_linter.R
@@ -1,7 +1,7 @@
 #' Require usage of `expect_identical(x, y)` where appropriate
 #'
-#' [testthat::expect_identical()] should be the default/go-to function for
-#'   comparing an output to an expected value. `expect_true(identical(x, y))`
+#' This linter enforces the usage of [testthat::expect_identical()] as the
+#'   default expectation for comparisons in a testthat suite. `expect_true(identical(x, y))`
 #'   is an equivalent but unadvised method of the same test. Further,
 #'   [testthat::expect_equal()] should only be used when `expect_identical()`
 #'   is inappropriate, i.e., when `x` and `y` need only be *numerically

--- a/R/expect_identical_linter.R
+++ b/R/expect_identical_linter.R
@@ -1,6 +1,6 @@
-#' Require usage of expect_identical(x, y) where appropriate
+#' Require usage of `expect_identical(x, y)` where appropriate
 #'
-#' At Google, [testthat::expect_identical()] should be the default/go-to function for
+#' [testthat::expect_identical()] should be the default/go-to function for
 #'   comparing an output to an expected value. `expect_true(identical(x, y))`
 #'   is an equivalent but unadvised method of the same test. Further,
 #'   [testthat::expect_equal()] should only be used when `expect_identical()`
@@ -17,7 +17,7 @@
 #'   1. A named argument is set (e.g. `ignore_attr` or `tolerance`)
 #'   2. Comparison is made to an explicit decimal, e.g.
 #'      `expect_equal(x, 1.0)` (implicitly setting `tolerance`)
-#'   3. `...` is passed (wrapper functions whcih might set
+#'   3. `...` is passed (wrapper functions which might set
 #'      arguments such as `ignore_attr` or `tolerance`)
 #'
 #' @evalRd rd_tags("expect_identical_linter")

--- a/R/expect_length_linter.R
+++ b/R/expect_length_linter.R
@@ -1,4 +1,4 @@
-#' Require usage of expect_length(x, n) over expect_equal(length(x), n)
+#' Require usage of `expect_length(x, n)` over `expect_equal(length(x), n)`
 #'
 #' [testthat::expect_length()] exists specifically for testing the [length()] of
 #'   an object. [testthat::expect_equal()] can also be used for such tests,

--- a/R/expect_named_linter.R
+++ b/R/expect_named_linter.R
@@ -1,4 +1,4 @@
-#' Require usage of expect_named(x, n) over expect_equal(names(x), n)
+#' Require usage of `expect_named(x, n)` over `expect_equal(names(x), n)`
 #'
 #' [testthat::expect_named()] exists specifically for testing the [names()] of
 #'   an object. [testthat::expect_equal()] can also be used for such tests,

--- a/R/expect_not_linter.R
+++ b/R/expect_not_linter.R
@@ -1,4 +1,4 @@
-#' Require usage of expect_false(.) over expect_true(!.)
+#' Require usage of `expect_false(x)` over `expect_true(!x)`
 #'
 #' [testthat::expect_false()] exists specifically for testing that an output is
 #'   `FALSE`. [testthat::expect_true()] can also be used for such tests by

--- a/R/expect_null_linter.R
+++ b/R/expect_null_linter.R
@@ -1,4 +1,4 @@
-#' expect_null Linter
+#' Require usage of `expect_null` for checking `NULL`
 #'
 #' Require usage of `expect_null(x)` over `expect_equal(x, NULL)` and similar
 #' usages.

--- a/R/expect_s3_class_linter.R
+++ b/R/expect_s3_class_linter.R
@@ -1,4 +1,4 @@
-#' Require usage of expect_s3_class()
+#' Require usage of `expect_s3_class()`
 #'
 #' [testthat::expect_s3_class()] exists specifically for testing the class
 #'   of S3 objects. [testthat::expect_equal()], [testthat::expect_identical()],
@@ -69,7 +69,7 @@ is_s3_class_calls <- paste0("is.", c(
   "mts", "stepfun", "ts", "tskernel"
 ))
 
-#' Require usage of expect_s4_class(x, k) over expect_true(is(x, k))
+#' Require usage of `expect_s4_class(x, k)` over `expect_true(is(x, k))`
 #'
 #' [testthat::expect_s4_class()] exists specifically for testing the class
 #'   of S4 objects. [testthat::expect_true()] can also be used for such tests,

--- a/R/expect_true_false_linter.R
+++ b/R/expect_true_false_linter.R
@@ -1,4 +1,4 @@
-#' Require usage of expect_true(x) over expect_equal(x, TRUE)
+#' Require usage of `expect_true(x)` over `expect_equal(x, TRUE)`
 #'
 #' [testthat::expect_true()] and [testthat::expect_false()] exist specifically
 #'   for testing the `TRUE`/`FALSE` value of an object.

--- a/R/expect_type_linter.R
+++ b/R/expect_type_linter.R
@@ -1,4 +1,4 @@
-#' Require usage of expect_type(x, type) over expect_equal(typeof(x), type)
+#' Require usage of `expect_type(x, type)` over `expect_equal(typeof(x), type)`
 #'
 #' [testthat::expect_type()] exists specifically for testing the storage type
 #'   of objects. [testthat::expect_equal()], [testthat::expect_identical()], and

--- a/R/extraction_operator_linter.R
+++ b/R/extraction_operator_linter.R
@@ -1,7 +1,7 @@
 #' Extraction operator linter
 #'
-#' Check that the `[[` operator is used when extracting a single element from an object, not `[` (subsetting) nor `$`
-#' (interactive use).
+#' Check that the `[[` operator is used when extracting a single element from an object,
+#' and not `[` (subsetting) or `$` (interactive use).
 #'
 #' @evalRd rd_tags("extraction_operator_linter")
 #' @seealso [linters] for a complete list of linters available in lintr.

--- a/R/extraction_operator_linter.R
+++ b/R/extraction_operator_linter.R
@@ -1,7 +1,7 @@
 #' Extraction operator linter
 #'
-#' Check that the `[[` operator is used when extracting a single element from an object,
-#' and not `[` (subsetting) or `$` (interactive use).
+#' Check that the `[[` operator is used when extracting a single element from an object, not `[` (subsetting) nor `$`
+#' (interactive use).
 #'
 #' @evalRd rd_tags("extraction_operator_linter")
 #' @seealso [linters] for a complete list of linters available in lintr.

--- a/R/fixed_regex_linter.R
+++ b/R/fixed_regex_linter.R
@@ -3,7 +3,7 @@
 #' Invoking a regular expression engine is overkill for cases when the search
 #'   pattern only involves static patterns.
 #'
-#' NB: for `stringr` functions, that means wrapping the pattern in `stringr::fixed()`.
+#' NB: For `stringr` functions, that means wrapping the pattern in `stringr::fixed()`.
 #'
 #' NB: This linter is likely not able to distinguish every possible case when
 #'   a fixed regular expression is preferable, rather it seeks to identify

--- a/R/fixed_regex_linter.R
+++ b/R/fixed_regex_linter.R
@@ -3,9 +3,9 @@
 #' Invoking a regular expression engine is overkill for cases when the search
 #'   pattern only involves static patterns.
 #'
-#' NB: For `stringr` functions, that means wrapping the pattern in `stringr::fixed()`.
+#' NB: for `stringr` functions, that means wrapping the pattern in `stringr::fixed()`.
 #'
-#' NB: This linter is likely not able to distinguish every possible case when
+#' NB: this linter is likely not able to distinguish every possible case when
 #'   a fixed regular expression is preferable, rather it seeks to identify
 #'   likely cases. It should _never_ report false positives, however; please
 #'   report false positives as an error.

--- a/R/function_left_parentheses_linter.R
+++ b/R/function_left_parentheses_linter.R
@@ -1,6 +1,8 @@
 #' Function left parentheses linter
 #'
-#' Check that all left parentheses in a function call do not have spaces before them.
+#' Check that all left parentheses in a function call do not have spaces before them
+#' (e.g. `mean  (1:3)`). Although this is syntactically valid, it makes the code
+#' difficult to read.
 #'
 #' @evalRd rd_tags("function_left_parentheses_linter")
 #' @seealso

--- a/R/ifelse_censor_linter.R
+++ b/R/ifelse_censor_linter.R
@@ -1,4 +1,4 @@
-#' Block usage of ifelse where pmin or pmax is more appropriate
+#' Block usage of `ifelse()` where `pmin()` or `pmax()` is more appropriate
 #'
 #' `ifelse(x > M, M, x)` is the same as `pmin(x, M)`, but harder
 #'   to read and requires several passes over the vector.

--- a/R/inner_combine_linter.R
+++ b/R/inner_combine_linter.R
@@ -1,7 +1,7 @@
-#' Require c() to be applied before relatively expensive vectorized functions
+#' Require `c()` to be applied before relatively expensive vectorized functions
 #'
-#' `as.Date(c(a, b))` is logically equivalent to `c(as.Date(a), as.Date(b))`;
-#'   ditto for the equivalence of several other vectorized functions like
+#' `as.Date(c(a, b))` is logically equivalent to `c(as.Date(a), as.Date(b))`.
+#'   The same equivalence holds for several other vectorized functions like
 #'   [as.POSIXct()] and math functions like [sin()]. The former is to be
 #'   preferred so that the most expensive part of the operation ([as.Date()])
 #'   is applied only once.

--- a/R/missing_argument_linter.R
+++ b/R/missing_argument_linter.R
@@ -1,6 +1,6 @@
 #' Missing argument linter
 #'
-#' Check for missing arguments in function calls (e.g. `stats::median(1:10, na.rm =)`).
+#' Check for missing arguments in function calls (e.g. `stats::median(1:10, )`).
 #'
 #' @param except a character vector of function names as exceptions.
 #' @param allow_trailing always allow trailing empty arguments?

--- a/R/missing_argument_linter.R
+++ b/R/missing_argument_linter.R
@@ -1,6 +1,7 @@
 #' Missing argument linter
 #'
-#' Check for missing arguments in function calls.
+#' Check for missing arguments in function calls (e.g. `stats::median(1:10, na.rm =)`).
+#'
 #' @param except a character vector of function names as exceptions.
 #' @param allow_trailing always allow trailing empty arguments?
 #' @evalRd rd_tags("missing_argument_linter")

--- a/R/nested_ifelse_linter.R
+++ b/R/nested_ifelse_linter.R
@@ -1,15 +1,15 @@
-#' Block usage of nested ifelse() calls
+#' Block usage of nested `ifelse()` calls
 #'
-#' Calling `ifelse` in nested calls is problematic for two main reasons:
+#' Calling `ifelse()` in nested calls is problematic for two main reasons:
 #'   1. It can be hard to read -- mapping the code to the expected output
 #'      for such code can be a messy task/require a lot of mental bandwidth,
 #'      especially for code that nests more than once
-#'   2. It is inefficient -- `ifelse` can evaluate _all_ of its arguments at
+#'   2. It is inefficient -- `ifelse()` can evaluate _all_ of its arguments at
 #'      both yes and no (see <https://stackoverflow.com/q/16275149>); this issue
 #'      is exacerbated for nested calls
 #'
 #' Users can instead rely on a more readable alternative modeled after SQL
-#'   CASE WHEN statements, such as `data.table::fcase` or `dplyr::case_when`,
+#'   CASE WHEN statements, such as `data.table::fcase()` or `dplyr::case_when()`,
 #'   or use a look-up-and-merge approach (build a mapping table between values
 #'   and outputs and merge this to the input).
 #'

--- a/R/nested_ifelse_linter.R
+++ b/R/nested_ifelse_linter.R
@@ -1,10 +1,10 @@
 #' Block usage of nested `ifelse()` calls
 #'
-#' Calling `ifelse()` in nested calls is problematic for two main reasons:
+#' Calling [ifelse()] in nested calls is problematic for two main reasons:
 #'   1. It can be hard to read -- mapping the code to the expected output
 #'      for such code can be a messy task/require a lot of mental bandwidth,
 #'      especially for code that nests more than once
-#'   2. It is inefficient -- `ifelse()` can evaluate _all_ of its arguments at
+#'   2. It is inefficient -- [ifelse()] can evaluate _all_ of its arguments at
 #'      both yes and no (see <https://stackoverflow.com/q/16275149>); this issue
 #'      is exacerbated for nested calls
 #'

--- a/R/nested_ifelse_linter.R
+++ b/R/nested_ifelse_linter.R
@@ -4,7 +4,7 @@
 #'   1. It can be hard to read -- mapping the code to the expected output
 #'      for such code can be a messy task/require a lot of mental bandwidth,
 #'      especially for code that nests more than once
-#'   2. It is inefficient -- [ifelse()] can evaluate _all_ of its arguments at
+#'   2. It is inefficient -- `ifelse()` can evaluate _all_ of its arguments at
 #'      both yes and no (see <https://stackoverflow.com/q/16275149>); this issue
 #'      is exacerbated for nested calls
 #'

--- a/R/nested_ifelse_linter.R
+++ b/R/nested_ifelse_linter.R
@@ -5,7 +5,7 @@
 #'      for such code can be a messy task/require a lot of mental bandwidth,
 #'      especially for code that nests more than once
 #'   2. It is inefficient -- `ifelse` can evaluate _all_ of its arguments at
-#'      both yes and no (see https://stackoverflow.com/q/16275149); this issue
+#'      both yes and no (see <https://stackoverflow.com/q/16275149>); this issue
 #'      is exacerbated for nested calls
 #'
 #' Users can instead rely on a more readable alternative modeled after SQL

--- a/R/object_usage_linter.R
+++ b/R/object_usage_linter.R
@@ -1,9 +1,9 @@
 #' Object usage linter
 #'
 #' Check that closures have the proper usage using [codetools::checkUsage()].
-#' Note that this runs [base::eval()] on the code, so do not use with untrusted code.
+#' Note that this runs [base::eval()] on the code, so **do not use with untrusted code**.
 #'
-#' @param interpret_glue If TRUE, interpret [glue::glue()] calls to avoid false positives caused by local variables
+#' @param interpret_glue If `TRUE`, interpret [glue::glue()] calls to avoid false positives caused by local variables
 #' which are only used in a glue expression.
 #'
 #' @evalRd rd_tags("object_usage_linter")

--- a/R/outer_negation_linter.R
+++ b/R/outer_negation_linter.R
@@ -1,4 +1,4 @@
-#' Require usage of !any(.) over all(!.), !all(.) over any(!.)
+#' Require usage of `!any(x)` over `all(!x)`, `!all(x)` over `any(!x)`
 #'
 #' `any(!x)` is logically equivalent to `!any(x)`; ditto for the equivalence of
 #'   `all(!x)` and `!any(x)`. Negating after aggregation only requires inverting

--- a/R/paren_brace_linter.R
+++ b/R/paren_brace_linter.R
@@ -1,6 +1,7 @@
 #' Parentheses before brace linter
 #'
 #' Check that there is a space between right parentheses and an opening curly brace.
+#' For example, `function(){}` doesn't have a space, while `function() {}` does.
 #'
 #' @evalRd rd_tags("paren_brace_linter")
 #' @seealso [linters] for a complete list of linters available in lintr.

--- a/R/paste_linter.R
+++ b/R/paste_linter.R
@@ -1,4 +1,4 @@
-#' Raise lints for several common poor usages of paste()
+#' Raise lints for several common poor usages of `paste()`
 #'
 #' The following issues are linted by default by this linter
 #'   (and each can be turned off optionally):

--- a/R/redundant_ifelse_linter.R
+++ b/R/redundant_ifelse_linter.R
@@ -1,9 +1,9 @@
-#' Prevent ifelse() from being used to produce TRUE/FALSE or 1/0
+#' Prevent `ifelse()` from being used to produce `TRUE/FALSE` or `1/0`
 #'
 #' Expressions like `ifelse(x, TRUE, FALSE)` and `ifelse(x, FALSE, TRUE)` are
 #'   redundant; just `x` or `!x` suffice in R code where logical vectors are a
 #'   core data structure. `ifelse(x, 1, 0)` is also `as.numeric(x)`, but even
-#'   this should only be needed rarely.
+#'   this should be needed only rarely.
 #'
 #' @evalRd rd_tags("redundant_ifelse_linter")
 #' @param allow10 Logical, default `FALSE`. If `TRUE`, usage like

--- a/R/redundant_ifelse_linter.R
+++ b/R/redundant_ifelse_linter.R
@@ -1,4 +1,4 @@
-#' Prevent `ifelse()` from being used to produce `TRUE/FALSE` or `1/0`
+#' Prevent `ifelse()` from being used to produce `TRUE`/`FALSE` or `1`/`0`
 #'
 #' Expressions like `ifelse(x, TRUE, FALSE)` and `ifelse(x, FALSE, TRUE)` are
 #'   redundant; just `x` or `!x` suffice in R code where logical vectors are a

--- a/R/regex_subset_linter.R
+++ b/R/regex_subset_linter.R
@@ -1,4 +1,4 @@
-#' Require usage of direct methods for subsetting strings via regex.
+#' Require usage of direct methods for subsetting strings via regex
 #'
 #' Using `value = TRUE` in [grep()] returns the subset of the input that matches
 #'   the pattern, e.g. `grep("[a-m]", letters, value = TRUE)` will return the

--- a/R/sprintf_linter.R
+++ b/R/sprintf_linter.R
@@ -1,7 +1,7 @@
-#' `sprintf` linter
+#' Require correct `sprintf()` calls
 #'
 #' Check for an inconsistent number of arguments or arguments with incompatible types (for literal arguments) in
-#' `sprintf` calls.
+#' `sprintf()` calls.
 #'
 #' @evalRd rd_tags("sprintf_linter")
 #' @seealso [linters] for a complete list of linters available in lintr.

--- a/R/string_boundary_linter.R
+++ b/R/string_boundary_linter.R
@@ -1,4 +1,4 @@
-#' Require usage of startsWith() and endsWith() over grepl()/substr() versions
+#' Require usage of `startsWith()` and `endsWith()` over `grepl()`/`substr()` versions
 #'
 #' [startsWith()] is used to detect fixed initial substrings; it is more
 #'   readable and more efficient than equivalents using [grepl()] or [substr()].
@@ -15,7 +15,7 @@
 #'
 #' We lint `grepl()` usages by default because the `!is.na()` version is more explicit
 #'   with respect to `NA` handling -- though documented, the way `grepl()` handles
-#'   missing inputs may be surprising to some readers.
+#'   missing inputs may be surprising to some users.
 #'
 #' @param allow_grepl Logical, default `FALSE`. If `TRUE`, usages with `grepl()`
 #'   are ignored. Some authors may prefer the `NA` input to `FALSE` output

--- a/R/strings_as_factors_linter.R
+++ b/R/strings_as_factors_linter.R
@@ -1,4 +1,4 @@
-#' Identify cases where stringsAsFactors should be supplied explicitly
+#' Identify cases where `stringsAsFactors` should be supplied explicitly
 #'
 #' Designed for code bases written for versions of R before 4.0 seeking to upgrade to R >= 4.0, where
 #'   one of the biggest pain points will surely be the flipping of the

--- a/R/system_file_linter.R
+++ b/R/system_file_linter.R
@@ -1,4 +1,4 @@
-#' Block usage of file.path() with system.file()
+#' Block usage of `file.path()` with `system.file()`
 #'
 #' [system.file()] has a `...` argument which, internally, is passed to
 #'   [file.path()], so including it in user code is repetitive.

--- a/R/undesirable_function_linter.R
+++ b/R/undesirable_function_linter.R
@@ -1,7 +1,7 @@
 #' Undesirable function linter
 #'
-#' Report the use of undesirable functions, e.g. [base::return()], [base::options()], or
-#' [base::sapply()] and suggest an alternative.
+#' Report the use of undesirable functions (e.g. [base::return()], [base::options()], or
+#' [base::sapply()]) and suggest an alternative.
 #'
 #' @param fun Named character vector. `names(fun)` correspond to undesirable functions,
 #'   while the values give a description of why the function is undesirable.

--- a/R/unneeded_concatenation_linter.R
+++ b/R/unneeded_concatenation_linter.R
@@ -5,7 +5,9 @@
 #' @param allow_single_expression Logical, default `TRUE`. If `FALSE`, one-expression
 #'   usages of `c()` are always linted, e.g. `c(x)` and `c(matrix(...))`. In some such
 #'   cases, `c()` is being used for its side-effect of stripping non-name attributes;
-#'   it is usually preferable to use the more readable [as.vector()] instead.
+#'   it is usually preferable to use the more readable [as.vector()] instead. But the
+#'   latter may not always be a suitable replacement (e.g., if `c(r6_object)`
+#'   is used to convert an `R6` class instance to a list).
 #'
 #' @evalRd rd_tags("unneeded_concatenation_linter")
 #' @seealso [linters] for a complete list of linters available in lintr.

--- a/R/unneeded_concatenation_linter.R
+++ b/R/unneeded_concatenation_linter.R
@@ -5,7 +5,7 @@
 #' @param allow_single_expression Logical, default `TRUE`. If `FALSE`, one-expression
 #'   usages of `c()` are always linted, e.g. `c(x)` and `c(matrix(...))`. In some such
 #'   cases, `c()` is being used for its side-effect of stripping non-name attributes;
-#'   it is usually preferable to use [as.vector()] to accomplish the same more readably.
+#'   it is usually preferable to use the more readable [as.vector()] instead.
 #'
 #' @evalRd rd_tags("unneeded_concatenation_linter")
 #' @seealso [linters] for a complete list of linters available in lintr.

--- a/R/unneeded_concatenation_linter.R
+++ b/R/unneeded_concatenation_linter.R
@@ -5,10 +5,9 @@
 #' @param allow_single_expression Logical, default `TRUE`. If `FALSE`, one-expression
 #'   usages of `c()` are always linted, e.g. `c(x)` and `c(matrix(...))`. In some such
 #'   cases, `c()` is being used for its side-effect of stripping non-name attributes;
-#'   it is usually preferable to use the more readable [as.vector()] instead. But the
-#'   latter may not always be a suitable replacement (e.g., if `c(r6_object)`
-#'   is used to convert an `R6` class instance to a list; in this case
-#'   `list(r6_object)` would be the preferred replacement).
+#'   it is usually preferable to use the more readable [as.vector()] instead.
+#'   [as.vector()] is not always preferable, for example with environments
+#'   (especially, `R6` objects), in which case `list()` is the better alternative.
 #'
 #' @evalRd rd_tags("unneeded_concatenation_linter")
 #' @seealso [linters] for a complete list of linters available in lintr.

--- a/R/unneeded_concatenation_linter.R
+++ b/R/unneeded_concatenation_linter.R
@@ -7,7 +7,8 @@
 #'   cases, `c()` is being used for its side-effect of stripping non-name attributes;
 #'   it is usually preferable to use the more readable [as.vector()] instead. But the
 #'   latter may not always be a suitable replacement (e.g., if `c(r6_object)`
-#'   is used to convert an `R6` class instance to a list).
+#'   is used to convert an `R6` class instance to a list; in this case
+#'   `list(r6_object)` would be the preferred replacement).
 #'
 #' @evalRd rd_tags("unneeded_concatenation_linter")
 #' @seealso [linters] for a complete list of linters available in lintr.

--- a/man/any_duplicated_linter.Rd
+++ b/man/any_duplicated_linter.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/any_duplicated_linter.R
 \name{any_duplicated_linter}
 \alias{any_duplicated_linter}
-\title{Require usage of anyDuplicated() > 0 over any(duplicated(.))}
+\title{Require usage of \code{anyDuplicated(x) > 0} over \code{any(duplicated(x))}}
 \usage{
 any_duplicated_linter()
 }

--- a/man/any_duplicated_linter.Rd
+++ b/man/any_duplicated_linter.Rd
@@ -7,10 +7,9 @@
 any_duplicated_linter()
 }
 \description{
-\code{\link[=anyDuplicated]{anyDuplicated()}} exists as a replacement for \code{any(duplicated(.))} which is
-more efficient for simple objects, and in the worst case is the same
-efficiency. Therefore it should be used in all situations instead of the
-latter.
+\code{\link[=anyDuplicated]{anyDuplicated()}} exists as a replacement for \code{any(duplicated(.))}, which is
+more efficient for simple objects, and is equally efficient in the worst case scenario.
+Therefore, it should be used in all situations instead of the latter.
 }
 \details{
 Also match usage like \code{length(unique(x$col)) == nrow(x)}, which can

--- a/man/any_duplicated_linter.Rd
+++ b/man/any_duplicated_linter.Rd
@@ -8,7 +8,7 @@ any_duplicated_linter()
 }
 \description{
 \code{\link[=anyDuplicated]{anyDuplicated()}} exists as a replacement for \code{any(duplicated(.))}, which is
-more efficient for simple objects, and is equally efficient in the worst case scenario.
+more efficient for simple objects, and is at worst equally efficient.
 Therefore, it should be used in all situations instead of the latter.
 }
 \details{

--- a/man/any_is_na_linter.Rd
+++ b/man/any_is_na_linter.Rd
@@ -2,12 +2,12 @@
 % Please edit documentation in R/any_is_na_linter.R
 \name{any_is_na_linter}
 \alias{any_is_na_linter}
-\title{Require usage of \code{anyNA()} over \code{any(is.na(.))}}
+\title{Require usage of \code{anyNA(x)} over \code{any(is.na(x))}}
 \usage{
 any_is_na_linter()
 }
 \description{
-\code{\link[=anyNA]{anyNA()}} exists as a replacement for \code{any(is.na(.))} which is more efficient
+\link{anyNA(x)} exists as a replacement for \code{any(is.na(x))} which is more efficient
 for simple objects, and has the same efficiency in the worst case scenario.
 Therefore, it should be used in all situations instead of the latter.
 }

--- a/man/any_is_na_linter.Rd
+++ b/man/any_is_na_linter.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/any_is_na_linter.R
 \name{any_is_na_linter}
 \alias{any_is_na_linter}
-\title{Require usage of anyNA over any(is.na(.))}
+\title{Require usage of \code{anyNA()} over \code{any(is.na(.))}}
 \usage{
 any_is_na_linter()
 }

--- a/man/any_is_na_linter.Rd
+++ b/man/any_is_na_linter.Rd
@@ -8,7 +8,7 @@ any_is_na_linter()
 }
 \description{
 \code{\link[=anyNA]{anyNA()}} exists as a replacement for \code{any(is.na(x))} which is more efficient
-for simple objects, and has the same efficiency in the worst case scenario.
+for simple objects, and is at worst equally efficient.
 Therefore, it should be used in all situations instead of the latter.
 }
 \seealso{

--- a/man/any_is_na_linter.Rd
+++ b/man/any_is_na_linter.Rd
@@ -8,8 +8,8 @@ any_is_na_linter()
 }
 \description{
 \code{\link[=anyNA]{anyNA()}} exists as a replacement for \code{any(is.na(.))} which is more efficient
-for simple objects, and in the worst case is the same efficiency. Therefore
-it should be used in all situations instead of the latter.
+for simple objects, and has the same efficiency in the worst case scenario.
+Therefore, it should be used in all situations instead of the latter.
 }
 \seealso{
 \link{linters} for a complete list of linters available in lintr.

--- a/man/any_is_na_linter.Rd
+++ b/man/any_is_na_linter.Rd
@@ -7,7 +7,7 @@
 any_is_na_linter()
 }
 \description{
-\link{anyNA(x)} exists as a replacement for \code{any(is.na(x))} which is more efficient
+\code{\link[=anyNA]{anyNA()}} exists as a replacement for \code{any(is.na(x))} which is more efficient
 for simple objects, and has the same efficiency in the worst case scenario.
 Therefore, it should be used in all situations instead of the latter.
 }

--- a/man/class_equals_linter.Rd
+++ b/man/class_equals_linter.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/class_equals_linter.R
 \name{class_equals_linter}
 \alias{class_equals_linter}
-\title{Block comparison of class with ==}
+\title{Block comparison of class with \code{==}}
 \usage{
 class_equals_linter()
 }

--- a/man/closed_curly_linter.Rd
+++ b/man/closed_curly_linter.Rd
@@ -10,7 +10,8 @@ closed_curly_linter(allow_single_line = FALSE)
 \item{allow_single_line}{if \code{TRUE}, allow an open and closed curly pair on the same line.}
 }
 \description{
-Check that closed curly braces are on their own line unless they follow an else, comma, or closing bracket.
+Check that closed curly braces are on their own line unless they follow
+an else, a comma, or a closing bracket.
 }
 \seealso{
 \link{linters} for a complete list of linters available in lintr. \cr

--- a/man/commas_linter.Rd
+++ b/man/commas_linter.Rd
@@ -7,7 +7,8 @@
 commas_linter()
 }
 \description{
-Check that all commas are followed by spaces, but do not have spaces before them.
+Check that all commas are followed by spaces (e.g. \code{c(a = 4, b = 5)}),
+but do not have spaces before them (e.g. \code{c(a = 4 , b = 5)}).
 }
 \seealso{
 \link{linters} for a complete list of linters available in lintr. \cr

--- a/man/commas_linter.Rd
+++ b/man/commas_linter.Rd
@@ -7,8 +7,7 @@
 commas_linter()
 }
 \description{
-Check that all commas are followed by spaces (e.g. \code{c(a = 4, b = 5)}),
-but do not have spaces before them (e.g. \code{c(a = 4 , b = 5)}).
+Check that all commas are followed by spaces, but do not have spaces before them.
 }
 \seealso{
 \link{linters} for a complete list of linters available in lintr. \cr

--- a/man/condition_message_linter.Rd
+++ b/man/condition_message_linter.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/condition_message_linter.R
 \name{condition_message_linter}
 \alias{condition_message_linter}
-\title{Block usage of paste() and paste0() with messaging functions using ...}
+\title{Block usage of \code{paste()} and \code{paste0()} with messaging functions using \code{...}}
 \usage{
 condition_message_linter()
 }

--- a/man/conjunct_test_linter.Rd
+++ b/man/conjunct_test_linter.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/conjunct_test_linter.R
 \name{conjunct_test_linter}
 \alias{conjunct_test_linter}
-\title{Force \code{&&} conditions in \code{expect_true()}, \code{expect_false()} to be written separately}
+\title{Force \code{&&} conditions in \code{expect_true()} and \code{expect_false()} to be written separately}
 \usage{
 conjunct_test_linter(allow_named_stopifnot = TRUE)
 }

--- a/man/conjunct_test_linter.Rd
+++ b/man/conjunct_test_linter.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/conjunct_test_linter.R
 \name{conjunct_test_linter}
 \alias{conjunct_test_linter}
-\title{Force && conditions in expect_true(), expect_false() to be written separately}
+\title{Force \code{&&} conditions in \code{expect_true()}, \code{expect_false()} to be written separately}
 \usage{
 conjunct_test_linter(allow_named_stopifnot = TRUE)
 }

--- a/man/cyclocomp_linter.Rd
+++ b/man/cyclocomp_linter.Rd
@@ -7,7 +7,8 @@
 cyclocomp_linter(complexity_limit = 15L)
 }
 \arguments{
-\item{complexity_limit}{expressions with a cyclomatic complexity higher than this are linted, defaults to 15.
+\item{complexity_limit}{expressions with a cyclomatic complexity higher than
+this limit are linted, defaults to 15.
 See \code{\link[cyclocomp:cyclocomp]{cyclocomp::cyclocomp()}}.}
 }
 \description{

--- a/man/cyclocomp_linter.Rd
+++ b/man/cyclocomp_linter.Rd
@@ -7,9 +7,8 @@
 cyclocomp_linter(complexity_limit = 15L)
 }
 \arguments{
-\item{complexity_limit}{expressions with a cyclomatic complexity higher than
-this limit are linted, defaults to 15.
-See \code{\link[cyclocomp:cyclocomp]{cyclocomp::cyclocomp()}}.}
+\item{complexity_limit}{Maximum cyclomatic complexity, default 15. Expressions more complex
+than this are linted. See \code{\link[cyclocomp:cyclocomp]{cyclocomp::cyclocomp()}}.}
 }
 \description{
 Check for overly complicated expressions. See \code{\link[cyclocomp:cyclocomp]{cyclocomp::cyclocomp()}}.

--- a/man/duplicate_argument_linter.Rd
+++ b/man/duplicate_argument_linter.Rd
@@ -10,10 +10,7 @@ duplicate_argument_linter(except = character())
 \item{except}{a character vector of function names as exceptions.}
 }
 \description{
-Check for duplicate arguments in function calls. Some of these cases will be
-blocked by R's syntax itself (e.g. \code{mean(x = 1:5, x = 2:3)}), but even when
-such usage \emph{is} allowed, it is rarely desirable and should be used sparingly
-(e.g. \code{data.frame(x = 1, x = 2)}).
+Check for duplicate arguments in function calls.
 }
 \seealso{
 \link{linters} for a complete list of linters available in lintr.

--- a/man/duplicate_argument_linter.Rd
+++ b/man/duplicate_argument_linter.Rd
@@ -10,7 +10,10 @@ duplicate_argument_linter(except = character())
 \item{except}{a character vector of function names as exceptions.}
 }
 \description{
-Check for duplicate arguments in function calls.
+Check for duplicate arguments in function calls. Some of these cases will be
+blocked by R's syntax itself (e.g. \code{mean(x = 1:5, x = 2:3)}), but even when
+such usage \emph{is} allowed, it is rarely desirable and should be used sparingly
+(e.g. \code{data.frame(x = 1, x = 2)}).
 }
 \seealso{
 \link{linters} for a complete list of linters available in lintr.

--- a/man/duplicate_argument_linter.Rd
+++ b/man/duplicate_argument_linter.Rd
@@ -10,7 +10,11 @@ duplicate_argument_linter(except = character())
 \item{except}{a character vector of function names as exceptions.}
 }
 \description{
-Check for duplicate arguments in function calls.
+Check for duplicate arguments in function calls. Some cases are run-time errors
+(e.g. \code{mean(x = 1:5, x = 2:3)}), otherwise this linter is used to discourage
+explicitly providing duplicate names to objects (e.g. \code{c(a = 1, a = 2)}).
+Duplicate-named objects are hard to work with programmatically and
+should typically be avoided.
 }
 \seealso{
 \link{linters} for a complete list of linters available in lintr.

--- a/man/equals_na_linter.Rd
+++ b/man/equals_na_linter.Rd
@@ -7,7 +7,8 @@
 equals_na_linter()
 }
 \description{
-Check for \code{x == NA} and \code{x != NA}
+Check for \code{x == NA} and \code{x != NA}. One should instead use \code{is.na()} function
+for such comparisons.
 }
 \seealso{
 \link{linters} for a complete list of linters available in lintr.

--- a/man/equals_na_linter.Rd
+++ b/man/equals_na_linter.Rd
@@ -7,8 +7,8 @@
 equals_na_linter()
 }
 \description{
-Check for \code{x == NA} and \code{x != NA}. One should instead use \code{is.na()} function
-for such comparisons.
+Check for \code{x == NA} and \code{x != NA}. Such usage is almost surely incorrect --
+checks for missing values should be done with \code{\link[=is.na]{is.na()}}.
 }
 \seealso{
 \link{linters} for a complete list of linters available in lintr.

--- a/man/expect_comparison_linter.Rd
+++ b/man/expect_comparison_linter.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/expect_comparison_linter.R
 \name{expect_comparison_linter}
 \alias{expect_comparison_linter}
-\title{Require usage of expect_gt(x, y) over expect_true(x > y) (and similar)}
+\title{Require usage of \code{expect_gt(x, y)} over \code{expect_true(x > y)} (and similar)}
 \usage{
 expect_comparison_linter()
 }

--- a/man/expect_identical_linter.Rd
+++ b/man/expect_identical_linter.Rd
@@ -2,12 +2,12 @@
 % Please edit documentation in R/expect_identical_linter.R
 \name{expect_identical_linter}
 \alias{expect_identical_linter}
-\title{Require usage of expect_identical(x, y) where appropriate}
+\title{Require usage of \code{expect_identical(x, y)} where appropriate}
 \usage{
 expect_identical_linter()
 }
 \description{
-At Google, \code{\link[testthat:equality-expectations]{testthat::expect_identical()}} should be the default/go-to function for
+\code{\link[testthat:equality-expectations]{testthat::expect_identical()}} should be the default/go-to function for
 comparing an output to an expected value. \code{expect_true(identical(x, y))}
 is an equivalent but unadvised method of the same test. Further,
 \code{\link[testthat:equality-expectations]{testthat::expect_equal()}} should only be used when \code{expect_identical()}
@@ -26,7 +26,7 @@ The linter allows \code{expect_equal()} in three circumstances:
 \item A named argument is set (e.g. \code{ignore_attr} or \code{tolerance})
 \item Comparison is made to an explicit decimal, e.g.
 \code{expect_equal(x, 1.0)} (implicitly setting \code{tolerance})
-\item \code{...} is passed (wrapper functions whcih might set
+\item \code{...} is passed (wrapper functions which might set
 arguments such as \code{ignore_attr} or \code{tolerance})
 }
 }

--- a/man/expect_identical_linter.Rd
+++ b/man/expect_identical_linter.Rd
@@ -7,8 +7,8 @@
 expect_identical_linter()
 }
 \description{
-\code{\link[testthat:equality-expectations]{testthat::expect_identical()}} should be the default/go-to function for
-comparing an output to an expected value. \code{expect_true(identical(x, y))}
+This linter enforces the usage of \code{\link[testthat:equality-expectations]{testthat::expect_identical()}} as the
+default expectation for comparisons in a testthat suite. \code{expect_true(identical(x, y))}
 is an equivalent but unadvised method of the same test. Further,
 \code{\link[testthat:equality-expectations]{testthat::expect_equal()}} should only be used when \code{expect_identical()}
 is inappropriate, i.e., when \code{x} and \code{y} need only be \emph{numerically

--- a/man/expect_length_linter.Rd
+++ b/man/expect_length_linter.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/expect_length_linter.R
 \name{expect_length_linter}
 \alias{expect_length_linter}
-\title{Require usage of expect_length(x, n) over expect_equal(length(x), n)}
+\title{Require usage of \code{expect_length(x, n)} over \code{expect_equal(length(x), n)}}
 \usage{
 expect_length_linter()
 }

--- a/man/expect_named_linter.Rd
+++ b/man/expect_named_linter.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/expect_named_linter.R
 \name{expect_named_linter}
 \alias{expect_named_linter}
-\title{Require usage of expect_named(x, n) over expect_equal(names(x), n)}
+\title{Require usage of \code{expect_named(x, n)} over \code{expect_equal(names(x), n)}}
 \usage{
 expect_named_linter()
 }

--- a/man/expect_not_linter.Rd
+++ b/man/expect_not_linter.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/expect_not_linter.R
 \name{expect_not_linter}
 \alias{expect_not_linter}
-\title{Require usage of expect_false(.) over expect_true(!.)}
+\title{Require usage of \code{expect_false(x)} over \code{expect_true(!x)}}
 \usage{
 expect_not_linter()
 }

--- a/man/expect_null_linter.Rd
+++ b/man/expect_null_linter.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/expect_null_linter.R
 \name{expect_null_linter}
 \alias{expect_null_linter}
-\title{expect_null Linter}
+\title{Require usage of \code{expect_null} for checking \code{NULL}}
 \usage{
 expect_null_linter()
 }

--- a/man/expect_s3_class_linter.Rd
+++ b/man/expect_s3_class_linter.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/expect_s3_class_linter.R
 \name{expect_s3_class_linter}
 \alias{expect_s3_class_linter}
-\title{Require usage of expect_s3_class()}
+\title{Require usage of \code{expect_s3_class()}}
 \usage{
 expect_s3_class_linter()
 }

--- a/man/expect_s4_class_linter.Rd
+++ b/man/expect_s4_class_linter.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/expect_s3_class_linter.R
 \name{expect_s4_class_linter}
 \alias{expect_s4_class_linter}
-\title{Require usage of expect_s4_class(x, k) over expect_true(is(x, k))}
+\title{Require usage of \code{expect_s4_class(x, k)} over \code{expect_true(is(x, k))}}
 \usage{
 expect_s4_class_linter()
 }

--- a/man/expect_true_false_linter.Rd
+++ b/man/expect_true_false_linter.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/expect_true_false_linter.R
 \name{expect_true_false_linter}
 \alias{expect_true_false_linter}
-\title{Require usage of expect_true(x) over expect_equal(x, TRUE)}
+\title{Require usage of \code{expect_true(x)} over \code{expect_equal(x, TRUE)}}
 \usage{
 expect_true_false_linter()
 }

--- a/man/expect_type_linter.Rd
+++ b/man/expect_type_linter.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/expect_type_linter.R
 \name{expect_type_linter}
 \alias{expect_type_linter}
-\title{Require usage of expect_type(x, type) over expect_equal(typeof(x), type)}
+\title{Require usage of \code{expect_type(x, type)} over \code{expect_equal(typeof(x), type)}}
 \usage{
 expect_type_linter()
 }

--- a/man/extraction_operator_linter.Rd
+++ b/man/extraction_operator_linter.Rd
@@ -7,8 +7,8 @@
 extraction_operator_linter()
 }
 \description{
-Check that the \code{[[} operator is used when extracting a single element from an object,
-and not \code{[} (subsetting) or \code{$} (interactive use).
+Check that the \code{[[} operator is used when extracting a single element from an object, not \code{[} (subsetting) nor \code{$}
+(interactive use).
 }
 \seealso{
 \link{linters} for a complete list of linters available in lintr.

--- a/man/extraction_operator_linter.Rd
+++ b/man/extraction_operator_linter.Rd
@@ -7,8 +7,8 @@
 extraction_operator_linter()
 }
 \description{
-Check that the \code{[[} operator is used when extracting a single element from an object, not \code{[} (subsetting) nor \code{$}
-(interactive use).
+Check that the \code{[[} operator is used when extracting a single element from an object,
+and not \code{[} (subsetting) or \code{$} (interactive use).
 }
 \seealso{
 \link{linters} for a complete list of linters available in lintr.

--- a/man/fixed_regex_linter.Rd
+++ b/man/fixed_regex_linter.Rd
@@ -11,9 +11,9 @@ Invoking a regular expression engine is overkill for cases when the search
 pattern only involves static patterns.
 }
 \details{
-NB: For \code{stringr} functions, that means wrapping the pattern in \code{stringr::fixed()}.
+NB: for \code{stringr} functions, that means wrapping the pattern in \code{stringr::fixed()}.
 
-NB: This linter is likely not able to distinguish every possible case when
+NB: this linter is likely not able to distinguish every possible case when
 a fixed regular expression is preferable, rather it seeks to identify
 likely cases. It should \emph{never} report false positives, however; please
 report false positives as an error.

--- a/man/fixed_regex_linter.Rd
+++ b/man/fixed_regex_linter.Rd
@@ -11,7 +11,7 @@ Invoking a regular expression engine is overkill for cases when the search
 pattern only involves static patterns.
 }
 \details{
-NB: for \code{stringr} functions, that means wrapping the pattern in \code{stringr::fixed()}.
+NB: For \code{stringr} functions, that means wrapping the pattern in \code{stringr::fixed()}.
 
 NB: This linter is likely not able to distinguish every possible case when
 a fixed regular expression is preferable, rather it seeks to identify

--- a/man/function_left_parentheses_linter.Rd
+++ b/man/function_left_parentheses_linter.Rd
@@ -7,7 +7,9 @@
 function_left_parentheses_linter()
 }
 \description{
-Check that all left parentheses in a function call do not have spaces before them.
+Check that all left parentheses in a function call do not have spaces before them
+(e.g. \code{mean  (1:3)}). Although this is syntactically valid, it makes the code
+difficult to read.
 }
 \seealso{
 \link{linters} for a complete list of linters available in lintr. \cr

--- a/man/ifelse_censor_linter.Rd
+++ b/man/ifelse_censor_linter.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/ifelse_censor_linter.R
 \name{ifelse_censor_linter}
 \alias{ifelse_censor_linter}
-\title{Block usage of ifelse where pmin or pmax is more appropriate}
+\title{Block usage of \code{ifelse()} where \code{pmin()} or \code{pmax()} is more appropriate}
 \usage{
 ifelse_censor_linter()
 }

--- a/man/inner_combine_linter.Rd
+++ b/man/inner_combine_linter.Rd
@@ -2,13 +2,13 @@
 % Please edit documentation in R/inner_combine_linter.R
 \name{inner_combine_linter}
 \alias{inner_combine_linter}
-\title{Require c() to be applied before relatively expensive vectorized functions}
+\title{Require \code{c()} to be applied before relatively expensive vectorized functions}
 \usage{
 inner_combine_linter()
 }
 \description{
-\code{as.Date(c(a, b))} is logically equivalent to \code{c(as.Date(a), as.Date(b))};
-ditto for the equivalence of several other vectorized functions like
+\code{as.Date(c(a, b))} is logically equivalent to \code{c(as.Date(a), as.Date(b))}.
+The same equivalence holds for several other vectorized functions like
 \code{\link[=as.POSIXct]{as.POSIXct()}} and math functions like \code{\link[=sin]{sin()}}. The former is to be
 preferred so that the most expensive part of the operation (\code{\link[=as.Date]{as.Date()}})
 is applied only once.

--- a/man/linters.Rd
+++ b/man/linters.Rd
@@ -4,7 +4,7 @@
 \alias{linters}
 \title{Available linters}
 \description{
-A variety of linters is available in \pkg{lintr}. The most popular ones are readily
+A variety of linters are available in \pkg{lintr}. The most popular ones are readily
 accessible through \code{\link[=default_linters]{default_linters()}}.
 
 Within a \code{\link[=lint]{lint()}} function call, the linters in use are initialized with the provided

--- a/man/missing_argument_linter.Rd
+++ b/man/missing_argument_linter.Rd
@@ -12,7 +12,7 @@ missing_argument_linter(except = c("switch", "alist"), allow_trailing = FALSE)
 \item{allow_trailing}{always allow trailing empty arguments?}
 }
 \description{
-Check for missing arguments in function calls (e.g. \code{stats::median(1:10, na.rm =)}).
+Check for missing arguments in function calls (e.g. \code{stats::median(1:10, )}).
 }
 \seealso{
 \link{linters} for a complete list of linters available in lintr.

--- a/man/missing_argument_linter.Rd
+++ b/man/missing_argument_linter.Rd
@@ -12,7 +12,7 @@ missing_argument_linter(except = c("switch", "alist"), allow_trailing = FALSE)
 \item{allow_trailing}{always allow trailing empty arguments?}
 }
 \description{
-Check for missing arguments in function calls.
+Check for missing arguments in function calls (e.g. \code{stats::median(1:10, na.rm =)}).
 }
 \seealso{
 \link{linters} for a complete list of linters available in lintr.

--- a/man/nested_ifelse_linter.Rd
+++ b/man/nested_ifelse_linter.Rd
@@ -7,12 +7,12 @@
 nested_ifelse_linter()
 }
 \description{
-Calling \code{ifelse()} in nested calls is problematic for two main reasons:
+Calling \code{\link[=ifelse]{ifelse()}} in nested calls is problematic for two main reasons:
 \enumerate{
 \item It can be hard to read -- mapping the code to the expected output
 for such code can be a messy task/require a lot of mental bandwidth,
 especially for code that nests more than once
-\item It is inefficient -- \code{ifelse()} can evaluate \emph{all} of its arguments at
+\item It is inefficient -- \code{\link[=ifelse]{ifelse()}} can evaluate \emph{all} of its arguments at
 both yes and no (see \url{https://stackoverflow.com/q/16275149}); this issue
 is exacerbated for nested calls
 }

--- a/man/nested_ifelse_linter.Rd
+++ b/man/nested_ifelse_linter.Rd
@@ -2,24 +2,24 @@
 % Please edit documentation in R/nested_ifelse_linter.R
 \name{nested_ifelse_linter}
 \alias{nested_ifelse_linter}
-\title{Block usage of nested ifelse() calls}
+\title{Block usage of nested \code{ifelse()} calls}
 \usage{
 nested_ifelse_linter()
 }
 \description{
-Calling \code{ifelse} in nested calls is problematic for two main reasons:
+Calling \code{ifelse()} in nested calls is problematic for two main reasons:
 \enumerate{
 \item It can be hard to read -- mapping the code to the expected output
 for such code can be a messy task/require a lot of mental bandwidth,
 especially for code that nests more than once
-\item It is inefficient -- \code{ifelse} can evaluate \emph{all} of its arguments at
+\item It is inefficient -- \code{ifelse()} can evaluate \emph{all} of its arguments at
 both yes and no (see \url{https://stackoverflow.com/q/16275149}); this issue
 is exacerbated for nested calls
 }
 }
 \details{
 Users can instead rely on a more readable alternative modeled after SQL
-CASE WHEN statements, such as \code{data.table::fcase} or \code{dplyr::case_when},
+CASE WHEN statements, such as \code{data.table::fcase()} or \code{dplyr::case_when()},
 or use a look-up-and-merge approach (build a mapping table between values
 and outputs and merge this to the input).
 }

--- a/man/nested_ifelse_linter.Rd
+++ b/man/nested_ifelse_linter.Rd
@@ -13,7 +13,7 @@ Calling \code{ifelse} in nested calls is problematic for two main reasons:
 for such code can be a messy task/require a lot of mental bandwidth,
 especially for code that nests more than once
 \item It is inefficient -- \code{ifelse} can evaluate \emph{all} of its arguments at
-both yes and no (see https://stackoverflow.com/q/16275149); this issue
+both yes and no (see \url{https://stackoverflow.com/q/16275149}); this issue
 is exacerbated for nested calls
 }
 }

--- a/man/nested_ifelse_linter.Rd
+++ b/man/nested_ifelse_linter.Rd
@@ -12,7 +12,7 @@ Calling \code{\link[=ifelse]{ifelse()}} in nested calls is problematic for two m
 \item It can be hard to read -- mapping the code to the expected output
 for such code can be a messy task/require a lot of mental bandwidth,
 especially for code that nests more than once
-\item It is inefficient -- \code{\link[=ifelse]{ifelse()}} can evaluate \emph{all} of its arguments at
+\item It is inefficient -- \code{ifelse()} can evaluate \emph{all} of its arguments at
 both yes and no (see \url{https://stackoverflow.com/q/16275149}); this issue
 is exacerbated for nested calls
 }

--- a/man/object_usage_linter.Rd
+++ b/man/object_usage_linter.Rd
@@ -7,12 +7,12 @@
 object_usage_linter(interpret_glue = TRUE)
 }
 \arguments{
-\item{interpret_glue}{If TRUE, interpret \code{\link[glue:glue]{glue::glue()}} calls to avoid false positives caused by local variables
+\item{interpret_glue}{If \code{TRUE}, interpret \code{\link[glue:glue]{glue::glue()}} calls to avoid false positives caused by local variables
 which are only used in a glue expression.}
 }
 \description{
 Check that closures have the proper usage using \code{\link[codetools:checkUsage]{codetools::checkUsage()}}.
-Note that this runs \code{\link[base:eval]{base::eval()}} on the code, so do not use with untrusted code.
+Note that this runs \code{\link[base:eval]{base::eval()}} on the code, so \strong{do not use with untrusted code}.
 }
 \seealso{
 \link{linters} for a complete list of linters available in lintr.

--- a/man/outer_negation_linter.Rd
+++ b/man/outer_negation_linter.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/outer_negation_linter.R
 \name{outer_negation_linter}
 \alias{outer_negation_linter}
-\title{Require usage of !any(.) over all(!.), !all(.) over any(!.)}
+\title{Require usage of \code{!any(x)} over \code{all(!x)}, \code{!all(x)} over \code{any(!x)}}
 \usage{
 outer_negation_linter()
 }

--- a/man/paren_brace_linter.Rd
+++ b/man/paren_brace_linter.Rd
@@ -8,6 +8,7 @@ paren_brace_linter()
 }
 \description{
 Check that there is a space between right parentheses and an opening curly brace.
+For example, \code{function(){}} doesn't have a space, while \code{function() {}} does.
 }
 \seealso{
 \link{linters} for a complete list of linters available in lintr.

--- a/man/paste_linter.Rd
+++ b/man/paste_linter.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/paste_linter.R
 \name{paste_linter}
 \alias{paste_linter}
-\title{Raise lints for several common poor usages of paste()}
+\title{Raise lints for several common poor usages of \code{paste()}}
 \usage{
 paste_linter(allow_empty_sep = FALSE, allow_to_string = FALSE)
 }

--- a/man/redundant_ifelse_linter.Rd
+++ b/man/redundant_ifelse_linter.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/redundant_ifelse_linter.R
 \name{redundant_ifelse_linter}
 \alias{redundant_ifelse_linter}
-\title{Prevent \code{ifelse()} from being used to produce \code{TRUE/FALSE} or \code{1/0}}
+\title{Prevent \code{ifelse()} from being used to produce \code{TRUE}/\code{FALSE} or \code{1}/\code{0}}
 \usage{
 redundant_ifelse_linter(allow10 = FALSE)
 }

--- a/man/redundant_ifelse_linter.Rd
+++ b/man/redundant_ifelse_linter.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/redundant_ifelse_linter.R
 \name{redundant_ifelse_linter}
 \alias{redundant_ifelse_linter}
-\title{Prevent ifelse() from being used to produce TRUE/FALSE or 1/0}
+\title{Prevent \code{ifelse()} from being used to produce \code{TRUE/FALSE} or \code{1/0}}
 \usage{
 redundant_ifelse_linter(allow10 = FALSE)
 }
@@ -15,7 +15,7 @@ redundant_ifelse_linter(allow10 = FALSE)
 Expressions like \code{ifelse(x, TRUE, FALSE)} and \code{ifelse(x, FALSE, TRUE)} are
 redundant; just \code{x} or \code{!x} suffice in R code where logical vectors are a
 core data structure. \code{ifelse(x, 1, 0)} is also \code{as.numeric(x)}, but even
-this should only be needed rarely.
+this should be needed only rarely.
 }
 \seealso{
 \link{linters} for a complete list of linters available in lintr.

--- a/man/regex_subset_linter.Rd
+++ b/man/regex_subset_linter.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/regex_subset_linter.R
 \name{regex_subset_linter}
 \alias{regex_subset_linter}
-\title{Require usage of direct methods for subsetting strings via regex.}
+\title{Require usage of direct methods for subsetting strings via regex}
 \usage{
 regex_subset_linter()
 }

--- a/man/sprintf_linter.Rd
+++ b/man/sprintf_linter.Rd
@@ -2,13 +2,13 @@
 % Please edit documentation in R/sprintf_linter.R
 \name{sprintf_linter}
 \alias{sprintf_linter}
-\title{\code{sprintf} linter}
+\title{Require correct usage of \code{sprintf()}}
 \usage{
 sprintf_linter()
 }
 \description{
 Check for an inconsistent number of arguments or arguments with incompatible types (for literal arguments) in
-\code{sprintf} calls.
+\code{sprintf()} calls.
 }
 \seealso{
 \link{linters} for a complete list of linters available in lintr.

--- a/man/sprintf_linter.Rd
+++ b/man/sprintf_linter.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/sprintf_linter.R
 \name{sprintf_linter}
 \alias{sprintf_linter}
-\title{Require correct usage of \code{sprintf()}}
+\title{Require correct \code{sprintf()} calls}
 \usage{
 sprintf_linter()
 }

--- a/man/string_boundary_linter.Rd
+++ b/man/string_boundary_linter.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/string_boundary_linter.R
 \name{string_boundary_linter}
 \alias{string_boundary_linter}
-\title{Require usage of startsWith() and endsWith() over grepl()/substr() versions}
+\title{Require usage of \code{startsWith()} and \code{endsWith()} over \code{grepl()}/\code{substr()} versions}
 \usage{
 string_boundary_linter(allow_grepl = FALSE)
 }
@@ -29,7 +29,7 @@ That means the strict equivalent of \code{grepl("^abc", x)} is
 
 We lint \code{grepl()} usages by default because the \code{!is.na()} version is more explicit
 with respect to \code{NA} handling -- though documented, the way \code{grepl()} handles
-missing inputs may be surprising to some readers.
+missing inputs may be surprising to some users.
 }
 \seealso{
 \link{linters} for a complete list of linters available in lintr.

--- a/man/strings_as_factors_linter.Rd
+++ b/man/strings_as_factors_linter.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/strings_as_factors_linter.R
 \name{strings_as_factors_linter}
 \alias{strings_as_factors_linter}
-\title{Identify cases where stringsAsFactors should be supplied explicitly}
+\title{Identify cases where \code{stringsAsFactors} should be supplied explicitly}
 \usage{
 strings_as_factors_linter()
 }

--- a/man/system_file_linter.Rd
+++ b/man/system_file_linter.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/system_file_linter.R
 \name{system_file_linter}
 \alias{system_file_linter}
-\title{Block usage of file.path() with system.file()}
+\title{Block usage of \code{file.path()} with \code{system.file()}}
 \usage{
 system_file_linter()
 }

--- a/man/undesirable_function_linter.Rd
+++ b/man/undesirable_function_linter.Rd
@@ -20,8 +20,8 @@ use \code{\link[=modify_defaults]{modify_defaults()}}.}
 or not.}
 }
 \description{
-Report the use of undesirable functions, e.g. \code{\link[base:function]{base::return()}}, \code{\link[base:options]{base::options()}}, or
-\code{\link[base:lapply]{base::sapply()}} and suggest an alternative.
+Report the use of undesirable functions (e.g. \code{\link[base:function]{base::return()}}, \code{\link[base:options]{base::options()}}, or
+\code{\link[base:lapply]{base::sapply()}}) and suggest an alternative.
 }
 \seealso{
 \link{linters} for a complete list of linters available in lintr.

--- a/man/unneeded_concatenation_linter.Rd
+++ b/man/unneeded_concatenation_linter.Rd
@@ -10,7 +10,7 @@ unneeded_concatenation_linter(allow_single_expression = TRUE)
 \item{allow_single_expression}{Logical, default \code{TRUE}. If \code{FALSE}, one-expression
 usages of \code{c()} are always linted, e.g. \code{c(x)} and \code{c(matrix(...))}. In some such
 cases, \code{c()} is being used for its side-effect of stripping non-name attributes;
-it is usually preferable to use \code{\link[=as.vector]{as.vector()}} to accomplish the same more readably.}
+it is usually preferable to use the more readable \code{\link[=as.vector]{as.vector()}} instead.}
 }
 \description{
 Check that the \code{\link[=c]{c()}} function is not used without arguments nor with a single constant.

--- a/man/unneeded_concatenation_linter.Rd
+++ b/man/unneeded_concatenation_linter.Rd
@@ -12,7 +12,8 @@ usages of \code{c()} are always linted, e.g. \code{c(x)} and \code{c(matrix(...)
 cases, \code{c()} is being used for its side-effect of stripping non-name attributes;
 it is usually preferable to use the more readable \code{\link[=as.vector]{as.vector()}} instead. But the
 latter may not always be a suitable replacement (e.g., if \code{c(r6_object)}
-is used to convert an \code{R6} class instance to a list).}
+is used to convert an \code{R6} class instance to a list; in this case
+\code{list(r6_object)} would be the preferred replacement).}
 }
 \description{
 Check that the \code{\link[=c]{c()}} function is not used without arguments nor with a single constant.

--- a/man/unneeded_concatenation_linter.Rd
+++ b/man/unneeded_concatenation_linter.Rd
@@ -10,10 +10,9 @@ unneeded_concatenation_linter(allow_single_expression = TRUE)
 \item{allow_single_expression}{Logical, default \code{TRUE}. If \code{FALSE}, one-expression
 usages of \code{c()} are always linted, e.g. \code{c(x)} and \code{c(matrix(...))}. In some such
 cases, \code{c()} is being used for its side-effect of stripping non-name attributes;
-it is usually preferable to use the more readable \code{\link[=as.vector]{as.vector()}} instead. But the
-latter may not always be a suitable replacement (e.g., if \code{c(r6_object)}
-is used to convert an \code{R6} class instance to a list; in this case
-\code{list(r6_object)} would be the preferred replacement).}
+it is usually preferable to use the more readable \code{\link[=as.vector]{as.vector()}} instead.
+\code{\link[=as.vector]{as.vector()}} is not always preferable, for example with environments
+(especially, \code{R6} objects), in which case \code{list()} is the better alternative.}
 }
 \description{
 Check that the \code{\link[=c]{c()}} function is not used without arguments nor with a single constant.

--- a/man/unneeded_concatenation_linter.Rd
+++ b/man/unneeded_concatenation_linter.Rd
@@ -10,7 +10,9 @@ unneeded_concatenation_linter(allow_single_expression = TRUE)
 \item{allow_single_expression}{Logical, default \code{TRUE}. If \code{FALSE}, one-expression
 usages of \code{c()} are always linted, e.g. \code{c(x)} and \code{c(matrix(...))}. In some such
 cases, \code{c()} is being used for its side-effect of stripping non-name attributes;
-it is usually preferable to use the more readable \code{\link[=as.vector]{as.vector()}} instead.}
+it is usually preferable to use the more readable \code{\link[=as.vector]{as.vector()}} instead. But the
+latter may not always be a suitable replacement (e.g., if \code{c(r6_object)}
+is used to convert an \code{R6} class instance to a list).}
 }
 \description{
 Check that the \code{\link[=c]{c()}} function is not used without arguments nor with a single constant.


### PR DESCRIPTION
- Where the text description wasn't clear, adds a small example
- Consistent formatting of function calls or names as code in Roxygen docs to distinguish it from text
- Grammar or spelling corrections