### PR TITLE
More XPaths avoiding //expr

### DIFF
--- a/R/condition_message_linter.R
+++ b/R/condition_message_linter.R
@@ -10,13 +10,15 @@
 #' @export
 condition_message_linter <- function() {
   translators <- c("packageStartupMessage", "message", "warning", "stop")
-  xpath <- glue::glue("//expr[
-    expr[1][SYMBOL_FUNCTION_CALL[ {xp_text_in_table(translators)} ]]
-    and expr[
-      expr[1][SYMBOL_FUNCTION_CALL[text() = 'paste' or text() = 'paste0']]
-      and not(SYMBOL_SUB[text() = 'collapse'])
-    ]
-  ]")
+  xpath <- glue::glue("
+  //SYMBOL_FUNCTION_CALL[ {xp_text_in_table(translators)} ]
+  /parent::expr
+  /following-sibling::expr[
+    expr[1][SYMBOL_FUNCTION_CALL[text() = 'paste' or text() = 'paste0']]
+    and not(SYMBOL_SUB[text() = 'collapse'])
+  ]
+  /parent::expr
+  ")
 
   Linter(function(source_expression) {
     if (!is_lint_level(source_expression, "expression")) {

--- a/R/consecutive_stopifnot_linter.R
+++ b/R/consecutive_stopifnot_linter.R
@@ -9,9 +9,11 @@
 consecutive_stopifnot_linter <- function() {
   # match on the expr, not the SYMBOL_FUNCTION_CALL, to ensure
   #   namespace-qualified calls only match if the namespaces do.
-  xpath <- glue::glue("//expr[
-    expr[1][SYMBOL_FUNCTION_CALL[text() = 'stopifnot']] = following-sibling::expr[1]/expr
-  ]")
+  xpath <- "
+  //SYMBOL_FUNCTION_CALL[text() = 'stopifnot']
+  /parent::expr
+  /parent::expr[expr[1] = following-sibling::expr[1]/expr]
+  "
 
   Linter(function(source_expression) {
     # need the full file to also catch usages at the top level

--- a/R/equals_na_linter.R
+++ b/R/equals_na_linter.R
@@ -6,12 +6,13 @@
 #' @seealso [linters] for a complete list of linters available in lintr.
 #' @export
 equals_na_linter <- function() {
-  comparators <- c("EQ", "NE")
-  comparator_table <- paste0("self::", comparators, collapse = " or ")
   na_table <- xp_text_in_table(c("NA", "NA_integer_", "NA_real_", "NA_complex_", "NA_character_"))
 
-  xpath_fmt <- "//expr[expr[NUM_CONST[%s]]]/*[%s]"
-  xpath <- sprintf(xpath_fmt, na_table, comparator_table)
+  xpath <- glue::glue("
+  //NUM_CONST[ {na_table} ]
+  /parent::expr
+  /parent::expr[EQ or NE]
+  ")
 
   Linter(function(source_expression) {
     if (!is_lint_level(source_expression, "expression")) {

--- a/R/function_left_parentheses_linter.R
+++ b/R/function_left_parentheses_linter.R
@@ -12,7 +12,7 @@
 function_left_parentheses_linter <- function() { # nolint: object_length.
   xpath <- "
     //FUNCTION[@col2 != following-sibling::OP-LEFT-PAREN/@col1 - 1] |
-    //expr[1][SYMBOL_FUNCTION_CALL and @col2 != following-sibling::OP-LEFT-PAREN/@col1 - 1]
+    //SYMBOL_FUNCTION_CALL/parent::expr[@col2 != following-sibling::OP-LEFT-PAREN/@col1 - 1]
   "
 
   Linter(function(source_expression) {

--- a/R/ifelse_censor_linter.R
+++ b/R/ifelse_censor_linter.R
@@ -12,14 +12,16 @@
 #' @seealso [linters] for a complete list of linters available in lintr.
 #' @export
 ifelse_censor_linter <- function() {
-  xpath <- glue::glue("//expr[
-    expr[1][SYMBOL_FUNCTION_CALL[ {xp_text_in_table(ifelse_funs)} ]]
-    and expr[2][
-      (LT or GT or LE or GE)
-      and expr[1] = following-sibling::expr
-      and expr[2] = following-sibling::expr
-    ]
-  ]")
+  xpath <- glue::glue("
+  //SYMBOL_FUNCTION_CALL[ {xp_text_in_table(ifelse_funs)} ]
+  /parent::expr
+  /following-sibling::expr[
+    (LT or GT or LE or GE)
+    and expr[1] = following-sibling::expr
+    and expr[2] = following-sibling::expr
+  ]
+  /parent::expr
+  ")
 
   Linter(function(source_expression) {
     if (!is_lint_level(source_expression, "expression")) {

--- a/R/nested_ifelse_linter.R
+++ b/R/nested_ifelse_linter.R
@@ -17,9 +17,11 @@
 #' @seealso [linters] for a complete list of linters available in lintr.
 #' @export
 nested_ifelse_linter <- function() {
+  # NB: land on the nested (inner) call, not the outer call, and throw a lint with the inner call's name
   xpath <- glue::glue("
-  //expr[expr[1][SYMBOL_FUNCTION_CALL[ {xp_text_in_table(ifelse_funs)} ]]]
-  /expr[expr[1][SYMBOL_FUNCTION_CALL[ {xp_text_in_table(ifelse_funs)} ]]]
+  //SYMBOL_FUNCTION_CALL[ {xp_text_in_table(ifelse_funs)}]
+  /parent::expr
+  /following-sibling::expr[expr[1][SYMBOL_FUNCTION_CALL[ {xp_text_in_table(ifelse_funs)} ]]]
   ")
 
   Linter(function(source_expression) {

--- a/R/seq_linter.R
+++ b/R/seq_linter.R
@@ -13,30 +13,28 @@
 #' @seealso [linters] for a complete list of linters available in lintr.
 #' @export
 seq_linter <- function() {
-  bad_funcs <- c("length", "n", "nrow", "ncol", "NROW", "NCOL", "dim")
+  bad_funcs <- xp_text_in_table(c("length", "n", "nrow", "ncol", "NROW", "NCOL", "dim"))
 
   # Exact `xpath` depends on whether bad function was used in conjunction with `seq()`
-  bad_func_xpath_with_seq <- glue::glue(
-    "expr[1][SYMBOL_FUNCTION_CALL[text() = 'seq']]
-    /following::expr[1]
-    /expr[SYMBOL_FUNCTION_CALL[ {xp_text_in_table(bad_funcs)} ]]"
-  )
-  bad_func_xpath_without_seq <- glue::glue(
-    "expr[expr[(expr|self::*)[SYMBOL_FUNCTION_CALL[ {xp_text_in_table(bad_funcs)} ]]]]"
-  )
-
+  seq_xpath <- glue::glue("
+  //SYMBOL_FUNCTION_CALL[text() = 'seq']
+  /parent::expr
+  /following-sibling::expr[1][expr/SYMBOL_FUNCTION_CALL[ {bad_funcs} ]]
+  /parent::expr[count(expr) = 2]
+  ")
   # `.N` from {data.table} is special since it's not a function but a symbol
-  xpath <- glue::glue("//expr[
-    (
-      {bad_func_xpath_with_seq}
-      and count(expr) = 2
-    ) or
-    (
+  colon_xpath <- glue::glue("
+    //OP-COLON
+    /parent::expr[
       expr[NUM_CONST[text() = '1' or text() = '1L']]
-      and OP-COLON
-      and ( {bad_func_xpath_without_seq} or expr[SYMBOL = '.N'] )
-    )
-  ]")
+      and (
+        expr[expr[(expr|self::*)[SYMBOL_FUNCTION_CALL[ {bad_funcs} ]]]]
+        or expr[SYMBOL = '.N']
+      )
+    ]
+  ")
+
+  xpath <- paste(seq_xpath, "|", colon_xpath)
 
   ## The actual order of the nodes is document order
   ## In practice we need to handle length(x):1

--- a/R/unneeded_concatenation_linter.R
+++ b/R/unneeded_concatenation_linter.R
@@ -39,9 +39,10 @@ unneeded_concatenation_linter <- function(allow_single_expression = TRUE) {
     ]
   "
   xpath_call <- glue::glue("
-    //expr[
-      expr[1][SYMBOL_FUNCTION_CALL[text() = 'c']]
-      and not(EQ_SUB)
+    //SYMBOL_FUNCTION_CALL[text() = 'c']
+    /parent::expr
+    /parent::expr[
+      not(EQ_SUB)
       and (
         (
           count(expr) = 2

--- a/tests/testthat/test-equals_na_linter.R
+++ b/tests/testthat/test-equals_na_linter.R
@@ -8,13 +8,13 @@ test_that("returns the correct linting", {
 
   expect_lint(
     "x == NA",
-    list(message = msg, line_number = 1L, column_number = 3L),
+    list(message = msg, line_number = 1L, column_number = 1L),
     linter
   )
 
   expect_lint(
     "x==NA",
-    list(message = msg, line_number = 1L, column_number = 2L),
+    list(message = msg, line_number = 1L, column_number = 1L),
     linter
   )
 
@@ -39,7 +39,7 @@ test_that("returns the correct linting", {
   # correct line number for multiline code
   expect_lint(
     "x ==\nNA",
-    list(line_number = 1L, column_number = 3L, ranges = list(3L:4L)),
+    list(line_number = 1L, column_number = 1L, ranges = list(c(1L, 4L))),
     linter
   )
 })


### PR DESCRIPTION
Part of #1358 

This one also has a substantive change -- in `equals_na_linter()`, previously we anchored to the `==` or `!=` in the lint metadata. That's a bit inconsistent with where we anchor in other linters, so I moved it to land on the parent expression instead. That means editing a few tests as well.