### PR TITLE
switch to using a hanging indent for extended XPaths

### DIFF
--- a/R/T_and_F_symbol_linter.R
+++ b/R/T_and_F_symbol_linter.R
@@ -33,25 +33,25 @@
 T_and_F_symbol_linter <- function() { # nolint: object_name.
   xpath <- paste0(
     "//SYMBOL[",
-    "(text() = 'T' or text() = 'F')", # T or F symbol
-    " and not(preceding-sibling::OP-DOLLAR)", # not part of a $-subset expression
-    " and not(parent::expr[",
-    "  following-sibling::LEFT_ASSIGN", # not target of left assignment
-    "  or preceding-sibling::RIGHT_ASSIGN", # not target of right assignment
-    "  or following-sibling::EQ_ASSIGN", # not target of equals assignment
-    "])",
+    "  (text() = 'T' or text() = 'F')", # T or F symbol
+    "  and not(preceding-sibling::OP-DOLLAR)", # not part of a $-subset expression
+    "  and not(parent::expr[",
+    "    following-sibling::LEFT_ASSIGN", # not target of left assignment
+    "    or preceding-sibling::RIGHT_ASSIGN", # not target of right assignment
+    "    or following-sibling::EQ_ASSIGN", # not target of equals assignment
+    "  ])",
     "]"
   )
 
   xpath_assignment <- paste0(
     "//SYMBOL[",
-    "(text() = 'T' or text() = 'F')", # T or F symbol
-    " and not(preceding-sibling::OP-DOLLAR)", # not part of a $-subset expression
-    " and parent::expr[", #, but ...
-    "  following-sibling::LEFT_ASSIGN", # target of left assignment
-    "  or preceding-sibling::RIGHT_ASSIGN", # target of right assignment
-    "  or following-sibling::EQ_ASSIGN", # target of equals assignment
-    " ]",
+    "  (text() = 'T' or text() = 'F')", # T or F symbol
+    "  and not(preceding-sibling::OP-DOLLAR)", # not part of a $-subset expression
+    "  and parent::expr[", #, but ...
+    "    following-sibling::LEFT_ASSIGN", # target of left assignment
+    "    or preceding-sibling::RIGHT_ASSIGN", # target of right assignment
+    "    or following-sibling::EQ_ASSIGN", # target of equals assignment
+    "  ]",
     "]"
   )
 

--- a/R/any_duplicated_linter.R
+++ b/R/any_duplicated_linter.R
@@ -36,12 +36,13 @@
 any_duplicated_linter <- function() {
   any_duplicated_xpath <- "
   //SYMBOL_FUNCTION_CALL[text() = 'any']
-  /parent::expr
-  /following-sibling::expr[1][expr[1][SYMBOL_FUNCTION_CALL[text() = 'duplicated']]]
-  /parent::expr[
-    count(expr) = 2
-    or (count(expr) = 3 and SYMBOL_SUB[text() = 'na.rm'])
-  ]"
+    /parent::expr
+    /following-sibling::expr[1][expr[1][SYMBOL_FUNCTION_CALL[text() = 'duplicated']]]
+    /parent::expr[
+      count(expr) = 2
+      or (count(expr) = 3 and SYMBOL_SUB[text() = 'na.rm'])
+    ]
+  "
 
   # outline:
   #   EQ/NE/GT/LT: ensure we're in a comparison clause
@@ -55,30 +56,31 @@ any_duplicated_linter <- function() {
   #  assumes we are before EQ, preceding-sibling assumes we are after EQ.
   length_unique_xpath_parts <- glue::glue("
   //{ c('EQ', 'NE', 'GT', 'LT') }
-  /parent::expr
-  /expr[
-    expr[1][SYMBOL_FUNCTION_CALL[text() = 'length']]
-    and expr[expr[1][
-      SYMBOL_FUNCTION_CALL[text() = 'unique']
-      and (
-        following-sibling::expr =
-          parent::expr
-          /parent::expr
-          /parent::expr
-          /expr
-          /expr[1][SYMBOL_FUNCTION_CALL[text()= 'length']]
-          /following-sibling::expr
-        or
-        following-sibling::expr[OP-DOLLAR or LBB]/expr[1] =
-          parent::expr
-          /parent::expr
-          /parent::expr
-          /expr
-          /expr[1][SYMBOL_FUNCTION_CALL[text()= 'nrow']]
-          /following-sibling::expr
-      )
-    ]]
-  ]")
+    /parent::expr
+    /expr[
+      expr[1][SYMBOL_FUNCTION_CALL[text() = 'length']]
+      and expr[expr[1][
+        SYMBOL_FUNCTION_CALL[text() = 'unique']
+        and (
+          following-sibling::expr =
+            parent::expr
+            /parent::expr
+            /parent::expr
+            /expr
+            /expr[1][SYMBOL_FUNCTION_CALL[text()= 'length']]
+            /following-sibling::expr
+          or
+          following-sibling::expr[OP-DOLLAR or LBB]/expr[1] =
+            parent::expr
+            /parent::expr
+            /parent::expr
+            /expr
+            /expr[1][SYMBOL_FUNCTION_CALL[text()= 'nrow']]
+            /following-sibling::expr
+        )
+      ]]
+    ]
+  ")
   length_unique_xpath <- paste(length_unique_xpath_parts, collapse = " | ")
 
   uses_nrow_xpath <- "./parent::expr/expr/expr[1]/SYMBOL_FUNCTION_CALL[text() = 'nrow']"

--- a/R/any_is_na_linter.R
+++ b/R/any_is_na_linter.R
@@ -38,12 +38,13 @@
 any_is_na_linter <- function() {
   xpath <- "
   //SYMBOL_FUNCTION_CALL[text() = 'any']
-  /parent::expr
-  /following-sibling::expr[1][expr[1][SYMBOL_FUNCTION_CALL[text() = 'is.na']]]
-  /parent::expr[
-    count(expr) = 2
-    or (count(expr) = 3 and SYMBOL_SUB[text() = 'na.rm'])
-  ]"
+    /parent::expr
+    /following-sibling::expr[1][expr[1][SYMBOL_FUNCTION_CALL[text() = 'is.na']]]
+    /parent::expr[
+      count(expr) = 2
+      or (count(expr) = 3 and SYMBOL_SUB[text() = 'na.rm'])
+    ]
+  "
 
   Linter(function(source_expression) {
     if (!is_lint_level(source_expression, "expression")) {

--- a/R/boolean_arithmetic_linter.R
+++ b/R/boolean_arithmetic_linter.R
@@ -32,12 +32,10 @@
 boolean_arithmetic_linter <- function() {
   # TODO(#1580): sum() cases x %in% y, A [&|] B, !A, is.na/is.nan/is.finite/is.infinite/is.element
   # TODO(#1581): extend to include all()-alike expressions
-  zero_expr <-
-    "(EQ or NE or GT or LE) and expr[NUM_CONST[text() = '0' or text() = '0L']]"
-  one_expr <-
-    "(LT or GE) and expr[NUM_CONST[text() = '1' or text() = '1L']]"
+  zero_expr <- "(EQ or NE or GT or LE) and expr[NUM_CONST[text() = '0' or text() = '0L']]"
+  one_expr <- "(LT or GE) and expr[NUM_CONST[text() = '1' or text() = '1L']]"
   length_xpath <- glue::glue("
-    //SYMBOL_FUNCTION_CALL[text() = 'which' or text() = 'grep']
+  //SYMBOL_FUNCTION_CALL[text() = 'which' or text() = 'grep']
     /parent::expr
     /parent::expr
     /parent::expr[
@@ -46,7 +44,7 @@ boolean_arithmetic_linter <- function() {
     ]
   ")
   sum_xpath <- glue::glue("
-    //SYMBOL_FUNCTION_CALL[text() = 'sum']
+  //SYMBOL_FUNCTION_CALL[text() = 'sum']
     /parent::expr
     /parent::expr[
       expr[

--- a/R/brace_linter.R
+++ b/R/brace_linter.R
@@ -130,7 +130,8 @@ brace_linter <- function(allow_single_line = FALSE) {
   xp_if_else_match_brace <- "
   //IF[
     following-sibling::expr[2][OP-LEFT-BRACE]
-    and following-sibling::ELSE
+    and
+      following-sibling::ELSE
         /following-sibling::expr[1][not(OP-LEFT-BRACE or IF/following-sibling::expr[2][OP-LEFT-BRACE])]
   ]
 

--- a/R/class_equals_linter.R
+++ b/R/class_equals_linter.R
@@ -36,12 +36,13 @@
 class_equals_linter <- function() {
   xpath <- "
   //SYMBOL_FUNCTION_CALL[text() = 'class']
-  /parent::expr
-  /parent::expr
-  /parent::expr[
-    not(preceding-sibling::OP-LEFT-BRACKET)
-    and (EQ or NE or SPECIAL[text() = '%in%'])
-  ]"
+    /parent::expr
+    /parent::expr
+    /parent::expr[
+      not(preceding-sibling::OP-LEFT-BRACKET)
+      and (EQ or NE or SPECIAL[text() = '%in%'])
+    ]
+  "
 
   Linter(function(source_expression) {
     if (!is_lint_level(source_expression, "expression")) {

--- a/R/condition_message_linter.R
+++ b/R/condition_message_linter.R
@@ -44,12 +44,12 @@ condition_message_linter <- function() {
   translators <- c("packageStartupMessage", "message", "warning", "stop")
   xpath <- glue::glue("
   //SYMBOL_FUNCTION_CALL[ {xp_text_in_table(translators)} ]
-  /parent::expr
-  /following-sibling::expr[
-    expr[1][SYMBOL_FUNCTION_CALL[text() = 'paste' or text() = 'paste0']]
-    and not(SYMBOL_SUB[text() = 'collapse'])
-  ]
-  /parent::expr
+    /parent::expr
+    /following-sibling::expr[
+      expr[1][SYMBOL_FUNCTION_CALL[text() = 'paste' or text() = 'paste0']]
+      and not(SYMBOL_SUB[text() = 'collapse'])
+    ]
+    /parent::expr
   ")
 
   Linter(function(source_expression) {

--- a/R/consecutive_stopifnot_linter.R
+++ b/R/consecutive_stopifnot_linter.R
@@ -24,8 +24,8 @@ consecutive_stopifnot_linter <- function() {
   #   namespace-qualified calls only match if the namespaces do.
   xpath <- "
   //SYMBOL_FUNCTION_CALL[text() = 'stopifnot']
-  /parent::expr
-  /parent::expr[expr[1] = following-sibling::expr[1]/expr]
+    /parent::expr
+    /parent::expr[expr[1] = following-sibling::expr[1]/expr]
   "
 
   Linter(function(source_expression) {

--- a/R/equals_na_linter.R
+++ b/R/equals_na_linter.R
@@ -10,8 +10,8 @@ equals_na_linter <- function() {
 
   xpath <- glue::glue("
   //NUM_CONST[ {na_table} ]
-  /parent::expr
-  /parent::expr[EQ or NE]
+    /parent::expr
+    /parent::expr[EQ or NE]
   ")
 
   Linter(function(source_expression) {

--- a/R/expect_comparison_linter.R
+++ b/R/expect_comparison_linter.R
@@ -14,9 +14,9 @@ expect_comparison_linter <- function() {
   comparator_nodes <- setdiff(as.list(infix_metadata$xml_tag[infix_metadata$comparator]), "NE")
   xpath <- glue::glue("
   //SYMBOL_FUNCTION_CALL[text() = 'expect_true']
-  /parent::expr
-  /following-sibling::expr[ {xp_or(comparator_nodes)} ]
-  /parent::expr[not(SYMBOL_SUB[text() = 'info'])]
+    /parent::expr
+    /following-sibling::expr[ {xp_or(comparator_nodes)} ]
+    /parent::expr[not(SYMBOL_SUB[text() = 'info'])]
   ")
 
   comparator_expectation_map <- c(

--- a/R/expect_identical_linter.R
+++ b/R/expect_identical_linter.R
@@ -34,22 +34,22 @@ expect_identical_linter <- function() {
   #   - skip calls using dots (`...`); see tests
   expect_equal_xpath <- "
   //SYMBOL_FUNCTION_CALL[text() = 'expect_equal']
-  /parent::expr[not(
-    following-sibling::EQ_SUB
-    or following-sibling::expr[
-      expr[1][SYMBOL_FUNCTION_CALL[text() = 'c']]
-      and expr[NUM_CONST[contains(text(), '.')]]
-    ]
-    or following-sibling::expr[NUM_CONST[contains(text(), '.')]]
-    or following-sibling::expr[SYMBOL[text() = '...']]
-  )]
-  /parent::expr
+    /parent::expr[not(
+      following-sibling::EQ_SUB
+      or following-sibling::expr[
+        expr[1][SYMBOL_FUNCTION_CALL[text() = 'c']]
+        and expr[NUM_CONST[contains(text(), '.')]]
+      ]
+      or following-sibling::expr[NUM_CONST[contains(text(), '.')]]
+      or following-sibling::expr[SYMBOL[text() = '...']]
+    )]
+    /parent::expr
   "
   expect_true_xpath <- "
   //SYMBOL_FUNCTION_CALL[text() = 'expect_true']
-  /parent::expr
-  /following-sibling::expr[1][expr[1]/SYMBOL_FUNCTION_CALL[text() = 'identical']]
-  /parent::expr
+    /parent::expr
+    /following-sibling::expr[1][expr[1]/SYMBOL_FUNCTION_CALL[text() = 'identical']]
+    /parent::expr
   "
   xpath <- paste(expect_equal_xpath, "|", expect_true_xpath)
 

--- a/R/expect_length_linter.R
+++ b/R/expect_length_linter.R
@@ -11,12 +11,12 @@ expect_length_linter <- function() {
   # TODO(michaelchirico): also catch expect_true(length(x) == 1)
   xpath <- sprintf("
   //SYMBOL_FUNCTION_CALL[text() = 'expect_equal' or text() = 'expect_identical']
-  /parent::expr
-  /following-sibling::expr[
-    expr[1][SYMBOL_FUNCTION_CALL[text() = 'length']]
-    and (position() = 1 or preceding-sibling::expr[NUM_CONST])
-  ]
-  /parent::expr[not(SYMBOL_SUB[text() = 'info' or contains(text(), 'label')])]
+    /parent::expr
+    /following-sibling::expr[
+      expr[1][SYMBOL_FUNCTION_CALL[text() = 'length']]
+      and (position() = 1 or preceding-sibling::expr[NUM_CONST])
+    ]
+    /parent::expr[not(SYMBOL_SUB[text() = 'info' or contains(text(), 'label')])]
   ")
 
   Linter(function(source_expression) {

--- a/R/expect_named_linter.R
+++ b/R/expect_named_linter.R
@@ -10,12 +10,12 @@
 expect_named_linter <- function() {
   xpath <- "
   //SYMBOL_FUNCTION_CALL[text() = 'expect_equal' or text() = 'expect_identical']
-  /parent::expr
-  /following-sibling::expr[
-    expr[1][SYMBOL_FUNCTION_CALL[text() = 'names']]
-    and (position() = 1 or preceding-sibling::expr[STR_CONST])
-  ]
-  /parent::expr
+    /parent::expr
+    /following-sibling::expr[
+      expr[1][SYMBOL_FUNCTION_CALL[text() = 'names']]
+      and (position() = 1 or preceding-sibling::expr[STR_CONST])
+    ]
+    /parent::expr
   "
 
   Linter(function(source_expression) {

--- a/R/expect_not_linter.R
+++ b/R/expect_not_linter.R
@@ -12,9 +12,9 @@
 expect_not_linter <- function() {
   xpath <- "
   //SYMBOL_FUNCTION_CALL[text() = 'expect_true' or text() = 'expect_false']
-  /parent::expr
-  /following-sibling::expr[OP-EXCLAMATION]
-  /parent::expr
+    /parent::expr
+    /following-sibling::expr[OP-EXCLAMATION]
+    /parent::expr
   "
 
   Linter(function(source_expression) {

--- a/R/expect_null_linter.R
+++ b/R/expect_null_linter.R
@@ -17,15 +17,15 @@ expect_null_linter <- function() {
   #  (2) expect_true(is.null(x))
   expect_equal_identical_xpath <- "
   //SYMBOL_FUNCTION_CALL[text() = 'expect_equal' or text() = 'expect_identical']
-  /parent::expr
-  /following-sibling::expr[position() <= 2 and NULL_CONST]
-  /parent::expr
+    /parent::expr
+    /following-sibling::expr[position() <= 2 and NULL_CONST]
+    /parent::expr
   "
   expect_true_xpath <- "
   //SYMBOL_FUNCTION_CALL[text() = 'expect_true']
-  /parent::expr
-  /following-sibling::expr[1][expr[1]/SYMBOL_FUNCTION_CALL[text() = 'is.null']]
-  /parent::expr
+    /parent::expr
+    /following-sibling::expr[1][expr[1]/SYMBOL_FUNCTION_CALL[text() = 'is.null']]
+    /parent::expr
   "
   xpath <- paste(expect_equal_identical_xpath, "|", expect_true_xpath)
 

--- a/R/expect_s3_class_linter.R
+++ b/R/expect_s3_class_linter.R
@@ -13,19 +13,19 @@ expect_s3_class_linter <- function() {
   # (2) expect_true(is.<class>(x)) and expect_true(inherits(x, C))
   expect_equal_identical_xpath <- "
   //SYMBOL_FUNCTION_CALL[text() = 'expect_equal' or text() = 'expect_identical']
-  /parent::expr
-  /following-sibling::expr[
-    expr[1][SYMBOL_FUNCTION_CALL[text() = 'class']]
-    and (position() = 1 or preceding-sibling::expr[STR_CONST])
-  ]
-  /parent::expr[not(SYMBOL_SUB[text() = 'info' or text() = 'label' or text() = 'expected.label'])]
+    /parent::expr
+    /following-sibling::expr[
+      expr[1][SYMBOL_FUNCTION_CALL[text() = 'class']]
+      and (position() = 1 or preceding-sibling::expr[STR_CONST])
+    ]
+    /parent::expr[not(SYMBOL_SUB[text() = 'info' or text() = 'label' or text() = 'expected.label'])]
   "
   is_class_call <- xp_text_in_table(c(is_s3_class_calls, "inherits"))
   expect_true_xpath <- glue::glue("
   //SYMBOL_FUNCTION_CALL[text() = 'expect_true']
-  /parent::expr
-  /following-sibling::expr[1][expr[1][SYMBOL_FUNCTION_CALL[ {is_class_call} ]]]
-  /parent::expr[not(SYMBOL_SUB[text() = 'info' or text() = 'label'])]
+    /parent::expr
+    /following-sibling::expr[1][expr[1][SYMBOL_FUNCTION_CALL[ {is_class_call} ]]]
+    /parent::expr[not(SYMBOL_SUB[text() = 'info' or text() = 'label'])]
   ")
   xpath <- paste(expect_equal_identical_xpath, "|", expect_true_xpath)
 
@@ -82,9 +82,9 @@ expect_s4_class_linter <- function() {
   #   though the character output wouldn't make any sense for expect_true().
   xpath <- "
   //SYMBOL_FUNCTION_CALL[text() = 'expect_true']
-  /parent::expr
-  /following-sibling::expr[1][count(expr) = 3 and expr[1][SYMBOL_FUNCTION_CALL[text() = 'is']]]
-  /parent::expr[not(SYMBOL_SUB[text() = 'info' or text() = 'label'])]
+    /parent::expr
+    /following-sibling::expr[1][count(expr) = 3 and expr[1][SYMBOL_FUNCTION_CALL[text() = 'is']]]
+    /parent::expr[not(SYMBOL_SUB[text() = 'info' or text() = 'label'])]
   "
 
   Linter(function(source_expression) {

--- a/R/expect_true_false_linter.R
+++ b/R/expect_true_false_linter.R
@@ -11,9 +11,9 @@
 expect_true_false_linter <- function() {
   xpath <- "
   //SYMBOL_FUNCTION_CALL[text() = 'expect_equal' or text() = 'expect_identical']
-  /parent::expr
-  /following-sibling::expr[position() <= 2 and NUM_CONST[text() = 'TRUE' or text() = 'FALSE']]
-  /parent::expr
+    /parent::expr
+    /following-sibling::expr[position() <= 2 and NUM_CONST[text() = 'TRUE' or text() = 'FALSE']]
+    /parent::expr
   "
 
   Linter(function(source_expression) {

--- a/R/expect_type_linter.R
+++ b/R/expect_type_linter.R
@@ -12,18 +12,18 @@ expect_type_linter <- function() {
   base_type_tests <- xp_text_in_table(paste0("is.", base_types))
   expect_equal_identical_xpath <- "
   //SYMBOL_FUNCTION_CALL[text() = 'expect_equal' or text() = 'expect_identical']
-  /parent::expr
-  /following-sibling::expr[
-    expr[1][SYMBOL_FUNCTION_CALL[text() = 'typeof']]
-    and (position() = 1 or preceding-sibling::expr[STR_CONST])
-  ]
-  /parent::expr[not(SYMBOL_SUB[text() = 'info' or text() = 'label' or text() = 'expected.label'])]
+    /parent::expr
+    /following-sibling::expr[
+      expr[1][SYMBOL_FUNCTION_CALL[text() = 'typeof']]
+      and (position() = 1 or preceding-sibling::expr[STR_CONST])
+    ]
+    /parent::expr[not(SYMBOL_SUB[text() = 'info' or text() = 'label' or text() = 'expected.label'])]
   "
   expect_true_xpath <- glue::glue("
   //SYMBOL_FUNCTION_CALL[text() = 'expect_true']
-  /parent::expr
-  /following-sibling::expr[1][expr[1][SYMBOL_FUNCTION_CALL[ {base_type_tests} ]]]
-  /parent::expr[not(SYMBOL_SUB[text() = 'info' or text() = 'label'])]
+    /parent::expr
+    /following-sibling::expr[1][expr[1][SYMBOL_FUNCTION_CALL[ {base_type_tests} ]]]
+    /parent::expr[not(SYMBOL_SUB[text() = 'info' or text() = 'label'])]
   ")
   xpath <- paste(expect_equal_identical_xpath, "|", expect_true_xpath)
 

--- a/R/extraction_operator_linter.R
+++ b/R/extraction_operator_linter.R
@@ -53,11 +53,12 @@
 extraction_operator_linter <- function() {
   constant_nodes_in_brackets <- paste0("self::", c("expr", "OP-PLUS", "NUM_CONST", "STR_CONST"))
   xpath <- glue::glue("
-    //OP-DOLLAR[not(preceding-sibling::expr[1]/SYMBOL[text() = 'self' or text() = '.self'])] |
-    //OP-LEFT-BRACKET[
-      not(following-sibling::expr[1]/descendant::*[not({xp_or(constant_nodes_in_brackets)})]) and
-      not(following-sibling::OP-COMMA)
-    ]
+  //OP-DOLLAR[not(preceding-sibling::expr[1]/SYMBOL[text() = 'self' or text() = '.self'])]
+  |
+  //OP-LEFT-BRACKET[
+    not(following-sibling::expr[1]/descendant::*[not({xp_or(constant_nodes_in_brackets)})]) and
+    not(following-sibling::OP-COMMA)
+  ]
   ")
 
   Linter(function(source_expression) {

--- a/R/fixed_regex_linter.R
+++ b/R/fixed_regex_linter.R
@@ -36,22 +36,22 @@ fixed_regex_linter <- function() {
   # NB: we intentionally exclude cases like gsub(x, c("a" = "b")), where "b" is fixed
   xpath <- glue::glue("
   //SYMBOL_FUNCTION_CALL[ {pos_1_regex_funs} ]
-  /parent::expr[
-    not(following-sibling::SYMBOL_SUB[
-      (text() = 'fixed' or text() = 'ignore.case')
-      and following-sibling::expr[1][NUM_CONST[text() = 'TRUE'] or SYMBOL[text() = 'T']]
-    ])
-  ]
-  /following-sibling::expr[1][STR_CONST and not(EQ_SUB)]
+    /parent::expr[
+      not(following-sibling::SYMBOL_SUB[
+        (text() = 'fixed' or text() = 'ignore.case')
+        and following-sibling::expr[1][NUM_CONST[text() = 'TRUE'] or SYMBOL[text() = 'T']]
+      ])
+    ]
+    /following-sibling::expr[1][STR_CONST and not(EQ_SUB)]
   |
   //SYMBOL_FUNCTION_CALL[ {pos_2_regex_funs} ]
-  /parent::expr[
-    not(following-sibling::SYMBOL_SUB[
-      text() = 'fixed'
-      and following-sibling::expr[1][NUM_CONST[text() = 'TRUE'] or SYMBOL[text() = 'T']]
-    ])
-  ]
-  /following-sibling::expr[2][STR_CONST and not(EQ_SUB)]
+    /parent::expr[
+      not(following-sibling::SYMBOL_SUB[
+        text() = 'fixed'
+        and following-sibling::expr[1][NUM_CONST[text() = 'TRUE'] or SYMBOL[text() = 'T']]
+      ])
+    ]
+    /following-sibling::expr[2][STR_CONST and not(EQ_SUB)]
   ")
 
   Linter(function(source_expression) {

--- a/R/function_argument_linter.R
+++ b/R/function_argument_linter.R
@@ -9,7 +9,7 @@
 #' @export
 function_argument_linter <- function() {
   xpath <- paste(collapse = " | ", glue::glue("
-    //{c('FUNCTION', 'OP-LAMBDA')}
+  //{c('FUNCTION', 'OP-LAMBDA')}
     /following-sibling::EQ_FORMALS[1]
     /following-sibling::SYMBOL_FORMALS[
       text() != '...'

--- a/R/function_left_parentheses_linter.R
+++ b/R/function_left_parentheses_linter.R
@@ -11,8 +11,9 @@
 #' @export
 function_left_parentheses_linter <- function() { # nolint: object_length.
   xpath <- "
-    //FUNCTION[@col2 != following-sibling::OP-LEFT-PAREN/@col1 - 1] |
-    //SYMBOL_FUNCTION_CALL/parent::expr[@col2 != following-sibling::OP-LEFT-PAREN/@col1 - 1]
+  //FUNCTION[@col2 != following-sibling::OP-LEFT-PAREN/@col1 - 1]
+  |
+  //SYMBOL_FUNCTION_CALL/parent::expr[@col2 != following-sibling::OP-LEFT-PAREN/@col1 - 1]
   "
 
   Linter(function(source_expression) {

--- a/R/function_return_linter.R
+++ b/R/function_return_linter.R
@@ -10,7 +10,7 @@
 function_return_linter <- function() {
   xpath <- "
   //SYMBOL_FUNCTION_CALL[text() = 'return']
-  /parent::expr/parent::expr/expr[LEFT_ASSIGN or RIGHT_ASSIGN]
+    /parent::expr/parent::expr/expr[LEFT_ASSIGN or RIGHT_ASSIGN]
   "
 
   Linter(function(source_expression) {

--- a/R/ifelse_censor_linter.R
+++ b/R/ifelse_censor_linter.R
@@ -14,13 +14,13 @@
 ifelse_censor_linter <- function() {
   xpath <- glue::glue("
   //SYMBOL_FUNCTION_CALL[ {xp_text_in_table(ifelse_funs)} ]
-  /parent::expr
-  /following-sibling::expr[
-    (LT or GT or LE or GE)
-    and expr[1] = following-sibling::expr
-    and expr[2] = following-sibling::expr
-  ]
-  /parent::expr
+    /parent::expr
+    /following-sibling::expr[
+      (LT or GT or LE or GE)
+      and expr[1] = following-sibling::expr
+      and expr[2] = following-sibling::expr
+    ]
+    /parent::expr
   ")
 
   Linter(function(source_expression) {

--- a/R/inner_combine_linter.R
+++ b/R/inner_combine_linter.R
@@ -60,9 +60,9 @@ inner_combine_linter <- function() {
   )
   xpath <- glue::glue("
   //SYMBOL_FUNCTION_CALL[text() = 'c']
-  /parent::expr
-  /following-sibling::expr[1][ {c_expr_cond} ]
-  /parent::expr
+    /parent::expr
+    /following-sibling::expr[1][ {c_expr_cond} ]
+    /parent::expr
   ")
 
   Linter(function(source_expression) {

--- a/R/lengths_linter.R
+++ b/R/lengths_linter.R
@@ -11,7 +11,7 @@ lengths_linter <- function() {
   loop_funs <- c("sapply", "vapply", "map_int", "map_dbl")
   xpath <- glue::glue("
   //SYMBOL_FUNCTION_CALL[ {xp_text_in_table(loop_funs)} ]
-  /parent::expr/parent::expr[expr[position() = 3 and SYMBOL[text() = 'length']]]
+    /parent::expr/parent::expr[expr[position() = 3 and SYMBOL[text() = 'length']]]
   ")
 
   Linter(function(source_expression) {

--- a/R/literal_coercion_linter.R
+++ b/R/literal_coercion_linter.R
@@ -35,11 +35,12 @@ literal_coercion_linter <- function() {
   "
   xpath <- glue::glue("
   //SYMBOL_FUNCTION_CALL[ {coercers} ]
-  /parent::expr
-  /parent::expr[
-    count(expr) = 2
-    and expr[2][ {not_extraction_or_scientific} ]
-  ]")
+    /parent::expr
+    /parent::expr[
+      count(expr) = 2
+      and expr[2][ {not_extraction_or_scientific} ]
+    ]
+  ")
 
   Linter(function(source_expression) {
     if (!is_lint_level(source_expression, "expression")) {

--- a/R/missing_package_linter.R
+++ b/R/missing_package_linter.R
@@ -8,24 +8,24 @@
 missing_package_linter <- function() {
   library_require_xpath <- "
   //SYMBOL_FUNCTION_CALL[text() = 'library' or text() = 'require']
-  /parent::expr
-  /parent::expr[
-    expr[2][STR_CONST]
-    or (
-      expr[2][SYMBOL]
-      and not(
-        SYMBOL_SUB[text() = 'character.only']
-        /following-sibling::expr[1]
-        /NUM_CONST[text() = 'TRUE' or text() = 'T']
+    /parent::expr
+    /parent::expr[
+      expr[2][STR_CONST]
+      or (
+        expr[2][SYMBOL]
+        and not(
+          SYMBOL_SUB[text() = 'character.only']
+          /following-sibling::expr[1]
+          /NUM_CONST[text() = 'TRUE' or text() = 'T']
+        )
       )
-    )
-  ]
+    ]
   "
   load_require_namespace_xpath <- "
   //SYMBOL_FUNCTION_CALL[text() = 'loadNamespace' or text() = 'requireNamespace']
-  /parent::expr
-  /following-sibling::expr[1][STR_CONST]
-  /parent::expr
+    /parent::expr
+    /following-sibling::expr[1][STR_CONST]
+    /parent::expr
   "
   call_xpath <- paste(library_require_xpath, "|", load_require_namespace_xpath)
 

--- a/R/nested_ifelse_linter.R
+++ b/R/nested_ifelse_linter.R
@@ -20,8 +20,8 @@ nested_ifelse_linter <- function() {
   # NB: land on the nested (inner) call, not the outer call, and throw a lint with the inner call's name
   xpath <- glue::glue("
   //SYMBOL_FUNCTION_CALL[ {xp_text_in_table(ifelse_funs)}]
-  /parent::expr
-  /following-sibling::expr[expr[1][SYMBOL_FUNCTION_CALL[ {xp_text_in_table(ifelse_funs)} ]]]
+    /parent::expr
+    /following-sibling::expr[expr[1][SYMBOL_FUNCTION_CALL[ {xp_text_in_table(ifelse_funs)} ]]]
   ")
 
   Linter(function(source_expression) {

--- a/R/object_name_linters.R
+++ b/R/object_name_linters.R
@@ -1,5 +1,5 @@
 object_name_xpath <- local({
-  xp_assignment_target <- paste(
+  xp_assignment_target <- paste0(
     "not(preceding-sibling::OP-DOLLAR)",
     "and ancestor::expr[",
     " following-sibling::LEFT_ASSIGN",
@@ -12,12 +12,11 @@ object_name_xpath <- local({
     "])"
   )
 
-  paste(
-    "//SYMBOL[", xp_assignment_target, "]",
-    "//STR_CONST[", xp_assignment_target, "]",
-    "//SYMBOL_FORMALS",
-    sep = " | "
-  )
+  glue::glue("
+  //SYMBOL[ {xp_assignment_target} ]
+  |  //STR_CONST[ {xp_assignment_target} ]
+  |  //SYMBOL_FORMALS
+  ")
 })
 
 #' Object name linter

--- a/R/object_name_linters.R
+++ b/R/object_name_linters.R
@@ -12,10 +12,11 @@ object_name_xpath <- local({
     "])"
   )
 
-  paste0(
-    "//SYMBOL[", xp_assignment_target, "] | ",
-    "//STR_CONST[", xp_assignment_target, "] | ",
-    "//SYMBOL_FORMALS"
+  paste(
+    "//SYMBOL[", xp_assignment_target, "]",
+    "//STR_CONST[", xp_assignment_target, "]",
+    "//SYMBOL_FORMALS",
+    sep = " | "
   )
 })
 

--- a/R/outer_negation_linter.R
+++ b/R/outer_negation_linter.R
@@ -17,14 +17,15 @@ outer_negation_linter <- function() {
   #   e.g. in magrittr pipelines.
   xpath <- "
   //SYMBOL_FUNCTION_CALL[text() = 'any' or text() = 'all']
-  /parent::expr[following-sibling::expr]
-  /parent::expr[
-    not(expr[
-      position() > 1
-      and not(OP-EXCLAMATION)
-      and not(preceding-sibling::*[1][self::EQ_SUB])
-    ])
-  ]"
+    /parent::expr[following-sibling::expr]
+    /parent::expr[
+      not(expr[
+        position() > 1
+        and not(OP-EXCLAMATION)
+        and not(preceding-sibling::*[1][self::EQ_SUB])
+      ])
+    ]
+  "
 
   Linter(function(source_expression) {
     if (!is_lint_level(source_expression, "expression")) {

--- a/R/package_hooks_linter.R
+++ b/R/package_hooks_linter.R
@@ -22,8 +22,8 @@ package_hooks_linter <- function() {
   )
   bad_msg_call_xpath_fmt <- "
   //FUNCTION
-  /parent::expr[preceding-sibling::expr/SYMBOL[text() = '%s']]
-  //SYMBOL_FUNCTION_CALL[%s]
+    /parent::expr[preceding-sibling::expr/SYMBOL[text() = '%s']]
+    //SYMBOL_FUNCTION_CALL[%s]
   "
   bad_call_xpaths <- vapply(
     seq_along(bad_calls),
@@ -49,42 +49,42 @@ package_hooks_linter <- function() {
 
   load_arg_name_xpath <- "
   //FUNCTION
-  /parent::expr[
-    preceding-sibling::expr/SYMBOL[text() = '.onAttach' or text() = '.onLoad']
-    and (
-      count(SYMBOL_FORMALS) != 2
-      or SYMBOL_FORMALS[
-        (position() = 1 and not(starts-with(text(), 'lib')))
-        or (position() = 2 and not(starts-with(text(), 'pkg')))
-      ]
-    )
-  ]
+    /parent::expr[
+      preceding-sibling::expr/SYMBOL[text() = '.onAttach' or text() = '.onLoad']
+      and (
+        count(SYMBOL_FORMALS) != 2
+        or SYMBOL_FORMALS[
+          (position() = 1 and not(starts-with(text(), 'lib')))
+          or (position() = 2 and not(starts-with(text(), 'pkg')))
+        ]
+      )
+    ]
   "
 
   library_require_xpath <- "
   //FUNCTION
-  /parent::expr[preceding-sibling::expr/SYMBOL[text() = '.onAttach' or text() = '.onLoad']]
-  //*[1][
-    (self::SYMBOL or self::SYMBOL_FUNCTION_CALL)
-    and (text() = 'require' or text() = 'library' or text() = 'installed.packages')
-  ]
+    /parent::expr[preceding-sibling::expr/SYMBOL[text() = '.onAttach' or text() = '.onLoad']]
+    //*[1][
+      (self::SYMBOL or self::SYMBOL_FUNCTION_CALL)
+      and (text() = 'require' or text() = 'library' or text() = 'installed.packages')
+    ]
   "
 
   bad_unload_call_xpath <- "
   //FUNCTION
-  /parent::expr[preceding-sibling::expr/SYMBOL[text() = '.Last.lib' or text() = '.onDetach']]
-  //SYMBOL_FUNCTION_CALL[text() = 'library.dynam.unload']
+    /parent::expr[preceding-sibling::expr/SYMBOL[text() = '.Last.lib' or text() = '.onDetach']]
+    //SYMBOL_FUNCTION_CALL[text() = 'library.dynam.unload']
   "
 
   unload_arg_name_xpath <- "
   //FUNCTION
-  /parent::expr[
-    preceding-sibling::expr/SYMBOL[text() = '.onDetach' or text() = '.Last.lib']
-    and (
-      count(SYMBOL_FORMALS) != 1
-      or SYMBOL_FORMALS[not(starts-with(text(), 'lib'))]
-    )
-  ]
+    /parent::expr[
+      preceding-sibling::expr/SYMBOL[text() = '.onDetach' or text() = '.Last.lib']
+      and (
+        count(SYMBOL_FORMALS) != 1
+        or SYMBOL_FORMALS[not(starts-with(text(), 'lib'))]
+      )
+    ]
   "
 
   Linter(function(source_expression) {

--- a/R/paren_body_linter.R
+++ b/R/paren_body_linter.R
@@ -13,7 +13,8 @@ paren_body_linter <- function() {
   #   be O(100K) <expr> nodes but in all but pathological examples,
   #   these other nodes will only be a small fraction of this amount.
   # note also that <forcond> only has one following-sibling::expr.
-  xpath <- "//OP-RIGHT-PAREN[
+  xpath <- "
+  //OP-RIGHT-PAREN[
     @end = following-sibling::expr[1]/@start - 1
     and @line1 = following-sibling::expr[1]/@line1
     and (
@@ -22,12 +23,14 @@ paren_body_linter <- function() {
       or preceding-sibling::WHILE
       or preceding-sibling::OP-LAMBDA
     )
-  ]/following-sibling::expr[1]
+  ]
+    /following-sibling::expr[1]
   |
   //forcond[
     @line1 = following-sibling::expr/@line2
     and OP-RIGHT-PAREN/@col1 = following-sibling::expr/@col1 - 1
-  ]/following-sibling::expr
+  ]
+    /following-sibling::expr
   "
 
   Linter(function(source_expression) {

--- a/R/paste_linter.R
+++ b/R/paste_linter.R
@@ -19,24 +19,25 @@
 paste_linter <- function(allow_empty_sep = FALSE, allow_to_string = FALSE) {
   sep_xpath <- "
   //SYMBOL_FUNCTION_CALL[text() = 'paste']
-  /parent::expr
-  /following-sibling::SYMBOL_SUB[text() = 'sep' and following-sibling::expr[1][STR_CONST]]
-  /parent::expr
+    /parent::expr
+    /following-sibling::SYMBOL_SUB[text() = 'sep' and following-sibling::expr[1][STR_CONST]]
+    /parent::expr
   "
 
   to_string_xpath <- "
   //SYMBOL_FUNCTION_CALL[text() = 'paste' or text() = 'paste0']
-  /parent::expr
-  /parent::expr[
-    count(expr) = 3
-    and SYMBOL_SUB[text() = 'collapse']/following-sibling::expr[1][STR_CONST]
-  ]"
+    /parent::expr
+    /parent::expr[
+      count(expr) = 3
+      and SYMBOL_SUB[text() = 'collapse']/following-sibling::expr[1][STR_CONST]
+    ]
+  "
 
   paste0_sep_xpath <- "
   //SYMBOL_FUNCTION_CALL[text() = 'paste0']
-  /parent::expr
-  /following-sibling::SYMBOL_SUB[text() = 'sep']
-  /parent::expr
+    /parent::expr
+    /following-sibling::SYMBOL_SUB[text() = 'sep']
+    /parent::expr
   "
 
   Linter(function(source_expression) {

--- a/R/pipe_continuation_linter.R
+++ b/R/pipe_continuation_linter.R
@@ -15,7 +15,7 @@ pipe_continuation_linter <- function() {
   # inside a function definition), the outer expression can span multiple lines
   # without a pipe-continuation lint being thrown.
 
-  multiline_pipe_test <- paste(
+  multiline_pipe_test <- paste0(
     # In xml derived from the expression `E1 %>% E2`:
     # `E1`, the pipe and `E2` are sibling expressions of the parent expression
 
@@ -27,25 +27,25 @@ pipe_continuation_linter <- function() {
     # rather than all ancestors.
 
     # select all pipes
-    "//SPECIAL[text() = '%>%'",
+    # TODO(#1609): Include native pipes
+    "//SPECIAL[",
+    "  text() = '%>%'",
     # that are nested in a parent-expression that spans multiple lines
-    "and parent::expr[@line1 < @line2]",
+    "  and parent::expr[@line1 < @line2]",
     # where the parent contains pipes that precede the pipe under scrutiny
-    "and preceding-sibling::*/descendant-or-self::SPECIAL[text() = '%>%']",
-    "and (",
+    "  and preceding-sibling::*/descendant-or-self::SPECIAL[text() = '%>%']",
+    "  and (",
     # where a preceding sibling 'expr' [...] ends on the same line that a
     # succeeding 'expr' starts {...}
     # either "[a %>%\n b()] %>% {c(...)}"
     # or     "[a %>% b(...\n)] %>% {c(...)}"
-    "(preceding-sibling::*/descendant-or-self::expr/@line2 = ",
-    "  following-sibling::*/descendant-or-self::expr/@line1)",
-
+    "    (preceding-sibling::*/descendant-or-self::expr/@line2 = following-sibling::*/descendant-or-self::expr/@line1)",
     # or, (if the post-pipe expression starts on a subsequent line) where a
     # preceding sibling 'expr' [...] contains a pipe character on the
     # same line as the original pipe character |...|
     # [a %>% b] |%>%| \n c
-    "or (@line1 = preceding-sibling::*/descendant-or-self::SPECIAL[text() = '%>%']/@line1)",
-    ")",
+    "    or (@line1 = preceding-sibling::*/descendant-or-self::SPECIAL[text() = '%>%']/@line1)",
+    "  )",
     "]"
   )
 

--- a/R/redundant_ifelse_linter.R
+++ b/R/redundant_ifelse_linter.R
@@ -14,19 +14,21 @@
 redundant_ifelse_linter <- function(allow10 = FALSE) {
   tf_xpath <- glue::glue("
   //SYMBOL_FUNCTION_CALL[ {xp_text_in_table(ifelse_funs)} ]
-  /parent::expr
-  /parent::expr[
-    expr[NUM_CONST[text() = 'TRUE']]
-    and expr[NUM_CONST[text() = 'FALSE']]
-  ]")
+    /parent::expr
+    /parent::expr[
+      expr[NUM_CONST[text() = 'TRUE']]
+      and expr[NUM_CONST[text() = 'FALSE']]
+    ]
+  ")
 
   num_xpath <- glue::glue("
   //SYMBOL_FUNCTION_CALL[ {xp_text_in_table(ifelse_funs)} ]
-  /parent::expr
-  /parent::expr[
-    expr[NUM_CONST[text() = '1' or text() = '1L']]
-    and expr[NUM_CONST[text() = '0' or text() = '0L']]
-  ]")
+    /parent::expr
+    /parent::expr[
+      expr[NUM_CONST[text() = '1' or text() = '1L']]
+      and expr[NUM_CONST[text() = '0' or text() = '0L']]
+    ]
+  ")
 
   Linter(function(source_expression) {
     if (!is_lint_level(source_expression, "expression")) {

--- a/R/regex_subset_linter.R
+++ b/R/regex_subset_linter.R
@@ -31,14 +31,14 @@ regex_subset_linter <- function() {
   #   <expr>[grepl(pattern, <expr>)] matches exactly, e.g. names(x)[grepl(ptn, names(x))].
   xpath_fmt <- "
   //SYMBOL_FUNCTION_CALL[ {xp_text_in_table(calls)} ]
-  /parent::expr
-  /parent::expr[
-    parent::expr[
-      OP-LEFT-BRACKET
-      and not(parent::*[LEFT_ASSIGN or EQ_ASSIGN or RIGHT_ASSIGN])
+    /parent::expr
+    /parent::expr[
+      parent::expr[
+        OP-LEFT-BRACKET
+        and not(parent::*[LEFT_ASSIGN or EQ_ASSIGN or RIGHT_ASSIGN])
+      ]
+      and expr[position() = {arg_pos} ] = parent::expr/expr[1]
     ]
-    and expr[position() = {arg_pos} ] = parent::expr/expr[1]
-  ]
   "
   grep_xpath <- glue::glue(xpath_fmt, calls = c("grepl", "grep"), arg_pos = 3L)
   stringr_xpath <- glue::glue(xpath_fmt, calls = c("str_detect", "str_which"), arg_pos = 2L)

--- a/R/seq_linter.R
+++ b/R/seq_linter.R
@@ -18,13 +18,13 @@ seq_linter <- function() {
   # Exact `xpath` depends on whether bad function was used in conjunction with `seq()`
   seq_xpath <- glue::glue("
   //SYMBOL_FUNCTION_CALL[text() = 'seq']
-  /parent::expr
-  /following-sibling::expr[1][expr/SYMBOL_FUNCTION_CALL[ {bad_funcs} ]]
-  /parent::expr[count(expr) = 2]
+    /parent::expr
+    /following-sibling::expr[1][expr/SYMBOL_FUNCTION_CALL[ {bad_funcs} ]]
+    /parent::expr[count(expr) = 2]
   ")
   # `.N` from {data.table} is special since it's not a function but a symbol
   colon_xpath <- glue::glue("
-    //OP-COLON
+  //OP-COLON
     /parent::expr[
       expr[NUM_CONST[text() = '1' or text() = '1L']]
       and (

--- a/R/sprintf_linter.R
+++ b/R/sprintf_linter.R
@@ -9,14 +9,15 @@
 sprintf_linter <- function() {
   xpath <- "
   //SYMBOL_FUNCTION_CALL[text() = 'sprintf']
-  /parent::expr
-  /parent::expr[
-    (
-      OP-LEFT-PAREN/following-sibling::expr[1]/STR_CONST or
-      SYMBOL_SUB[text() = 'fmt']/following-sibling::expr[1]/STR_CONST
-    ) and
-    not(expr/SYMBOL[text() = '...'])
-  ]"
+    /parent::expr
+    /parent::expr[
+      (
+        OP-LEFT-PAREN/following-sibling::expr[1]/STR_CONST or
+        SYMBOL_SUB[text() = 'fmt']/following-sibling::expr[1]/STR_CONST
+      ) and
+      not(expr/SYMBOL[text() = '...'])
+    ]
+  "
 
   Linter(function(source_expression) {
     if (!is_lint_level(source_expression, "file")) {

--- a/R/string_boundary_linter.R
+++ b/R/string_boundary_linter.R
@@ -31,27 +31,27 @@ string_boundary_linter <- function(allow_grepl = FALSE) {
   )
   str_detect_xpath <- glue::glue("
   //SYMBOL_FUNCTION_CALL[text() = 'str_detect']
-  /parent::expr
-  /following-sibling::expr[2]
-  /STR_CONST[ {str_cond} ]
+    /parent::expr
+    /following-sibling::expr[2]
+    /STR_CONST[ {str_cond} ]
   ")
 
   if (!allow_grepl) {
     grepl_xpath <- glue::glue("
     //SYMBOL_FUNCTION_CALL[text() = 'grepl']
-    /parent::expr
-    /parent::expr[
-      not(SYMBOL_SUB[
-        text() = 'ignore.case'
-        and not(following-sibling::expr[1][NUM_CONST[text() = 'FALSE'] or SYMBOL[text() = 'F']])
-      ])
-      and not(SYMBOL_SUB[
-        text() = 'fixed'
-        and not(following-sibling::expr[1][NUM_CONST[text() = 'FALSE'] or SYMBOL[text() = 'F']])
-      ])
-    ]
-    /expr[2]
-    /STR_CONST[ {str_cond} ]
+      /parent::expr
+      /parent::expr[
+        not(SYMBOL_SUB[
+          text() = 'ignore.case'
+          and not(following-sibling::expr[1][NUM_CONST[text() = 'FALSE'] or SYMBOL[text() = 'F']])
+        ])
+        and not(SYMBOL_SUB[
+          text() = 'fixed'
+          and not(following-sibling::expr[1][NUM_CONST[text() = 'FALSE'] or SYMBOL[text() = 'F']])
+        ])
+      ]
+      /expr[2]
+      /STR_CONST[ {str_cond} ]
     ")
   }
 
@@ -67,22 +67,23 @@ string_boundary_linter <- function(allow_grepl = FALSE) {
 
   substr_xpath_parts <- glue::glue("
   //{ c('EQ', 'NE') }
-  /parent::expr[
-    expr[STR_CONST]
-    and expr[
-      expr[1][SYMBOL_FUNCTION_CALL[text() = 'substr' or text() = 'substring']]
+    /parent::expr[
+      expr[STR_CONST]
       and expr[
-        (
-          position() = 3
-          and NUM_CONST[text() = '1' or text() = '1L']
-        ) or (
-          position() = 4
-          and expr[1][SYMBOL_FUNCTION_CALL[text() = 'nchar']]
-          and expr[position() = 2] = preceding-sibling::expr[2]
-        )
+        expr[1][SYMBOL_FUNCTION_CALL[text() = 'substr' or text() = 'substring']]
+        and expr[
+          (
+            position() = 3
+            and NUM_CONST[text() = '1' or text() = '1L']
+          ) or (
+            position() = 4
+            and expr[1][SYMBOL_FUNCTION_CALL[text() = 'nchar']]
+            and expr[position() = 2] = preceding-sibling::expr[2]
+          )
+        ]
       ]
     ]
-  ]")
+  ")
   substr_xpath <- paste(substr_xpath_parts, collapse = " | ")
 
   substr_arg2_xpath <- "string(./expr[expr[1][SYMBOL_FUNCTION_CALL]]/expr[3])"

--- a/R/strings_as_factors_linter.R
+++ b/R/strings_as_factors_linter.R
@@ -41,22 +41,23 @@ strings_as_factors_linter <- function() {
   #   (2) stringsAsFactors is manually supplied (with any value)
   xpath <- glue::glue("
   //SYMBOL_FUNCTION_CALL[text() = 'data.frame']
-  /parent::expr
-  /parent::expr[
-    expr[
-      (
-        STR_CONST[not(following-sibling::*[1][self::EQ_SUB])]
-        or ( {c_combine_strings} )
-        or expr[1][
-          SYMBOL_FUNCTION_CALL[text() = 'rep']
-          and following-sibling::expr[1][STR_CONST or ({c_combine_strings})]
-        ]
-        or expr[1][SYMBOL_FUNCTION_CALL[ {xp_text_in_table(known_character_funs)} ]]
-      )
-      and not(preceding-sibling::*[2][self::SYMBOL_SUB and text() = 'row.names'])
+    /parent::expr
+    /parent::expr[
+      expr[
+        (
+          STR_CONST[not(following-sibling::*[1][self::EQ_SUB])]
+          or ( {c_combine_strings} )
+          or expr[1][
+            SYMBOL_FUNCTION_CALL[text() = 'rep']
+            and following-sibling::expr[1][STR_CONST or ({c_combine_strings})]
+          ]
+          or expr[1][SYMBOL_FUNCTION_CALL[ {xp_text_in_table(known_character_funs)} ]]
+        )
+        and not(preceding-sibling::*[2][self::SYMBOL_SUB and text() = 'row.names'])
+      ]
+      and not(SYMBOL_SUB[text() = 'stringsAsFactors'])
     ]
-    and not(SYMBOL_SUB[text() = 'stringsAsFactors'])
-  ]")
+  ")
 
   Linter(function(source_expression) {
     if (!is_lint_level(source_expression, "expression")) {

--- a/R/system_file_linter.R
+++ b/R/system_file_linter.R
@@ -11,8 +11,8 @@ system_file_linter <- function() {
   # either system.file(file.path(...)) or file.path(system.file(...))
   xpath_parts <- glue::glue("
   //SYMBOL_FUNCTION_CALL[text() = '{funs}']
-  /parent::expr[following-sibling::expr/expr/SYMBOL_FUNCTION_CALL[text() = '{rev(funs)}']]
-  /parent::expr
+    /parent::expr[following-sibling::expr/expr/SYMBOL_FUNCTION_CALL[text() = '{rev(funs)}']]
+    /parent::expr
   ")
   xpath <- paste(xpath_parts, collapse = " | ")
 

--- a/R/unnecessary_lambda_linter.R
+++ b/R/unnecessary_lambda_linter.R
@@ -39,14 +39,15 @@ unnecessary_lambda_linter <- function() {
   # TODO(#1567): This misses some common cases, e.g. function(x) { foo(x) }
   default_fun_xpath <- glue::glue("
   //SYMBOL_FUNCTION_CALL[ {apply_funs} ]
-  /parent::expr
-  /following-sibling::expr[
-    FUNCTION
-    and count(SYMBOL_FORMALS) = 1
-    and expr/OP-LEFT-PAREN/following-sibling::expr[1][not(preceding-sibling::*[2][self::SYMBOL_SUB])]/SYMBOL
-    and SYMBOL_FORMALS/text() = expr/OP-LEFT-PAREN/following-sibling::expr[1]/SYMBOL/text()
-    and not(SYMBOL_FORMALS/text() = expr/OP-LEFT-PAREN/following-sibling::expr[position() > 1]//SYMBOL/text())
-  ]")
+    /parent::expr
+    /following-sibling::expr[
+      FUNCTION
+      and count(SYMBOL_FORMALS) = 1
+      and expr/OP-LEFT-PAREN/following-sibling::expr[1][not(preceding-sibling::*[2][self::SYMBOL_SUB])]/SYMBOL
+      and SYMBOL_FORMALS/text() = expr/OP-LEFT-PAREN/following-sibling::expr[1]/SYMBOL/text()
+      and not(SYMBOL_FORMALS/text() = expr/OP-LEFT-PAREN/following-sibling::expr[position() > 1]//SYMBOL/text())
+    ]
+  ")
 
   # purrr-style inline formulas-as-functions, e.g. ~foo(.x)
   # logic is basically the same as that above, except we need
@@ -55,12 +56,13 @@ unnecessary_lambda_linter <- function() {
   purrr_symbol <- "SYMBOL[text() = '.x' or text() = '.']"
   purrr_fun_xpath <- glue::glue("
   //SYMBOL_FUNCTION_CALL[ {xp_text_in_table(purrr_mappers)} ]
-  /parent::expr
-  /following-sibling::expr[
-    OP-TILDE
-    and expr[OP-LEFT-PAREN/following-sibling::expr[1][not(preceding-sibling::*[2][self::SYMBOL_SUB])]/{purrr_symbol}]
-    and not(expr/OP-LEFT-PAREN/following-sibling::expr[position() > 1]//{purrr_symbol})
-  ]")
+    /parent::expr
+    /following-sibling::expr[
+      OP-TILDE
+      and expr[OP-LEFT-PAREN/following-sibling::expr[1][not(preceding-sibling::*[2][self::SYMBOL_SUB])]/{purrr_symbol}]
+      and not(expr/OP-LEFT-PAREN/following-sibling::expr[position() > 1]//{purrr_symbol})
+    ]
+  ")
 
   # path to calling function symbol from the matched expressions
   fun_xpath <- "./parent::expr/expr/SYMBOL_FUNCTION_CALL"

--- a/R/unneeded_concatenation_linter.R
+++ b/R/unneeded_concatenation_linter.R
@@ -39,7 +39,7 @@ unneeded_concatenation_linter <- function(allow_single_expression = TRUE) {
     ]
   "
   xpath_call <- glue::glue("
-    //SYMBOL_FUNCTION_CALL[text() = 'c']
+  //SYMBOL_FUNCTION_CALL[text() = 'c']
     /parent::expr
     /parent::expr[
       not(EQ_SUB)

--- a/R/unreachable_code_linter.R
+++ b/R/unreachable_code_linter.R
@@ -17,14 +17,14 @@ unreachable_code_linter <- function() {
   #  - land on the culprit expression
   xpath <- "
   //FUNCTION
-  /following-sibling::expr
-  /*[
-    self::expr
-    and expr[1][not(OP-DOLLAR) and SYMBOL_FUNCTION_CALL[text() = 'return' or text() = 'stop']]
-    and (position() != last() - 1 or not(following-sibling::OP-RIGHT-BRACE))
-    and @line2 < following-sibling::*[1]/@line2
-  ]
-  /following-sibling::*[1]
+    /following-sibling::expr
+    /*[
+      self::expr
+      and expr[1][not(OP-DOLLAR) and SYMBOL_FUNCTION_CALL[text() = 'return' or text() = 'stop']]
+      and (position() != last() - 1 or not(following-sibling::OP-RIGHT-BRACE))
+      and @line2 < following-sibling::*[1]/@line2
+    ]
+    /following-sibling::*[1]
   "
 
   Linter(function(source_expression) {

--- a/R/unused_import_linter.R
+++ b/R/unused_import_linter.R
@@ -12,14 +12,15 @@
 unused_import_linter <- function(allow_ns_usage = FALSE, except_packages = c("bit64", "data.table", "tidyverse")) {
   import_xpath <- "
   //SYMBOL_FUNCTION_CALL[text() = 'library' or text() = 'require']
-  /parent::expr
-  /parent::expr[
-    expr[2][STR_CONST]
-    or not(SYMBOL_SUB[
-      text() = 'character.only' and
-      following-sibling::expr[1][NUM_CONST[text() = 'TRUE'] or SYMBOL[text() = 'T']]
-    ])
-  ]"
+    /parent::expr
+    /parent::expr[
+      expr[2][STR_CONST]
+      or not(SYMBOL_SUB[
+        text() = 'character.only' and
+        following-sibling::expr[1][NUM_CONST[text() = 'TRUE'] or SYMBOL[text() = 'T']]
+      ])
+    ]
+  "
 
   xp_used_symbols <- paste(
     "//SYMBOL_FUNCTION_CALL[not(preceding-sibling::NS_GET)]/text()",

--- a/R/vector_logic_linter.R
+++ b/R/vector_logic_linter.R
@@ -37,9 +37,9 @@ vector_logic_linter <- function() {
   #     <expr> ... </expr>
   #  </expr>
   #  we _don't_ want to match anything on the second expr, hence this
-  xpath <- "//*[
-    (self::AND or self::OR)
-    and ancestor::expr[
+  xpath_parts <- glue::glue("
+  //{ c('AND', 'OR') }[
+    ancestor::expr[
       not(preceding-sibling::OP-RIGHT-PAREN)
       and preceding-sibling::*[
         self::IF
@@ -51,7 +51,9 @@ vector_logic_linter <- function() {
       preceding-sibling::expr[last()][SYMBOL_FUNCTION_CALL[not(text() = 'expect_true' or text() = 'expect_false')]]
       or preceding-sibling::OP-LEFT-BRACKET
     ])
-  ]"
+  ]
+  ")
+  xpath <- paste(xpath_parts, collapse = " | ")
 
   Linter(function(source_expression) {
     if (!is_lint_level(source_expression, "expression")) {

--- a/R/yoda_test_linter.R
+++ b/R/yoda_test_linter.R
@@ -24,9 +24,9 @@ yoda_test_linter <- function() {
   "
   xpath <- glue::glue("
   //SYMBOL_FUNCTION_CALL[text() = 'expect_equal' or text() = 'expect_identical' or text() = 'expect_setequal']
-  /parent::expr
-  /following-sibling::expr[1][ {const_condition} ]
-  /parent::expr[not(preceding-sibling::*[self::PIPE or self::SPECIAL[text() = '%>%']])]
+    /parent::expr
+    /following-sibling::expr[1][ {const_condition} ]
+    /parent::expr[not(preceding-sibling::*[self::PIPE or self::SPECIAL[text() = '%>%']])]
   ")
 
   second_const_xpath <- glue::glue("expr[position() = 3 and ({const_condition})]")


### PR DESCRIPTION
Switch from extended xpaths like

```xpath
//NODE[ conditions]
/parent::expr[ conditions ]
/parent::expr[ conditions ]
```

To use hanging indent for changing axes:

```xpath
//NODE[ conditions]
  /parent::expr[ conditions ]
  /parent::expr[ conditions ]
```

I think it's more readable this way, especially when there's multiple XPaths combined with `|`, or there's a `//` sub-path (as in `package_hooks_linter()`).