### PR TITLE
GHA workflow `lint-changed-files` fails when a new lint is found in changed files

### DIFF
--- a/.github/workflows/lint-changed-files.yaml
+++ b/.github/workflows/lint-changed-files.yaml
@@ -32,6 +32,7 @@ jobs:
 
       - name: Extract and lint files changed by this PR
         run: |
+          Sys.setenv("LINTR_ERROR_ON_LINT" = TRUE)
           files <- gh::gh("GET https://api.github.com/repos/r-lib/lintr/pulls/${{ github.event.pull_request.number }}/files")
           changed_files <- purrr::map_chr(files, "filename")
           all_files <- list.files(recursive = TRUE)

--- a/tests/testthat/test-closed_curly_linter.R
+++ b/tests/testthat/test-closed_curly_linter.R
@@ -1,5 +1,3 @@
-x = 5 # Just to check if the workflow fails
-
 test_that("returns the correct linting", {
   closed_curly_message_regex <- rex(
     paste(

--- a/tests/testthat/test-closed_curly_linter.R
+++ b/tests/testthat/test-closed_curly_linter.R
@@ -1,3 +1,5 @@
+x = 5 # Just to check if the workflow fails
+
 test_that("returns the correct linting", {
   closed_curly_message_regex <- rex(
     paste(


### PR DESCRIPTION
Closes #1489

This seems to be working: https://github.com/r-lib/lintr/runs/8070424277?check_suite_focus=true