### PR TITLE
Examples for ?expect_lint too wide for R CMD check

### DIFF
--- a/R/expect_lint.R
+++ b/R/expect_lint.R
@@ -32,7 +32,10 @@
 #' expect_lint("a\n\n", list("superfluous", "superfluous"), trailing_blank_lines_linter)
 #' expect_lint(
 #'   "a\n\n",
-#'   list(list(message = "superfluous", line_number = 2), list(message = "superfluous", line_number = 3)),
+#'   list(
+#'     list(message = "superfluous", line_number = 2),
+#'     list(message = "superfluous", line_number = 3)
+#'   ),
 #'   trailing_blank_lines_linter()
 #' )
 #' @export

--- a/man/expect_lint.Rd
+++ b/man/expect_lint.Rd
@@ -47,7 +47,10 @@ expect_lint("a\n", list(message = "superfluous", line_number = 2), trailing_blan
 expect_lint("a\n\n", list("superfluous", "superfluous"), trailing_blank_lines_linter)
 expect_lint(
   "a\n\n",
-  list(list(message = "superfluous", line_number = 2), list(message = "superfluous", line_number = 3)),
+  list(
+    list(message = "superfluous", line_number = 2),
+    list(message = "superfluous", line_number = 3)
+  ),
   trailing_blank_lines_linter()
 )
 }


### PR DESCRIPTION
We're currently getting a NOTE because of width>100 characters in examples