### PR TITLE
Get rid of version label and tooltip

### DIFF
--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -8,8 +8,6 @@ template:
 
 development:
   mode: "auto"
-  version_label: "default"
-  version_tooltip: "Version"
 
 reference:
 - title: Linting


### PR DESCRIPTION
This is the reason why the package version in navigation bar looks so dull:

<img width="292" alt="Screenshot 2022-09-13 at 16 09 16" src="https://user-images.githubusercontent.com/11330453/189923882-7aecbdea-8ea0-4881-8421-fbfef215e957.png">

It's either this, or we add the following to `pkgdown/extra.scss`:

```css
.nav-text.text-default.me-auto {
    color: rgba(0,0,0,0.9) !important;
}
```

I prefer the first solution, which I have implemented in this PR. No strong opinions, though. Happy to also add the aforementioned CSS.