### PR TITLE
Include `expect_*()` linters in `.lintr_new`

### DIFF
--- a/.lintr_new
+++ b/.lintr_new
@@ -1,6 +1,16 @@
 linters: linters_with_defaults(
     implicit_integer_linter(),
     line_length_linter(120),
+    expect_comparison_linter(),
+    expect_identical_linter(),
+    expect_length_linter(),
+    expect_named_linter(),
+    expect_not_linter(),
+    expect_null_linter(),
+    expect_s3_class_linter(),
+    expect_s4_class_linter(),
+    expect_true_false_linter(),
+    expect_type_linter(),
     backport_linter("oldrel-4", except = "R_user_dir")
   )
 exclusions: list(


### PR DESCRIPTION
As discussed here: https://github.com/r-lib/lintr/pull/1548#discussion_r979355818