### PR TITLE
`fixed_regex_linter()` doesn't fail with `"\\;"`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # lintr (development version)
 
+## Bug fixes
+
+* `fixed_regex_linter()` no longer fails with regular expression pattern `"\\;"` (#1545, @IndrajeetPatil).
+
 # lintr 3.0.1
 
 * Skip multi-byte tests in non UTF-8 locales (#1504)

--- a/R/fixed_regex_linter.R
+++ b/R/fixed_regex_linter.R
@@ -181,7 +181,7 @@ get_token_replacement <- function(token_content, token_type) {
       token_content
     }
   } else { # char_escape token
-    if (rex::re_matches(token_content, rex::rex("\\", one_of("^${}().*+?|[]\\<>:")))) {
+    if (rex::re_matches(token_content, rex::rex("\\", one_of("^${}().*+?|[]\\<>:;")))) {
       substr(token_content, start = 2L, stop = nchar(token_content))
     } else {
       eval(parse(text = paste0('"', token_content, '"')))

--- a/tests/testthat/test-fixed_regex_linter.R
+++ b/tests/testthat/test-fixed_regex_linter.R
@@ -39,6 +39,7 @@ test_that("fixed_regex_linter blocks simple disallowed usages", {
   expect_lint("gregexpr('a-z', y)", msg, linter)
   expect_lint("regexec('\\\\$', x)", msg, linter)
   expect_lint("grep('\n', x)", msg, linter)
+  expect_lint("grep('\\\\;', x)", msg, linter)
 
   # naming the argument doesn't matter (if it's still used positionally)
   expect_lint("gregexpr(pattern = 'a-z', y)", msg, linter)
@@ -76,6 +77,7 @@ test_that("fixed_regex_linter catches calls to strsplit as well", {
   linter <- fixed_regex_linter()
   msg <- rex::rex("This regular expression is static")
 
+  expect_lint("strsplit('a;b', '\\\\;')", msg, linter)
   expect_lint("strsplit(x, '\\\\.')", msg, linter)
   expect_lint("tstrsplit(x, 'abcdefg')", msg, linter)
   expect_lint("strsplit(x, '[.]')", msg, linter)


### PR DESCRIPTION
Closes #1545

``` r
lintr::lint(
  'strsplit("a;b", split = "\\\\;")\n', 
  lintr::fixed_regex_linter()
)
#> <text>:1:25: warning: [fixed_regex_linter] This regular expression is static, i.e., its matches can be expressed as a fixed substring expression, which is faster to compute. Here, you can use ";" with fixed = TRUE.
#> strsplit("a;b", split = "\\;")
#>                         ^~~~~
```

<sup>Created on 2022-09-21 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>