### PR TITLE
Slightly improve dataset symbol detection

### DIFF
--- a/R/unused_import_linter.R
+++ b/R/unused_import_linter.R
@@ -98,6 +98,8 @@ unused_import_linter <- function(allow_ns_usage = FALSE, except_packages = c("bi
 #' Get dataset names lazy-loaded by imported packages
 #' @noRd
 get_datasets <- function(pkg) {
-  res <- utils::data(package = pkg)
-  as.data.frame(res$results)[["Item"]]
+  results <- utils::data(package = pkg)$results
+  items <- results[, "Item"]
+  # e.g. 'state.abb (state)' in 'datasets'
+  gsub("\\s*\\([^)]*\\)$", "", items)
 }

--- a/tests/testthat/test-unused_import_linter.R
+++ b/tests/testthat/test-unused_import_linter.R
@@ -9,6 +9,7 @@ test_that("unused_import_linter lints as expected", {
   expect_lint("library(magrittr)\n1:3 %>% mean()", NULL, linter)
   # dataset is detected
   expect_lint("library(dplyr)\nstarwars", NULL, linter)
+  expect_lint("library(datasets)\nstate.center", NULL, linter)
 
   # Missing packages are ignored
   expect_lint("library(not.a.package)\ntibble(a = 1)", NULL, linter)


### PR DESCRIPTION
Follow-up to #1549, the `Items` column has a funny format for some objects, per `?data`:

```
Where the datasets have a different name from the
argument that should be used to retrieve them the index will have
an entry like ‘beaver1 (beavers)’ which tells us that dataset
‘beaver1’ can be retrieved by the call ‘data(beaver)’.
```

From experimenting, it looks like `beaver1` is the one we want to allow.