### PR TITLE
`expect_length_linter()` can handle `expect_true()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -15,6 +15,8 @@
 * `unused_import_linter()` can detect datasets from imported packages and no longer
   warns when a package is imported only for its datasets (#1545, @IndrajeetPatil).
 
+* `expect_length_linter()` requires usage of `expect_length(x, n)` over `expect_true(length(x) == n)` (#1545, @IndrajeetPatil).
+
 ## New and improved features
 
 * New `get_r_string()` helper to get the R-equivalent value of a string, especially useful for R-4-style raw strings.

--- a/R/expect_length_linter.R
+++ b/R/expect_length_linter.R
@@ -9,13 +9,17 @@
 #' @export
 expect_length_linter <- function() {
   xpath <- glue::glue("//expr[
-    expr[1][SYMBOL_FUNCTION_CALL[text() = 'expect_equal' or text() = 'expect_identical' or text() = 'expect_true']]
-    and expr[
-      expr[1][SYMBOL_FUNCTION_CALL[text() = 'length']]
-      and
-      position() = 2 or EQ or preceding-sibling::expr[NUM_CONST]
-    ]
-    and not(SYMBOL_SUB[text() = 'info' or contains(text(), 'label')])
+    expr[1][SYMBOL_FUNCTION_CALL[text() = 'expect_equal' or
+                                 text() = 'expect_identical' or
+                                 text() = 'expect_true']]
+    and
+      expr[
+        (expr[1][SYMBOL_FUNCTION_CALL[text() = 'length']] and position() = 2)
+        or
+        (EQ or preceding-sibling::expr[NUM_CONST])
+      ]
+    and
+      not(SYMBOL_SUB[text() = 'info' or contains(text(), 'label')])
   ]")
 
   Linter(function(source_expression) {

--- a/tests/testthat/test-expect_length_linter.R
+++ b/tests/testthat/test-expect_length_linter.R
@@ -47,3 +47,11 @@ test_that("expect_length_linter blocks expect_identical usage as well", {
     expect_length_linter()
   )
 })
+
+test_that("expect_length_linter blocks expect_true usage as well", {
+  expect_lint(
+    "expect_true(length(x) == 1L)",
+    rex::rex("expect_length(x, n) is better than expect_true(length(x) == n)"),
+    expect_length_linter()
+  )
+})

--- a/tests/testthat/test-expect_length_linter.R
+++ b/tests/testthat/test-expect_length_linter.R
@@ -55,3 +55,8 @@ test_that("expect_length_linter blocks expect_true usage as well", {
     expect_length_linter()
   )
 })
+
+test_that("expect_length_linter doesn't block valid expect_identical and expect_true usages", {
+  expect_lint("expect_true(1 == 1)", NULL, expect_length_linter())
+  expect_lint("expect_identical(1, 1)", NULL, expect_length_linter())
+})


### PR DESCRIPTION
``` r
library(lintr)

lint(
  text = "expect_true(length(x) == 1L)",
  linters = expect_length_linter()
)
#> <text>:1:1: warning: [expect_length_linter] expect_length(x, n) is better than expect_true(length(x) == n)
#> expect_true(length(x) == 1L)
#> ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

<sup>Created on 2022-09-28 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>