### PR TITLE
WIP: Remove deprecated workarounds

### DIFF
--- a/man/lint.Rd
+++ b/man/lint.Rd
@@ -2,7 +2,6 @@
 % Please edit documentation in R/lint.R
 \name{lint}
 \alias{lint}
-\alias{lint_file}
 \alias{lint_dir}
 \alias{lint_package}
 \title{Lint a file, directory, or package}

--- a/tests/testthat/test-dir_linters.R
+++ b/tests/testthat/test-dir_linters.R
@@ -92,13 +92,3 @@ test_that("lint_dir works with specific linters without specifying other argumen
   expect_length(lint_dir(the_dir, assignment_linter(), parse_settings = FALSE), 12L)
   expect_length(lint_dir(the_dir, commented_code_linter(), parse_settings = FALSE), 0L)
 })
-
-test_that("lint_dir continues to accept relative_path= in 2nd positional argument, with a warning", {
-  the_dir <- test_path("dummy_packages", "package", "vignettes")
-  expect_warning(
-    positional_lints <- lint_dir(the_dir, FALSE),
-    "'relative_path' is no longer available as a positional argument",
-    fixed = TRUE
-  )
-  expect_identical(positional_lints, lint_dir(the_dir, relative_path = FALSE))
-})


### PR DESCRIPTION
These were slated for the next release after `3.0.0`.

So probably will be part of the release to be made for #1504?