### PR TITLE
More clean up for tests

### DIFF
--- a/tests/testthat/checkstyle.xml
+++ b/tests/testthat/checkstyle.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<checkstyle version="lintr-3.0.0.9000">
+<checkstyle version="lintr-3.0.1">
   <file name="test_file">
     <error line="1" column="2" severity="error" message="foo"/>
     <error line="2" column="1" severity="info" message="bar"/>

--- a/tests/testthat/test-closed_curly_linter.R
+++ b/tests/testthat/test-closed_curly_linter.R
@@ -3,7 +3,8 @@ test_that("returns the correct linting", {
     paste(
       "Closing curly-braces should always be on their own line,",
       "unless they are followed by an else."
-    ))
+    )
+  )
 
   expect_warning(
     linter <- closed_curly_linter(),
@@ -11,52 +12,26 @@ test_that("returns the correct linting", {
     fixed = TRUE
   )
 
-  expect_lint("blah",
-              NULL,
-              linter)
+  # should generate lints
+  expect_lint("a <- function() { 1 }", closed_curly_message_regex, linter)
+  expect_lint("a <- function() { 1 }", closed_curly_message_regex, linter)
+  expect_lint("a <- if(1) {\n 1} else {\n 2\n}", closed_curly_message_regex, linter)
+  expect_lint("a <- if(1) {\n 1\n} else {\n 2}", closed_curly_message_regex, linter)
+  expect_lint(
+    "a <- if(1) {\n 1} else {\n 2}",
+    list(
+      closed_curly_message_regex,
+      closed_curly_message_regex
+    ),
+    linter
+  )
 
-  expect_lint("a <- function() {\n}",
-              NULL,
-              linter)
-
-  expect_lint("a <- function() { 1 }",
-              closed_curly_message_regex,
-              linter)
-
-  expect_lint("a <- function() { 1 }",
-              closed_curly_message_regex,
-              linter)
-
-  expect_lint("a <- function() { 1 }",
-              NULL,
-              suppressWarnings(closed_curly_linter(allow_single_line = TRUE)))
-
-  expect_lint("a <- if(1) {\n 1} else {\n 2\n}",
-              closed_curly_message_regex,
-              linter)
-
-  expect_lint("a <- if(1) {\n 1\n} else {\n 2}",
-              closed_curly_message_regex,
-              linter)
-
-  expect_lint("a <- if(1) {\n 1} else {\n 2}",
-              list(
-                closed_curly_message_regex,
-                closed_curly_message_regex
-              ),
-              linter)
-
-  expect_lint("eval(bquote({...}))",
-              NULL,
-              linter)
-
-  expect_lint("fun({\n  statements\n}, param)",
-              NULL,
-              linter)
-
-  expect_lint("out <- lapply(stuff, function(i) {\n  do_something(i)\n}) %>% unlist",
-              NULL,
-              linter)
-
+  # should not generate lints
+  expect_lint("blah", NULL, linter)
+  expect_lint("a <- function() {\n}", NULL, linter)
+  expect_lint("eval(bquote({...}))", NULL, linter)
+  expect_lint("fun({\n  statements\n}, param)", NULL, linter)
+  expect_lint("out <- lapply(stuff, function(i) {\n  do_something(i)\n}) %>% unlist", NULL, linter)
   expect_lint("{{x}}", NULL, linter)
+  expect_lint("a <- function() { 1 }", NULL, suppressWarnings(closed_curly_linter(allow_single_line = TRUE)))
 })

--- a/tests/testthat/test-conjunct_test_linter.R
+++ b/tests/testthat/test-conjunct_test_linter.R
@@ -1,6 +1,6 @@
-linter <- conjunct_test_linter()
-
 test_that("conjunct_test_linter skips allowed usages of expect_true", {
+  linter <- conjunct_test_linter()
+
   expect_lint("expect_true(x)", NULL, linter)
   expect_lint("testthat::expect_true(x, y, z)", NULL, linter)
 
@@ -12,6 +12,8 @@ test_that("conjunct_test_linter skips allowed usages of expect_true", {
 })
 
 test_that("conjunct_test_linter skips allowed usages of expect_true", {
+  linter <- conjunct_test_linter()
+
   expect_lint("expect_false(x)", NULL, linter)
   expect_lint("testthat::expect_false(x, y, z)", NULL, linter)
 
@@ -21,6 +23,8 @@ test_that("conjunct_test_linter skips allowed usages of expect_true", {
 })
 
 test_that("conjunct_test_linter blocks && conditions with expect_true()", {
+  linter <- conjunct_test_linter()
+
   msg <- rex::rex("Instead of expect_true(A && B), write multiple expectations")
 
   expect_lint("expect_true(x && y)", msg, linter)
@@ -28,6 +32,8 @@ test_that("conjunct_test_linter blocks && conditions with expect_true()", {
 })
 
 test_that("conjunct_test_linter blocks || conditions with expect_false()", {
+  linter <- conjunct_test_linter()
+
   msg <- rex::rex("Instead of expect_false(A || B), write multiple expectations")
 
   expect_lint("expect_false(x || y)", msg, linter)
@@ -39,6 +45,8 @@ test_that("conjunct_test_linter blocks || conditions with expect_false()", {
 })
 
 test_that("conjunct_test_linter skips allowed stopifnot() and assert_that() usages", {
+  linter <- conjunct_test_linter()
+
   expect_lint("stopifnot(x)", NULL, linter)
   expect_lint("assert_that(x, y, z)", NULL, linter)
 
@@ -50,6 +58,7 @@ test_that("conjunct_test_linter skips allowed stopifnot() and assert_that() usag
 })
 
 test_that("conjunct_test_linter blocks simple disallowed usages of stopifnot() and assert_that()", {
+  linter <- conjunct_test_linter()
   msg_stopifnot <- rex::rex("Instead of stopifnot(A && B), write multiple conditions")
   msg_assertthat <- rex::rex("Instead of assert_that(A && B), write multiple conditions")
 
@@ -62,6 +71,8 @@ test_that("conjunct_test_linter blocks simple disallowed usages of stopifnot() a
 })
 
 test_that("conjunct_test_linter's allow_named_stopifnot argument works", {
+  linter <- conjunct_test_linter()
+
   # allowed by default
   expect_lint(
     "stopifnot('x must be a logical scalar' = length(x) == 1 && is.logical(x) && !is.na(x))",

--- a/tests/testthat/test-conjunct_test_linter.R
+++ b/tests/testthat/test-conjunct_test_linter.R
@@ -1,99 +1,64 @@
+linter <- conjunct_test_linter()
+
 test_that("conjunct_test_linter skips allowed usages of expect_true", {
-  expect_lint("expect_true(x)", NULL, conjunct_test_linter())
-  expect_lint("testthat::expect_true(x, y, z)", NULL, conjunct_test_linter())
+  expect_lint("expect_true(x)", NULL, linter)
+  expect_lint("testthat::expect_true(x, y, z)", NULL, linter)
 
   # more complicated expression
-  expect_lint("expect_true(x || (y && z))", NULL, conjunct_test_linter())
+  expect_lint("expect_true(x || (y && z))", NULL, linter)
   # the same by operator precedence, though not obvious a priori
-  expect_lint("expect_true(x || y && z)", NULL, conjunct_test_linter())
-  expect_lint("expect_true(x && y || z)", NULL, conjunct_test_linter())
+  expect_lint("expect_true(x || y && z)", NULL, linter)
+  expect_lint("expect_true(x && y || z)", NULL, linter)
 })
 
 test_that("conjunct_test_linter skips allowed usages of expect_true", {
-  expect_lint("expect_false(x)", NULL, conjunct_test_linter())
-  expect_lint("testthat::expect_false(x, y, z)", NULL, conjunct_test_linter())
+  expect_lint("expect_false(x)", NULL, linter)
+  expect_lint("testthat::expect_false(x, y, z)", NULL, linter)
 
   # more complicated expression
   # (NB: xx && yy || zz and xx || yy && zz both parse with || first)
-  expect_lint("expect_false(x && (y || z))", NULL, conjunct_test_linter())
+  expect_lint("expect_false(x && (y || z))", NULL, linter)
 })
 
 test_that("conjunct_test_linter blocks && conditions with expect_true()", {
-  expect_lint(
-    "expect_true(x && y)",
-    rex::rex("Instead of expect_true(A && B), write multiple expectations"),
-    conjunct_test_linter()
-  )
+  msg <- rex::rex("Instead of expect_true(A && B), write multiple expectations")
 
-  expect_lint(
-    "expect_true(x && y && z)",
-    rex::rex("Instead of expect_true(A && B), write multiple expectations"),
-    conjunct_test_linter()
-  )
+  expect_lint("expect_true(x && y)", msg, linter)
+  expect_lint("expect_true(x && y && z)", msg, linter)
 })
 
 test_that("conjunct_test_linter blocks || conditions with expect_false()", {
-  expect_lint(
-    "expect_false(x || y)",
-    rex::rex("Instead of expect_false(A || B), write multiple expectations"),
-    conjunct_test_linter()
-  )
+  msg <- rex::rex("Instead of expect_false(A || B), write multiple expectations")
 
-  expect_lint(
-    "expect_false(x || y || z)",
-    rex::rex("Instead of expect_false(A || B), write multiple expectations"),
-    conjunct_test_linter()
-  )
+  expect_lint("expect_false(x || y)", msg, linter)
+  expect_lint("expect_false(x || y || z)", msg, linter)
 
   # these lint because `||` is always outer by operator precedence
-  expect_lint(
-    "expect_false(x || y && z)",
-    rex::rex("Instead of expect_false(A || B), write multiple expectations"),
-    conjunct_test_linter()
-  )
-  expect_lint(
-    "expect_false(x && y || z)",
-    rex::rex("Instead of expect_false(A || B), write multiple expectations"),
-    conjunct_test_linter()
-  )
+  expect_lint("expect_false(x || y && z)", msg, linter)
+  expect_lint("expect_false(x && y || z)", msg, linter)
 })
 
 test_that("conjunct_test_linter skips allowed stopifnot() and assert_that() usages", {
-  expect_lint("stopifnot(x)", NULL, conjunct_test_linter())
-  expect_lint("assert_that(x, y, z)", NULL, conjunct_test_linter())
+  expect_lint("stopifnot(x)", NULL, linter)
+  expect_lint("assert_that(x, y, z)", NULL, linter)
 
   # more complicated expression
-  expect_lint("stopifnot(x || (y && z))", NULL, conjunct_test_linter())
+  expect_lint("stopifnot(x || (y && z))", NULL, linter)
   # the same by operator precedence, though not obvious a priori
-  expect_lint("stopifnot(x || y && z)", NULL, conjunct_test_linter())
-  expect_lint("assertthat::assert_that(x && y || z)", NULL, conjunct_test_linter())
+  expect_lint("stopifnot(x || y && z)", NULL, linter)
+  expect_lint("assertthat::assert_that(x && y || z)", NULL, linter)
 })
 
 test_that("conjunct_test_linter blocks simple disallowed usages of stopifnot() and assert_that()", {
-  expect_lint(
-    "stopifnot(x && y)",
-    rex::rex("Instead of stopifnot(A && B), write multiple conditions"),
-    conjunct_test_linter()
-  )
+  msg_stopifnot <- rex::rex("Instead of stopifnot(A && B), write multiple conditions")
+  msg_assertthat <- rex::rex("Instead of assert_that(A && B), write multiple conditions")
 
-  expect_lint(
-    "stopifnot(x && y && z)",
-    rex::rex("Instead of stopifnot(A && B), write multiple conditions"),
-    conjunct_test_linter()
-  )
+  expect_lint("stopifnot(x && y)", msg_stopifnot, linter)
+  expect_lint("stopifnot(x && y && z)", msg_stopifnot, linter)
 
   # assert_that() versions
-  expect_lint(
-    "assert_that(x && y)",
-    rex::rex("Instead of assert_that(A && B), write multiple conditions"),
-    conjunct_test_linter()
-  )
-
-  expect_lint(
-    "assertthat::assert_that(x && y && z)",
-    rex::rex("Instead of assert_that(A && B), write multiple conditions"),
-    conjunct_test_linter()
-  )
+  expect_lint("assert_that(x && y)", msg_assertthat, linter)
+  expect_lint("assertthat::assert_that(x && y && z)", msg_assertthat, linter)
 })
 
 test_that("conjunct_test_linter's allow_named_stopifnot argument works", {
@@ -101,7 +66,7 @@ test_that("conjunct_test_linter's allow_named_stopifnot argument works", {
   expect_lint(
     "stopifnot('x must be a logical scalar' = length(x) == 1 && is.logical(x) && !is.na(x))",
     NULL,
-    conjunct_test_linter()
+    linter
   )
   expect_lint(
     "stopifnot('x is a logical scalar' = length(x) == 1 && is.logical(x) && !is.na(x))",

--- a/tests/testthat/test-consecutive_stopifnot_linter.R
+++ b/tests/testthat/test-consecutive_stopifnot_linter.R
@@ -1,9 +1,12 @@
 test_that("consecutive_stopifnot_linter skips allowed usages", {
-  expect_lint("stopifnot(x)", NULL, consecutive_stopifnot_linter())
-  expect_lint("stopifnot(x, y, z)", NULL, consecutive_stopifnot_linter())
+  linter <- consecutive_stopifnot_linter()
+  msg <- rex::rex("Unify consecutive calls to stopifnot().")
+
+  expect_lint("stopifnot(x)", NULL, linter)
+  expect_lint("stopifnot(x, y, z)", NULL, linter)
 
   # intervening expression
-  expect_lint("stopifnot(x); y; stopifnot(z)", NULL, consecutive_stopifnot_linter())
+  expect_lint("stopifnot(x); y; stopifnot(z)", NULL, linter)
 
   # inline or potentially with gaps don't matter
   lines <- trim_some("
@@ -12,46 +15,33 @@ test_that("consecutive_stopifnot_linter skips allowed usages", {
 
     stopifnot(z)
   ")
-  expect_lint(lines, NULL, consecutive_stopifnot_linter())
+  expect_lint(lines, NULL, linter)
 })
 
 test_that("consecutive_stopifnot_linter blocks simple disallowed usages", {
+  linter <- consecutive_stopifnot_linter()
+  msg <- rex::rex("Unify consecutive calls to stopifnot().")
+
   # one test of inline usage
-  expect_lint(
-    "stopifnot(x); stopifnot(y)",
-    rex::rex("Unify consecutive calls to stopifnot()."),
-    consecutive_stopifnot_linter()
-  )
+  expect_lint("stopifnot(x); stopifnot(y)", msg, linter)
 
   lines_gap <- trim_some("
     stopifnot(x)
 
     stopifnot(y, z)
   ")
-  expect_lint(
-    lines_gap,
-    rex::rex("Unify consecutive calls to stopifnot()."),
-    consecutive_stopifnot_linter()
-  )
+  expect_lint(lines_gap, msg, linter)
 
   lines_consecutive <- trim_some("
     stopifnot(x)
     stopifnot(y)
   ")
-  expect_lint(
-    lines_consecutive,
-    rex::rex("Unify consecutive calls to stopifnot()."),
-    consecutive_stopifnot_linter()
-  )
+  expect_lint(lines_consecutive, msg, linter)
 
   lines_comment <- trim_some("
     stopifnot(x)
     # a comment on y
     stopifnot(y)
   ")
-  expect_lint(
-    lines_comment,
-    rex::rex("Unify consecutive calls to stopifnot()."),
-    consecutive_stopifnot_linter()
-  )
+  expect_lint(lines_comment, msg, linter)
 })


### PR DESCRIPTION
- DRY in tests for `consecutive_stopifnot_linter()`
- DRY in tests for `test-conjunct_test_linter()`
- Restructuring `closed_curly_linter()` tests to improve readability and consistency with other test files
