### PR TITLE
Always qualify rex in tests, make private API calls clearer

### DIFF
--- a/tests/testthat/test-cache.R
+++ b/tests/testthat/test-cache.R
@@ -36,7 +36,7 @@ test_that("clear_cache deletes the file if a file is given", {
   e1 <- new.env(parent = emptyenv())
   d1 <- tempfile(pattern = "lintr_cache_")
   f1 <- "R/test.R"
-  save_cache(cache = e1, file = f1, path = d1)
+  lintr:::save_cache(cache = e1, file = f1, path = d1)
 
   want <- list(file.path(d1, fhash("R/test.R")), recursive = TRUE)
   expect_equal(clear_cache(f1, d1), want)
@@ -57,8 +57,8 @@ test_that("load_cache loads the saved file in a new empty environment", {
   e1[["x"]] <- "foobar"
   d1 <- tempfile(pattern = "lintr_cache_")
   f1 <- "R/test.R"
-  save_cache(cache = e1, file = f1, path = d1)
-  e2 <- load_cache(file = f1, path = d1)
+  lintr:::save_cache(cache = e1, file = f1, path = d1)
+  e2 <- lintr:::load_cache(file = f1, path = d1)
 
   expect_equal(e2, e1)
 })
@@ -69,8 +69,8 @@ test_that("load_cache returns an empty environment if no cache file exists", {
   f1 <- "R/test.R"
   f2 <- "test.R"
 
-  save_cache(cache = e1, file = f1, path = d1)
-  e2 <- load_cache(file = f2, path = d1)
+  lintr:::save_cache(cache = e1, file = f1, path = d1)
+  e2 <- lintr:::load_cache(file = f2, path = d1)
 
   expect_equal(e2, e1)
 })
@@ -80,13 +80,13 @@ test_that("load_cache returns an empty environment if reading cache file fails",
   e1[["x"]] <- "foobar"
   d1 <- tempfile(pattern = "lintr_cache_")
   f1 <- "R/test.R"
-  save_cache(cache = e1, file = f1, path = d1)
+  lintr:::save_cache(cache = e1, file = f1, path = d1)
   cache_f1 <- file.path(d1, fhash(f1))
   writeLines(character(), cache_f1)
 
-  expect_warning(e2 <- load_cache(file = f1, path = d1), "Could not load cache file")
+  expect_warning(e2 <- lintr:::load_cache(file = f1, path = d1), "Could not load cache file")
   saveRDS(e1, cache_f1)
-  expect_warning(e3 <- load_cache(file = f1, path = d1), "Could not load cache file")
+  expect_warning(e3 <- lintr:::load_cache(file = f1, path = d1), "Could not load cache file")
 
   expect_equal(ls(e2), character())
   expect_equal(ls(e3), character())
@@ -102,7 +102,7 @@ test_that("save_cache creates a directory if needed", {
   expect_false(file.exists(d1))
   expect_false(file.exists(file.path(d1, fhash(f1))))
 
-  save_cache(cache = e1, file = f1, path = d1)
+  lintr:::save_cache(cache = e1, file = f1, path = d1)
 
   expect_true(file.exists(d1))
   expect_true(file.info(d1)$isdir)
@@ -118,8 +118,8 @@ test_that("save_cache uses unambiguous cache file names", {
   expect_false(file.exists(file.path(d1, fhash(f1))))
   expect_false(file.exists(file.path(d1, fhash(f2))))
 
-  save_cache(cache = e1, file = f1, path = d1)
-  save_cache(cache = e1, file = f2, path = d1)
+  lintr:::save_cache(cache = e1, file = f1, path = d1)
+  lintr:::save_cache(cache = e1, file = f2, path = d1)
 
   expect_true(fhash(f1) != fhash(f2))
   expect_true(file.exists(file.path(d1, fhash(f1))))
@@ -134,7 +134,7 @@ test_that("save_cache saves all non-hidden objects from the environment", {
   d1 <- tempfile(pattern = "lintr_cache_")
   f1 <- "R/test.R"
 
-  save_cache(cache = e1, file = f1, path = d1)
+  lintr:::save_cache(cache = e1, file = f1, path = d1)
 
   e2 <- new.env(parent = emptyenv())
   load(file = file.path(d1, fhash(f1)), envir = e2)
@@ -151,8 +151,8 @@ test_that("cache_file generates the same cache with different lints", {
   writeLines("foobar", f1)
   on.exit(unlink(f1))
 
-  cache_file(e1, f1, list(), list())
-  cache_file(e1, f1, list(), list(1L))
+  lintr:::cache_file(e1, f1, list(), list())
+  lintr:::cache_file(e1, f1, list(), list(1L))
 
   expect_length(ls(e1), 1L)
 })
@@ -164,8 +164,8 @@ test_that("cache_file generates different caches for different linters", {
   writeLines("foobar", f1)
   on.exit(unlink(f1))
 
-  cache_file(e1, f1, list(), list())
-  cache_file(e1, f1, list(1L), list())
+  lintr:::cache_file(e1, f1, list(), list())
+  lintr:::cache_file(e1, f1, list(1L), list())
 
   expect_length(ls(e1), 2L)
 })
@@ -179,7 +179,7 @@ test_that("retrieve_file returns NULL if there is no cached result", {
   writeLines("foobar", f1)
   on.exit(unlink(f1))
 
-  expect_null(retrieve_file(e1, f1, list()))
+  expect_null(lintr:::retrieve_file(e1, f1, list()))
 })
 
 test_that("retrieve_file returns the cached result if found", {
@@ -189,8 +189,8 @@ test_that("retrieve_file returns the cached result if found", {
   writeLines("foobar", f1)
   on.exit(unlink(f1))
 
-  cache_file(e1, f1, list(), list("foobar"))
-  expect_equal(retrieve_file(e1, f1, list()), list("foobar"))
+  lintr:::cache_file(e1, f1, list(), list("foobar"))
+  expect_equal(lintr:::retrieve_file(e1, f1, list()), list("foobar"))
 })
 
 # `cache_lint`
@@ -199,8 +199,8 @@ test_that("cache_lint generates the same cache with different lints", {
   e1 <- new.env(parent = emptyenv())
 
   t1 <- list(content = "test")
-  cache_lint(e1, t1, list(), list())
-  cache_lint(e1, t1, list(), list(1L))
+  lintr:::cache_lint(e1, t1, list(), list())
+  lintr:::cache_lint(e1, t1, list(), list(1L))
 
   expect_length(ls(e1), 1L)
 })
@@ -210,8 +210,8 @@ test_that("cache_lint generates different caches for different linters", {
 
   t1 <- list(content = "test")
 
-  cache_lint(e1, t1, list(), list())
-  cache_lint(e1, t1, list(1L), list())
+  lintr:::cache_lint(e1, t1, list(), list())
+  lintr:::cache_lint(e1, t1, list(1L), list())
 
   expect_length(ls(e1), 2L)
 })
@@ -223,14 +223,14 @@ test_that("retrieve_lint returns the same lints if nothing has changed", {
 
   e1 <- new.env(parent = emptyenv())
 
-  cache_lint(
+  lintr:::cache_lint(
     cache = e1,
     expr = test_data[["expr"]],
     linter = test_data[["linters"]],
     lints = test_data[["lints"]]
   )
 
-  t1 <- retrieve_lint(
+  t1 <- lintr:::retrieve_lint(
     cache = e1,
     expr = test_data[["expr"]],
     linter = test_data[["linters"]],
@@ -251,14 +251,14 @@ test_that(
     lines2 <- c("", lines1)
     lints <- test_data[["lints"]]
 
-    cache_lint(
+    lintr:::cache_lint(
       cache = e1,
       expr = test_data[["expr"]],
       linter = test_data[["linters"]],
       lints = lints
     )
 
-    t1 <- retrieve_lint(
+    t1 <- lintr:::retrieve_lint(
       cache = e1,
       expr = test_data[["expr"]],
       linter = test_data[["linters"]],
@@ -279,14 +279,14 @@ test_that("retrieve_lint returns the same lints with lines added below", {
   lines1 <- test_data[["lines"]]
   lines2 <- c(lines1, "")
 
-  cache_lint(
+  lintr:::cache_lint(
     cache = e1,
     expr = test_data[["expr"]],
     linter = test_data[["linters"]],
     lints = test_data[["lints"]]
   )
 
-  t1 <- retrieve_lint(
+  t1 <- lintr:::retrieve_lint(
     cache = e1,
     expr = test_data[["expr"]],
     linter = test_data[["linters"]],
@@ -308,14 +308,14 @@ test_that(
 
     lints1 <- test_data[["lints"]]
 
-    cache_lint(
+    lintr:::cache_lint(
       cache = e1,
       expr = test_data[["expr"]],
       linter = test_data[["linters"]],
       lints = lints1
     )
 
-    t1 <- retrieve_lint(
+    t1 <- lintr:::retrieve_lint(
       cache = e1,
       expr = test_data[["expr"]],
       linter = test_data[["linters"]],
@@ -334,15 +334,15 @@ test_that("has_lint returns FALSE if there is no cached result", {
   e1 <- new.env(parent = emptyenv())
 
   t1 <- list(content = "foobar")
-  expect_false(has_lint(e1, t1, list()))
+  expect_false(lintr:::has_lint(e1, t1, list()))
 })
 
 test_that("has_lint returns TRUE if there is a cached result", {
   e1 <- new.env(parent = emptyenv())
 
   t1 <- list(content = "foobar")
-  cache_lint(e1, t1, list(), list())
-  expect_true(has_lint(e1, t1, list()))
+  lintr:::cache_lint(e1, t1, list(), list())
+  expect_true(lintr:::has_lint(e1, t1, list()))
 })
 
 test_that("has_lint distinguishes global expressions from line expression with same content", {
@@ -351,10 +351,10 @@ test_that("has_lint distinguishes global expressions from line expression with s
   same_content <- "foobar"
 
   line_expr <- list(content = same_content, parsed_content = data.frame())
-  cache_lint(e1, line_expr, list(), list())
+  lintr:::cache_lint(e1, line_expr, list(), list())
 
   global_expr <- list(content = same_content, file_lines = character())
-  expect_false(has_lint(e1, global_expr, list()))
+  expect_false(lintr:::has_lint(e1, global_expr, list()))
 })
 
 # `find_new_line`
@@ -365,11 +365,11 @@ test_that("find_new_line returns the same if the line is the same", {
     "foobar2",
     "foobar3"
   )
-  expect_equal(find_new_line(1L, "foobar1", t1), 1L)
+  expect_equal(lintr:::find_new_line(1L, "foobar1", t1), 1L)
 
-  expect_equal(find_new_line(2L, "foobar2", t1), 2L)
+  expect_equal(lintr:::find_new_line(2L, "foobar2", t1), 2L)
 
-  expect_equal(find_new_line(3L, "foobar3", t1), 3L)
+  expect_equal(lintr:::find_new_line(3L, "foobar3", t1), 3L)
 })
 
 test_that("find_new_line returns the correct line if it is before the current line", {
@@ -378,11 +378,11 @@ test_that("find_new_line returns the correct line if it is before the current li
     "foobar2",
     "foobar3"
   )
-  expect_equal(find_new_line(1L, "foobar1", t1), 1L)
+  expect_equal(lintr:::find_new_line(1L, "foobar1", t1), 1L)
 
-  expect_equal(find_new_line(2L, "foobar1", t1), 1L)
+  expect_equal(lintr:::find_new_line(2L, "foobar1", t1), 1L)
 
-  expect_equal(find_new_line(3L, "foobar1", t1), 1L)
+  expect_equal(lintr:::find_new_line(3L, "foobar1", t1), 1L)
 })
 
 test_that("find_new_line returns the correct line if it is after the current line", {
@@ -391,11 +391,11 @@ test_that("find_new_line returns the correct line if it is after the current lin
     "foobar2",
     "foobar3"
   )
-  expect_equal(find_new_line(1L, "foobar3", t1), 3L)
+  expect_equal(lintr:::find_new_line(1L, "foobar3", t1), 3L)
 
-  expect_equal(find_new_line(2L, "foobar3", t1), 3L)
+  expect_equal(lintr:::find_new_line(2L, "foobar3", t1), 3L)
 
-  expect_equal(find_new_line(3L, "foobar3", t1), 3L)
+  expect_equal(lintr:::find_new_line(3L, "foobar3", t1), 3L)
 })
 
 #

--- a/tests/testthat/test-ci.R
+++ b/tests/testthat/test-ci.R
@@ -14,7 +14,7 @@ test_that("GitHub Actions functionality works in a subdirectory", {
   withr::local_envvar(list(GITHUB_ACTIONS = "true"))
   withr::local_options(lintr.rstudio_source_markers = FALSE, lintr.github_annotation_project_dir = pkg_path)
 
-  read_settings(NULL)
+  lintr:::read_settings(NULL)
   l <- lint_package(
     pkg_path,
     linters = list(assignment_linter()),

--- a/tests/testthat/test-closed_curly_linter.R
+++ b/tests/testthat/test-closed_curly_linter.R
@@ -1,5 +1,5 @@
 test_that("returns the correct linting", {
-  closed_curly_message_regex <- rex(
+  closed_curly_message_regex <- rex::rex(
     paste(
       "Closing curly-braces should always be on their own line,",
       "unless they are followed by an else."

--- a/tests/testthat/test-commas_linter.R
+++ b/tests/testthat/test-commas_linter.R
@@ -1,7 +1,7 @@
 test_that("returns the correct linting", {
   linter <- commas_linter()
-  msg_after <- rex("Commas should always have a space after.")
-  msg_before <- rex("Commas should never have a space before.")
+  msg_after <- rex::rex("Commas should always have a space after.")
+  msg_before <- rex::rex("Commas should never have a space before.")
 
   expect_lint("blah", NULL, linter)
   expect_lint("fun(1, 1)", NULL, linter)

--- a/tests/testthat/test-commented_code_linter.R
+++ b/tests/testthat/test-commented_code_linter.R
@@ -1,5 +1,5 @@
 test_that("returns the correct linting", {
-  msg <- rex("Commented code should be removed.")
+  msg <- rex::rex("Commented code should be removed.")
   linter <- commented_code_linter()
   expect_s3_class(linter, "linter")
 
@@ -76,7 +76,7 @@ test_that("returns the correct linting", {
     linter
   )
 
-  test_ops <- append(ops[ops != "%[^%]*%"], values = c("%>%", "%anything%"))
+  test_ops <- append(lintr:::ops[lintr:::ops != "%[^%]*%"], values = c("%>%", "%anything%"))
   for (op in test_ops) {
     expect_lint(paste("i", op, "1", collapse = ""), NULL, linter)
     expect_lint(paste("# something like i", op, "1", collapse = ""), NULL, linter)

--- a/tests/testthat/test-comments.R
+++ b/tests/testthat/test-comments.R
@@ -14,9 +14,9 @@ clear_ci_info <- function() {
 test_that("it detects CI environments", {
   clear_ci_info()
   Sys.setenv(TRAVIS_REPO_SLUG = "foo/bar")
-  expect_true(in_ci())
+  expect_true(lintr:::in_ci())
   Sys.setenv(TRAVIS_REPO_SLUG = "")
-  expect_false(in_ci())
+  expect_false(lintr:::in_ci())
 })
 
 test_that("it returns NULL if GIT_URL is not on github", {
@@ -26,7 +26,7 @@ test_that("it returns NULL if GIT_URL is not on github", {
     GIT_URL = "https://example.com/user/repo.git",
     CHANGE_ID = "123"
   )
-  expect_false(in_ci())
+  expect_false(lintr:::in_ci())
 })
 
 test_that("it determines Jenkins PR build info", {
@@ -36,9 +36,9 @@ test_that("it determines Jenkins PR build info", {
     GIT_URL = "https://github.com/user/repo.git",
     CHANGE_ID = "123"
   )
-  expect_true(in_ci())
+  expect_true(lintr:::in_ci())
 
-  expect_equal(ci_build_info(), list(
+  expect_equal(lintr:::ci_build_info(), list(
     user = "user",
     repo = "repo",
     pull = "123",
@@ -46,7 +46,7 @@ test_that("it determines Jenkins PR build info", {
   ))
 
   Sys.unsetenv(c("JENKINS_URL", "GIT_URL", "CHANGE_ID"))
-  expect_false(in_ci())
+  expect_false(lintr:::in_ci())
 })
 
 test_that("it determines Jenkins commit build info", {
@@ -57,8 +57,8 @@ test_that("it determines Jenkins commit build info", {
     GIT_COMMIT = "abcde"
   )
 
-  expect_true(in_ci())
-  expect_equal(ci_build_info(), list(
+  expect_true(lintr:::in_ci())
+  expect_equal(lintr:::ci_build_info(), list(
     user = "user",
     repo = "repo",
     pull = NULL,

--- a/tests/testthat/test-dir_linters.R
+++ b/tests/testthat/test-dir_linters.R
@@ -20,7 +20,7 @@ test_that("lint all relevant directories in a package", {
     c("package.Rproj", "DESCRIPTION", "NAMESPACE", "lintr_test_config")
   )
 
-  read_settings(NULL)
+  lintr:::read_settings(NULL)
   lints <- lint_package(the_pkg, parse_settings = FALSE)
   linted_files <- unique(names(lints))
 
@@ -34,7 +34,7 @@ test_that("lint all relevant directories in a package", {
   # We want to ensure that object_name_linter uses namespace_imports correctly.
   # assignment_linter is needed to cause a lint in all vignettes.
   linters <- list(assignment_linter(), object_name_linter())
-  read_settings(NULL)
+  lintr:::read_settings(NULL)
   lints <- lint_package(the_pkg, linters = linters, parse_settings = FALSE)
   linted_files <- unique(names(lints))
 

--- a/tests/testthat/test-duplicate_argument_linter.R
+++ b/tests/testthat/test-duplicate_argument_linter.R
@@ -11,7 +11,7 @@ test_that("duplicate_argument_linter doesn't block allowed usages", {
 
 test_that("duplicate_argument_linter blocks disallowed usages", {
   linter <- duplicate_argument_linter()
-  msg <- rex("Duplicate arguments in function call.")
+  msg <- rex::rex("Duplicate arguments in function call.")
 
   expect_lint("fun(arg = 1, arg = 2)", msg, linter)
   expect_lint("fun(arg = 1, 'arg' = 2)", msg, linter)
@@ -51,13 +51,13 @@ test_that("duplicate_argument_linter respects except argument", {
     "fun(`
 ` = 1, `
 ` = 2)",
-    list(message = rex("Duplicate arguments in function call.")),
+    list(message = rex::rex("Duplicate arguments in function call.")),
     duplicate_argument_linter(except = character())
   )
 
   expect_lint(
     "function(arg = 1, arg = 1) {}",
-    list(message = rex("Repeated formal argument 'arg'.")),
+    list(message = rex::rex("Repeated formal argument 'arg'.")),
     duplicate_argument_linter(except = character())
   )
 })

--- a/tests/testthat/test-equals_na_linter.R
+++ b/tests/testthat/test-equals_na_linter.R
@@ -1,6 +1,6 @@
 test_that("returns the correct linting", {
   linter <- equals_na_linter()
-  msg <- rex("Use is.na for comparisons to NA (not == or !=)")
+  msg <- rex::rex("Use is.na for comparisons to NA (not == or !=)")
   expect_lint("blah", NULL, linter)
   expect_lint("  blah", NULL, linter)
   expect_lint("  blah", NULL, linter)

--- a/tests/testthat/test-error.R
+++ b/tests/testthat/test-error.R
@@ -1,5 +1,5 @@
 test_that("returns the correct linting", {
-  msg_escape_char <- rex("is an unrecognized escape in character string")
+  msg_escape_char <- rex::rex("is an unrecognized escape in character string")
   expect_lint('"\\R"', msg_escape_char)
   expect_lint('"\\A"', msg_escape_char)
   expect_lint('"\\z"', msg_escape_char)
@@ -7,15 +7,15 @@ test_that("returns the correct linting", {
     "a <- 1
     function() {
     b",
-    rex("unexpected end of input"),
+    rex::rex("unexpected end of input"),
     structure(function(...) NULL, class = "linter", name = "null")
   )
 
   linter <- equals_na_linter()
-  expect_lint("x=", rex("unexpected end of input"), linter)
-  expect_lint("x += 1", rex("unexpected '='"), linter)
-  expect_lint("{x = }", rex("unexpected '}'"), linter)
-  expect_lint("x = ;", rex("unexpected ';'"), linter)
+  expect_lint("x=", rex::rex("unexpected end of input"), linter)
+  expect_lint("x += 1", rex::rex("unexpected '='"), linter)
+  expect_lint("{x = }", rex::rex("unexpected '}'"), linter)
+  expect_lint("x = ;", rex::rex("unexpected ';'"), linter)
 
   # no parsing error is expected for the equals-assignment in this code
   expect_lint(
@@ -43,9 +43,9 @@ test_that("returns the correct linting", {
   }
 
   expected_message <- tryCatch(parse(text = "\\"), error = get_base_message)
-  expect_lint("\\", rex(expected_message))
+  expect_lint("\\", rex::rex(expected_message))
 
-  msg_zero_length_var <- rex("attempt to use zero-length variable name")
+  msg_zero_length_var <- rex::rex("attempt to use zero-length variable name")
   expect_lint("``", msg_zero_length_var)
   expect_lint("``()", msg_zero_length_var)
   expect_lint("''()", msg_zero_length_var)

--- a/tests/testthat/test-exclusions.R
+++ b/tests/testthat/test-exclusions.R
@@ -1,14 +1,14 @@
 test_that("line_info works as expected", {
   expect_identical(
-    line_info(integer(), type = "end"),
+    lintr:::line_info(integer(), type = "end"),
     "0 range ends"
   )
   expect_identical(
-    line_info(2L, type = "start"),
+    lintr:::line_info(2L, type = "start"),
     "1 range start (line 2)"
   )
   expect_identical(
-    line_info(c(2L, 5L), type = "end"),
+    lintr:::line_info(c(2L, 5L), type = "end"),
     "2 range ends (lines 2, 5)"
   )
 })
@@ -20,7 +20,7 @@ test_that("it excludes properly", {
     lintr.exclude_end = "#TeSt_NoLiNt_EnD"
   )
 
-  read_settings(NULL)
+  lintr:::read_settings(NULL)
 
   t1 <- lint("exclusions-test", parse_settings = FALSE)
 
@@ -49,33 +49,33 @@ test_that("it doesn't fail when encountering misspecified encodings", {
     lintr.exclude_start = "#TeSt_NoLiNt_StArT",
     lintr.exclude_end = "#TeSt_NoLiNt_EnD"
   )
-  read_settings(NULL)
+  lintr:::read_settings(NULL)
 
-  expect_length(parse_exclusions("dummy_projects/project/cp1252.R"), 0L)
+  expect_length(lintr:::parse_exclusions("dummy_projects/project/cp1252.R"), 0L)
 })
 
 test_that("it gives the expected error message when there is only one start but no end", {
-  read_settings(NULL)
+  lintr:::read_settings(NULL)
 
   expect_error(
-    parse_exclusions("dummy_projects/project/one_start_no_end.R"),
+    lintr:::parse_exclusions("dummy_projects/project/one_start_no_end.R"),
     "has 1 range start (line 3) but only 0 range ends for exclusion from linting",
     fixed = TRUE
   )
 })
 
 test_that("it gives the expected error message when there is mismatch between multiple starts and ends", {
-  read_settings(NULL)
+  lintr:::read_settings(NULL)
 
   expect_error(
-    parse_exclusions("dummy_projects/project/mismatched_starts_ends.R"),
+    lintr:::parse_exclusions("dummy_projects/project/mismatched_starts_ends.R"),
     "has 3 range starts (lines 3, 7, 11) but only 2 range ends (lines 1, 9) for exclusion from linting",
     fixed = TRUE
   )
 })
 
 test_that("partial matching works for exclusions but warns if no linter found", {
-  read_settings(NULL)
+  lintr:::read_settings(NULL)
 
   expect_warning(
     expect_warning(

--- a/tests/testthat/test-function_left_parentheses_linter.R
+++ b/tests/testthat/test-function_left_parentheses_linter.R
@@ -1,6 +1,6 @@
 test_that("returns the correct linting", {
   linter <- function_left_parentheses_linter()
-  msg <- rex("Remove spaces before the left parenthesis in a function call.")
+  msg <- rex::rex("Remove spaces before the left parenthesis in a function call.")
 
   expect_lint("blah", NULL, linter)
   expect_lint("print(blah)", NULL, linter)

--- a/tests/testthat/test-get_source_expressions.R
+++ b/tests/testthat/test-get_source_expressions.R
@@ -103,13 +103,13 @@ test_that("Multi-byte character truncated by parser is ignored", {
 
 test_that("Can read non UTF-8 file", {
   file <- test_path("dummy_projects", "project", "cp1252.R")
-  read_settings(file)
+  lintr:::read_settings(file)
   expect_null(get_source_expressions(file)$error)
 })
 
 test_that("Warns if encoding is misspecified", {
   file <- test_path("dummy_projects", "project", "cp1252.R")
-  read_settings(NULL)
+  lintr:::read_settings(NULL)
   the_lint <- lint(filename = file, parse_settings = FALSE)[[1L]]
   expect_s3_class(the_lint, "lint")
 
@@ -126,7 +126,7 @@ test_that("Warns if encoding is misspecified", {
   expect_identical(the_lint$line_number, 4L)
 
   file <- test_path("dummy_projects", "project", "cp1252_parseable.R")
-  read_settings(NULL)
+  lintr:::read_settings(NULL)
   the_lint <- lint(filename = file, parse_settings = FALSE)[[1L]]
   expect_s3_class(the_lint, "lint")
   expect_identical(the_lint$linter, "error")

--- a/tests/testthat/test-knitr_formats.R
+++ b/tests/testthat/test-knitr_formats.R
@@ -1,9 +1,9 @@
 regexes <- list(
-  assign = rex("Use <-, not =, for assignment."),
-  local_var = rex("local variable"),
-  quotes = rex("Only use double-quotes."),
-  trailing = rex("Trailing blank lines are superfluous."),
-  trailws = rex("Trailing whitespace is superfluous.")
+  assign = rex::rex("Use <-, not =, for assignment."),
+  local_var = rex::rex("local variable"),
+  quotes = rex::rex("Only use double-quotes."),
+  trailing = rex::rex("Trailing blank lines are superfluous."),
+  trailws = rex::rex("Trailing whitespace is superfluous.")
 )
 
 test_that("it handles dir", {

--- a/tests/testthat/test-line_length_linter.R
+++ b/tests/testthat/test-line_length_linter.R
@@ -1,6 +1,6 @@
 test_that("returns the correct linting", {
   linter <- line_length_linter(80L)
-  msg <- rex("Lines should not be more than 80 characters")
+  msg <- rex::rex("Lines should not be more than 80 characters")
 
   expect_lint("blah", NULL, linter)
   expect_lint(strrep("x", 80L), NULL, linter)
@@ -28,7 +28,7 @@ test_that("returns the correct linting", {
   )
 
   linter <- line_length_linter(20L)
-  msg <- rex("Lines should not be more than 20 characters")
+  msg <- rex::rex("Lines should not be more than 20 characters")
   expect_lint(strrep("a", 20L), NULL, linter)
   expect_lint(
     strrep("a", 22L), list(

--- a/tests/testthat/test-lint_package.R
+++ b/tests/testthat/test-lint_package.R
@@ -27,7 +27,7 @@ test_that(
       "jkl = 456",
       "mno = 789"
     )
-    read_settings(NULL)
+    lintr:::read_settings(NULL)
     lints_from_outside <- lint_package(
       pkg_path,
       linters = list(assignment_linter())

--- a/tests/testthat/test-make_linter_from_regex.R
+++ b/tests/testthat/test-make_linter_from_regex.R
@@ -1,5 +1,5 @@
 test_that("test make_linter_from_regex works", {
-  linter <- make_linter_from_regex("-", "style", "Silly lint.")()
+  linter <- lintr:::make_linter_from_regex("-", "style", "Silly lint.")()
   expect_lint("a <- 2L", "Silly lint.", linter)
   expect_lint("a = '2-3'", NULL, linter)
 })

--- a/tests/testthat/test-methods.R
+++ b/tests/testthat/test-methods.R
@@ -1,11 +1,11 @@
 test_that("it returns the input if less than the max", {
-  expect_equal(trim_output(character()), character())
+  expect_equal(lintr:::trim_output(character()), character())
 
-  expect_equal(trim_output("test", max = 10L), "test")
+  expect_equal(lintr:::trim_output("test", max = 10L), "test")
 })
 
 test_that("it returns the input trimmed strictly to max if no lints found", {
-  expect_equal(trim_output("testing a longer non_lint string", max = 7L), "testing")
+  expect_equal(lintr:::trim_output("testing a longer non_lint string", max = 7L), "testing")
 })
 
 test_that("it returns the input trimmed to the last full lint if one exists within the max", {
@@ -14,9 +14,9 @@ test_that("it returns the input trimmed to the last full lint if one exists with
     # Magic numbers expect newlines to be 1 character
     t1 <- gsub("\r\n", "\n", t1, fixed = TRUE)
   }
-  expect_equal(trim_output(t1, max = 200L), substr(t1, 1L, 195L))
-  expect_equal(trim_output(t1, max = 400L), substr(t1, 1L, 380L))
-  expect_equal(trim_output(t1, max = 2000L), substr(t1, 1L, 1930L))
+  expect_equal(lintr:::trim_output(t1, max = 200L), substr(t1, 1L, 195L))
+  expect_equal(lintr:::trim_output(t1, max = 400L), substr(t1, 1L, 380L))
+  expect_equal(lintr:::trim_output(t1, max = 2000L), substr(t1, 1L, 1930L))
 })
 
 test_that("as.data.frame.lints", {
@@ -55,7 +55,7 @@ test_that("as.data.frame.lints", {
   # Convert lints to data.frame
   lints <- structure(list(l1, l2), class = "lints")
   expect_s3_class(
-    df <- as.data.frame.lints(lints),
+    df <- lintr:::as.data.frame.lints(lints),
     "data.frame"
   )
 

--- a/tests/testthat/test-missing_argument_linter.R
+++ b/tests/testthat/test-missing_argument_linter.R
@@ -1,6 +1,6 @@
 test_that("returns the correct linting", {
   linter <- missing_argument_linter()
-  msg <- rex("Missing argument in function call.")
+  msg <- rex::rex("Missing argument in function call.")
 
   expect_lint("fun(x, a = 1)", NULL, linter)
   expect_lint("fun(x = 1, a = 1)", NULL, linter)

--- a/tests/testthat/test-missing_package_linter.R
+++ b/tests/testthat/test-missing_package_linter.R
@@ -1,6 +1,6 @@
 test_that("returns the correct linting", {
   linter <- missing_package_linter()
-  msg <- list(message = rex("Package 'statts' is not installed."))
+  msg <- list(message = rex::rex("Package 'statts' is not installed."))
 
   expect_lint("library(stats)", NULL, linter)
   expect_lint('library("stats")', NULL, linter)

--- a/tests/testthat/test-namespace.R
+++ b/tests/testthat/test-namespace.R
@@ -4,7 +4,7 @@ test_that("is_s3_generic", {
     UseMethod("func")
   }
 
-  expect_true(is_s3_generic(func))
+  expect_true(lintr:::is_s3_generic(func))
 })
 
 test_that("is_s3_generic doesn't error for namespace-qualified calls", {
@@ -12,6 +12,6 @@ test_that("is_s3_generic doesn't error for namespace-qualified calls", {
     pkg::call()
   }
 
-  expect_warning(result <- is_s3_generic(func), NA)
+  expect_warning(result <- lintr:::is_s3_generic(func), NA)
   expect_false(result)
 })

--- a/tests/testthat/test-no_tab_linter.R
+++ b/tests/testthat/test-no_tab_linter.R
@@ -1,6 +1,6 @@
 test_that("returns the correct linting", {
   linter <- no_tab_linter()
-  msg <- rex("Use spaces to indent, not tabs.")
+  msg <- rex::rex("Use spaces to indent, not tabs.")
 
   expect_lint("blah", NULL, linter)
   expect_lint("  blah", NULL, linter)

--- a/tests/testthat/test-normalize_exclusions.R
+++ b/tests/testthat/test-normalize_exclusions.R
@@ -13,17 +13,17 @@ b <- normalizePath(b)
 c <- normalizePath(c)
 
 test_that("it merges two NULL or empty objects as an empty list", {
-  expect_equal(normalize_exclusions(c(NULL, NULL)), list())
-  expect_equal(normalize_exclusions(c(NULL, list())), list())
-  expect_equal(normalize_exclusions(c(list(), NULL)), list())
-  expect_equal(normalize_exclusions(c(list(), list())), list())
+  expect_equal(lintr:::normalize_exclusions(c(NULL, NULL)), list())
+  expect_equal(lintr:::normalize_exclusions(c(NULL, list())), list())
+  expect_equal(lintr:::normalize_exclusions(c(list(), NULL)), list())
+  expect_equal(lintr:::normalize_exclusions(c(list(), list())), list())
 })
 
 test_that("it returns the object if the other is NULL", {
   t1 <- list()
   t1[[a]] <- list(1L:10L)
-  expect_equal(normalize_exclusions(c(t1, NULL)), t1)
-  expect_equal(normalize_exclusions(c(NULL, t1)), t1)
+  expect_equal(lintr:::normalize_exclusions(c(t1, NULL)), t1)
+  expect_equal(lintr:::normalize_exclusions(c(NULL, t1)), t1)
 })
 
 test_that("it returns the union of two non-overlapping lists", {
@@ -33,7 +33,7 @@ test_that("it returns the union of two non-overlapping lists", {
   t2[[a]] <- list(20L:30L)
   res <- list()
   res[[a]] <- list(c(1L:10L, 20L:30L))
-  expect_equal(normalize_exclusions(c(t1, t2)), res)
+  expect_equal(lintr:::normalize_exclusions(c(t1, t2)), res)
 })
 
 test_that("it works with named lists", {
@@ -43,7 +43,7 @@ test_that("it works with named lists", {
   t2[[a]] <- list(11L:15L, my_linter = 21L:25L)
   res <- list()
   res[[a]] <- list(1L:15L, my_linter = 1L:25L)
-  expect_equal(normalize_exclusions(c(t1, t2)), res)
+  expect_equal(lintr:::normalize_exclusions(c(t1, t2)), res)
 })
 
 test_that("it returns the union of two overlapping lists", {
@@ -53,7 +53,7 @@ test_that("it returns the union of two overlapping lists", {
   t2[[a]] <- list(5L:15L)
   res <- list()
   res[[a]] <- list(1L:15L)
-  expect_equal(normalize_exclusions(c(t1, t2)), res)
+  expect_equal(lintr:::normalize_exclusions(c(t1, t2)), res)
 })
 
 test_that("it adds names if needed", {
@@ -64,13 +64,13 @@ test_that("it adds names if needed", {
   res <- list()
   res[[a]] <- list(1L:10L)
   res[[b]] <- list(5L:15L)
-  expect_equal(normalize_exclusions(c(t1, t2)), res)
+  expect_equal(lintr:::normalize_exclusions(c(t1, t2)), res)
 })
 
 test_that("it handles full file exclusions", {
   res <- list()
   res[[a]] <- list(Inf)
-  expect_equal(normalize_exclusions(list(a)), res)
+  expect_equal(lintr:::normalize_exclusions(list(a)), res)
 
   t1 <- list()
   t1[[1L]] <- a
@@ -78,7 +78,7 @@ test_that("it handles full file exclusions", {
   res <- list()
   res[[a]] <- list(Inf)
   res[[b]] <- list(1L)
-  expect_equal(normalize_exclusions(t1), res)
+  expect_equal(lintr:::normalize_exclusions(t1), res)
 })
 
 test_that("it handles redundant lines", {
@@ -86,7 +86,7 @@ test_that("it handles redundant lines", {
   t1[[a]] <- list(c(1L, 1L, 1L:10L))
   res <- list()
   res[[a]] <- list(1L:10L)
-  expect_equal(normalize_exclusions(t1), res)
+  expect_equal(lintr:::normalize_exclusions(t1), res)
 
   t1 <- list()
   t1[[a]] <- list(c(1L, 1L, 1L:10L))
@@ -94,7 +94,7 @@ test_that("it handles redundant lines", {
   res <- list()
   res[[a]] <- list(1L:10L)
   res[[b]] <- list(1L:10L)
-  expect_equal(normalize_exclusions(t1), res)
+  expect_equal(lintr:::normalize_exclusions(t1), res)
 })
 
 test_that("it handles redundant linters", {
@@ -102,7 +102,7 @@ test_that("it handles redundant linters", {
   t1[[a]] <- list(c(1L, 1L, 1L:10L), my_linter = c(1L, 1L, 1L, 2L), my_linter = 3L)
   res <- list()
   res[[a]] <- list(1L:10L, my_linter = 1L:3L)
-  expect_equal(normalize_exclusions(t1), res)
+  expect_equal(lintr:::normalize_exclusions(t1), res)
 
   t1 <- list()
   t1[[a]] <- list(c(1L, 1L, 1L:10L), my_linter = c(1L, 1L, 1L, 2L))
@@ -110,7 +110,7 @@ test_that("it handles redundant linters", {
   res <- list()
   res[[a]] <- list(1L:10L, my_linter = 1L:2L)
   res[[b]] <- list(1L:10L, my_linter = 1L:20L)
-  expect_equal(normalize_exclusions(t1), res)
+  expect_equal(lintr:::normalize_exclusions(t1), res)
 })
 
 test_that("it handles redundant files", {
@@ -118,7 +118,7 @@ test_that("it handles redundant files", {
   names(t1) <- c(a, a)
   res <- list()
   res[[a]] <- list(1L:20L)
-  expect_equal(normalize_exclusions(t1), res)
+  expect_equal(lintr:::normalize_exclusions(t1), res)
 })
 
 test_that("it normalizes file paths, removing non-existing files", {
@@ -131,23 +131,23 @@ test_that("it normalizes file paths, removing non-existing files", {
   res <- list()
   res[[a]] <- list(1L:10L)
   res[[normalizePath(c)]] <- list(5L:15L)
-  expect_equal(normalize_exclusions(c(t1, t2, t3)), res)
+  expect_equal(lintr:::normalize_exclusions(c(t1, t2, t3)), res)
 
   res <- list()
   res[[a]] <- list(1L:10L)
   res[["notafile"]] <- list(5L:15L)
   res[[c]] <- list(5L:15L)
-  expect_equal(normalize_exclusions(c(t1, t2, t3), normalize_path = FALSE), res)
+  expect_equal(lintr:::normalize_exclusions(c(t1, t2, t3), normalize_path = FALSE), res)
 })
 
 test_that("it errors for invalid specifications", {
   msg_full_files <- "Full file exclusions must be character vectors of length 1."
-  expect_error(normalize_exclusions(2L), msg_full_files)
-  expect_error(normalize_exclusions(list("a.R", 2L)), msg_full_files)
-  expect_error(normalize_exclusions(list("a.R" = Inf, 2L)), msg_full_files)
+  expect_error(lintr:::normalize_exclusions(2L), msg_full_files)
+  expect_error(lintr:::normalize_exclusions(list("a.R", 2L)), msg_full_files)
+  expect_error(lintr:::normalize_exclusions(list("a.R" = Inf, 2L)), msg_full_files)
 
   msg_full_lines <- "Full line exclusions must be numeric or integer vectors."
-  expect_error(normalize_exclusions(list("a.R" = "Inf")), msg_full_lines)
+  expect_error(lintr:::normalize_exclusions(list("a.R" = "Inf")), msg_full_lines)
 })
 
 unlink(c(a, b, c))

--- a/tests/testthat/test-object_length_linter.R
+++ b/tests/testthat/test-object_length_linter.R
@@ -1,6 +1,6 @@
 test_that("returns the correct linting", {
   linter <- object_length_linter()
-  lint_msg <- rex("Variable and function names should not be longer than 30 characters.")
+  lint_msg <- rex::rex("Variable and function names should not be longer than 30 characters.")
 
   expect_lint("blah", NULL, linter)
 
@@ -8,7 +8,7 @@ test_that("returns the correct linting", {
 
   expect_lint(
     "very_very_very_very_long_variable_names_are_not_ideal <<- 'foo'",
-    rex("Variable and function names should not be longer than 40 characters."),
+    rex::rex("Variable and function names should not be longer than 40 characters."),
     object_length_linter(length = 40L)
   )
 })
@@ -16,7 +16,7 @@ test_that("returns the correct linting", {
 # Regression tests for #871
 test_that("lints S3 generics correctly", {
   linter <- object_length_linter()
-  lint_msg <- rex("Variable and function names should not be longer than 30 characters.")
+  lint_msg <- rex::rex("Variable and function names should not be longer than 30 characters.")
 
   expect_lint("print.very_very_long_class_name <- 1", NULL, linter)
   expect_lint("print.very_very_very_very_long_class_name <- 1", lint_msg, linter)

--- a/tests/testthat/test-object_name_linter.R
+++ b/tests/testthat/test-object_name_linter.R
@@ -1,6 +1,6 @@
 test_that("styles are correctly identified", {
-  styles <- names(style_regexes)
-  do_style_check <- function(nms) lapply(styles, check_style, nms = nms)
+  styles <- names(lintr:::style_regexes)
+  do_style_check <- function(nms) lapply(styles, lintr:::check_style, nms = nms)
   #                                            symbl   UpC   lowC   snake  SNAKE  dot    allow  ALLUP
   expect_identical(do_style_check("x"),   list(FALSE, FALSE, TRUE,  TRUE,  FALSE, TRUE,   TRUE,  FALSE))
   expect_identical(do_style_check(".x"),  list(FALSE, FALSE, TRUE,  TRUE,  FALSE, TRUE,   TRUE,  FALSE))

--- a/tests/testthat/test-object_usage_linter.R
+++ b/tests/testthat/test-object_usage_linter.R
@@ -33,7 +33,7 @@ test_that("returns the correct linting", {
         a <- 1
       }
     "),
-    rex("local variable", anything, "assigned but may not be used"),
+    rex::rex("local variable", anything, "assigned but may not be used"),
     linter
   )
 
@@ -44,7 +44,7 @@ test_that("returns the correct linting", {
         1
       }
     "),
-    rex("local variable", anything, "assigned but may not be used"),
+    rex::rex("local variable", anything, "assigned but may not be used"),
     linter
   )
 
@@ -54,7 +54,7 @@ test_that("returns the correct linting", {
         a <- 1
       }
     "),
-    rex("local variable", anything, "assigned but may not be used"),
+    rex::rex("local variable", anything, "assigned but may not be used"),
     linter
   )
 
@@ -65,7 +65,7 @@ test_that("returns the correct linting", {
         a = 1
       }
     "),
-    rex("local variable", anything, "assigned but may not be used"),
+    rex::rex("local variable", anything, "assigned but may not be used"),
     linter
   )
 
@@ -77,8 +77,8 @@ test_that("returns the correct linting", {
       }
     "),
     list(
-      rex("local variable", anything, "assigned but may not be used"),
-      rex("no visible binding for global variable ", anything)
+      rex::rex("local variable", anything, "assigned but may not be used"),
+      rex::rex("no visible binding for global variable ", anything)
     ),
     linter
   )
@@ -89,7 +89,7 @@ test_that("returns the correct linting", {
         fnu(1)
       }
     "),
-    rex("no visible global function definition for ", anything),
+    rex::rex("no visible global function definition for ", anything),
     linter
   )
 
@@ -101,7 +101,7 @@ test_that("returns the correct linting", {
         `__lintr_obj`(1)
       }
     "),
-    rex("no visible global function definition for ", anything),
+    rex::rex("no visible global function definition for ", anything),
     linter
   )
 
@@ -114,7 +114,7 @@ test_that("returns the correct linting", {
         1
       })
     "),
-    rex("local variable", anything, "assigned but may not be used"),
+    rex::rex("local variable", anything, "assigned but may not be used"),
     linter
   )
 
@@ -125,7 +125,7 @@ test_that("returns the correct linting", {
         1
       })
     "),
-    rex("local variable", anything, "assigned but may not be used"),
+    rex::rex("local variable", anything, "assigned but may not be used"),
     linter
   )
 })
@@ -137,7 +137,7 @@ test_that("replace_functions_stripped", {
         `__lintr_obj`(x) = 1
       }
     "),
-    rex("no visible global function definition for ", anything),
+    rex::rex("no visible global function definition for ", anything),
     object_usage_linter()
   )
 
@@ -147,7 +147,7 @@ test_that("replace_functions_stripped", {
         `__lintr_obj`(x) <- 1
       }
     "),
-    rex("no visible global function definition for ", anything),
+    rex::rex("no visible global function definition for ", anything),
     object_usage_linter()
   )
 })

--- a/tests/testthat/test-paren_brace_linter.R
+++ b/tests/testthat/test-paren_brace_linter.R
@@ -4,7 +4,7 @@ test_that("returns the correct linting", {
     "Linter paren_brace_linter was deprecated",
     fixed = TRUE
   )
-  msg <- rex("There should be a space between right parenthesis and an opening curly brace.")
+  msg <- rex::rex("There should be a space between right parenthesis and an opening curly brace.")
 
   expect_lint("blah", NULL, linter)
   expect_lint("blah <- function() {}", NULL, linter)

--- a/tests/testthat/test-parse_exclusions.R
+++ b/tests/testthat/test-parse_exclusions.R
@@ -5,18 +5,18 @@ old_ops <- options(
 )
 
 test_that("it returns an empty list if there are no exclusions", {
-  read_settings(NULL)
+  lintr:::read_settings(NULL)
   t1 <- withr::local_tempfile(lines = trim_some("
     this
     is
     a
     test
    "))
-  expect_equal(parse_exclusions(t1), list())
+  expect_equal(lintr:::parse_exclusions(t1), list())
 })
 
 test_that("it returns the line if one line is excluded", {
-  read_settings(NULL)
+  lintr:::read_settings(NULL)
 
   t1 <- tempfile()
   on.exit(unlink(t1))
@@ -26,7 +26,7 @@ test_that("it returns the line if one line is excluded", {
     a
     test
   "), t1)
-  expect_equal(parse_exclusions(t1), list(2L))
+  expect_equal(lintr:::parse_exclusions(t1), list(2L))
 
   t2 <- tempfile()
   on.exit(unlink(t2))
@@ -36,11 +36,11 @@ test_that("it returns the line if one line is excluded", {
     a
     test #TeSt_NoLiNt
   "), t2)
-  expect_equal(parse_exclusions(t2), list(c(2L, 4L)))
+  expect_equal(lintr:::parse_exclusions(t2), list(c(2L, 4L)))
 })
 
 test_that("it supports specific linter exclusions", {
-  read_settings(NULL)
+  lintr:::read_settings(NULL)
 
   t1 <- tempfile()
   on.exit(unlink(t1))
@@ -50,7 +50,7 @@ test_that("it supports specific linter exclusions", {
     a
     test
   "), t1)
-  expect_equal(parse_exclusions(t1), list(my_linter = 2L))
+  expect_equal(lintr:::parse_exclusions(t1), list(my_linter = 2L))
 
   t2 <- tempfile()
   on.exit(unlink(t2))
@@ -60,7 +60,7 @@ test_that("it supports specific linter exclusions", {
     a
     test #TeSt_NoLiNt: my_linter2.
   "), t2)
-  expect_equal(parse_exclusions(t2), list(my_linter = 2L, my_linter2 = 4L))
+  expect_equal(lintr:::parse_exclusions(t2), list(my_linter = 2L, my_linter2 = 4L))
 
   t3 <- tempfile()
   on.exit(unlink(t3))
@@ -72,7 +72,7 @@ test_that("it supports specific linter exclusions", {
     test
     testing #TeSt_NoLiNt: my_linter2.
   "), t2)
-  expect_equal(parse_exclusions(t2), list(my_linter = c(2L, 4L), my_linter2 = 6L))
+  expect_equal(lintr:::parse_exclusions(t2), list(my_linter = c(2L, 4L), my_linter2 = 6L))
 })
 
 test_that("it supports multiple linter exclusions", {
@@ -92,7 +92,7 @@ test_that("it supports multiple linter exclusions", {
     each #TeSt_NoLiNt_EnD
     other
   "), t1)
-  expect_equal(parse_exclusions(t1), list(
+  expect_equal(lintr:::parse_exclusions(t1), list(
     a = c(2L, 4L:6L),
     b = c(2L, 4L:6L),
     c = 4L:6L,
@@ -112,14 +112,14 @@ test_that("it supports overlapping exclusion ranges", {
     overlapping #TeSt_NoLiNt_EnD
     ranges
   "), t1)
-  expect_equal(parse_exclusions(t1), list(
+  expect_equal(lintr:::parse_exclusions(t1), list(
     a = 1L:5L,
     b = 3L:6L
   ))
 })
 
 test_that("it returns all lines between start and end", {
-  read_settings(NULL)
+  lintr:::read_settings(NULL)
 
   t1 <- tempfile()
   on.exit(unlink(t1))
@@ -129,7 +129,7 @@ test_that("it returns all lines between start and end", {
     a #TeSt_NoLiNt_EnD
     test
   "), t1)
-  expect_equal(parse_exclusions(t1), list(c(1L, 2L, 3L)))
+  expect_equal(lintr:::parse_exclusions(t1), list(c(1L, 2L, 3L)))
 
   t2 <- tempfile()
   on.exit(unlink(t2))
@@ -144,11 +144,11 @@ test_that("it returns all lines between start and end", {
     broadcast
     system
   "), t2)
-  expect_equal(parse_exclusions(t2), list(c(1L, 2L, 3L, 6L, 7L)))
+  expect_equal(lintr:::parse_exclusions(t2), list(c(1L, 2L, 3L, 6L, 7L)))
 })
 
 test_that("it ignores exclude coverage lines within start and end", {
-  read_settings(NULL)
+  lintr:::read_settings(NULL)
 
   t1 <- tempfile()
   on.exit(unlink(t1))
@@ -160,11 +160,11 @@ test_that("it ignores exclude coverage lines within start and end", {
       "test"
     ), t1
   )
-  expect_equal(parse_exclusions(t1), list(c(1L, 2L, 3L)))
+  expect_equal(lintr:::parse_exclusions(t1), list(c(1L, 2L, 3L)))
 })
 
 test_that("it throws an error if start and end are unpaired", {
-  read_settings(NULL)
+  lintr:::read_settings(NULL)
 
   t1 <- tempfile()
   on.exit(unlink(t1))
@@ -174,7 +174,7 @@ test_that("it throws an error if start and end are unpaired", {
     a
     test
   "), t1)
-  expect_error(parse_exclusions(t1), "but only")
+  expect_error(lintr:::parse_exclusions(t1), "but only")
 
 
   t2 <- tempfile()
@@ -185,7 +185,7 @@ test_that("it throws an error if start and end are unpaired", {
     a  #TeSt_NoLiNt_EnD
     test
   "), t2)
-  expect_error(parse_exclusions(t2), "but only")
+  expect_error(lintr:::parse_exclusions(t2), "but only")
 })
 
 options(old_ops)

--- a/tests/testthat/test-pipe_continuation_linter.R
+++ b/tests/testthat/test-pipe_continuation_linter.R
@@ -1,4 +1,4 @@
-pipe_error <- rex(
+pipe_error <- rex::rex(
   paste(
     "`%>%` should always have a space before it and a new line after it,",
     "unless the full pipeline fits on one line."

--- a/tests/testthat/test-seq_linter.R
+++ b/tests/testthat/test-seq_linter.R
@@ -20,25 +20,25 @@ test_that("finds seq(...) expressions", {
 
   expect_lint(
     "function(x) { seq(length(x)) }",
-    rex("seq(length(...))", anything, "Use seq_along(...)"),
+    rex::rex("seq(length(...))", anything, "Use seq_along(...)"),
     linter
   )
 
   expect_lint(
     "function(x) { seq(nrow(x)) }",
-    rex("seq(nrow(...))", anything, "Use seq_len(nrow(...))"),
+    rex::rex("seq(nrow(...))", anything, "Use seq_len(nrow(...))"),
     linter
   )
 
   expect_lint(
     "function(x) { rev(seq(length(x))) }",
-    rex("seq(length(...))", anything, "Use seq_along(...)"),
+    rex::rex("seq(length(...))", anything, "Use seq_along(...)"),
     linter
   )
 
   expect_lint(
     "function(x) { rev(seq(nrow(x))) }",
-    rex("seq(nrow(...))", anything, "Use seq_len(nrow(...))"),
+    rex::rex("seq(nrow(...))", anything, "Use seq_len(nrow(...))"),
     linter
   )
 })
@@ -48,55 +48,55 @@ test_that("finds 1:length(...) expressions", {
 
   expect_lint(
     "function(x) { 1:length(x) }",
-    rex("length(...)", anything, "Use seq_along"),
+    rex::rex("length(...)", anything, "Use seq_along"),
     linter
   )
 
   expect_lint(
     "function(x) { 1:nrow(x) }",
-    rex("nrow(...)", anything, "Use seq_len"),
+    rex::rex("nrow(...)", anything, "Use seq_len"),
     linter
   )
 
   expect_lint(
     "function(x) { 1:ncol(x) }",
-    rex("ncol(...)", anything, "Use seq_len"),
+    rex::rex("ncol(...)", anything, "Use seq_len"),
     linter
   )
 
   expect_lint(
     "function(x) { 1:NROW(x) }",
-    rex("NROW(...)", anything, "Use seq_len"),
+    rex::rex("NROW(...)", anything, "Use seq_len"),
     linter
   )
 
   expect_lint(
     "function(x) { 1:NCOL(x) }",
-    rex("NCOL(...)", anything, "Use seq_len"),
+    rex::rex("NCOL(...)", anything, "Use seq_len"),
     linter
   )
 
   expect_lint(
     "function(x) { 1:dim(x)[1L] }",
-    rex("dim(...)", anything, "Use seq_len"),
+    rex::rex("dim(...)", anything, "Use seq_len"),
     linter
   )
 
   expect_lint(
     "function(x) { 1L:dim(x)[[1]] }",
-    rex("dim(...)", anything, "Use seq_len"),
+    rex::rex("dim(...)", anything, "Use seq_len"),
     linter
   )
 
   expect_lint(
     "function(x) { mutate(x, .id = 1:n()) }",
-    rex("n() is", anything, "Use seq_len"),
+    rex::rex("n() is", anything, "Use seq_len"),
     linter
   )
 
   expect_lint(
     "function(x) { x[, .id := 1:.N] }",
-    rex(".N is", anything, "Use seq_len"),
+    rex::rex(".N is", anything, "Use seq_len"),
     linter
   )
 })
@@ -104,7 +104,7 @@ test_that("finds 1:length(...) expressions", {
 test_that("1L is also bad", {
   expect_lint(
     "function(x) { 1L:length(x) }",
-    rex("1L:length(...)", anything, "Use seq_along"),
+    rex::rex("1L:length(...)", anything, "Use seq_along"),
     seq_linter()
   )
 })
@@ -116,7 +116,7 @@ test_that("reverse seq is ok", {
 
   expect_lint(
     "function(x) { length(x):1 }",
-    rex("length(...):1", anything, "Use seq_along"),
+    rex::rex("length(...):1", anything, "Use seq_along"),
     seq_linter()
   )
 })

--- a/tests/testthat/test-single_quotes_linter.R
+++ b/tests/testthat/test-single_quotes_linter.R
@@ -1,6 +1,6 @@
 test_that("returns the correct linting", {
   linter <- single_quotes_linter()
-  msg <- rex("Only use double-quotes.")
+  msg <- rex::rex("Only use double-quotes.")
 
   expect_lint("blah", NULL, linter)
   expect_lint("\"blah\"", NULL, linter)

--- a/tests/testthat/test-spaces_left_parentheses_linter.R
+++ b/tests/testthat/test-spaces_left_parentheses_linter.R
@@ -1,6 +1,6 @@
 test_that("returns the correct linting", {
   linter <- spaces_left_parentheses_linter()
-  msg <- rex("Place a space before left parenthesis, except in a function call.")
+  msg <- rex::rex("Place a space before left parenthesis, except in a function call.")
 
   expect_lint("blah", NULL, linter)
   expect_lint("print(blah)", NULL, linter)

--- a/tests/testthat/test-sprintf_linter.R
+++ b/tests/testthat/test-sprintf_linter.R
@@ -39,19 +39,19 @@ test_that("returns the correct linting", {
 
   expect_lint(
     "sprintf('hello %d', 'a')",
-    list(message = rex("invalid format '%d'; use format %s for character objects")),
+    list(message = rex::rex("invalid format '%d'; use format %s for character objects")),
     linter
   )
 
   expect_lint(
     "sprintf('hello %d', 1.5)",
-    list(message = rex("invalid format '%d'; use format %f, %e, %g or %a for numeric objects")),
+    list(message = rex::rex("invalid format '%d'; use format %f, %e, %g or %a for numeric objects")),
     linter
   )
 
   expect_lint(
     "sprintf('hello %d',)",
-    list(message = rex("argument is missing, with no default")),
+    list(message = rex::rex("argument is missing, with no default")),
     linter
   )
 
@@ -81,13 +81,13 @@ test_that("returns the correct linting", {
 
   expect_lint(
     "sprintf('hello %1$s %1$s %3$d', x, y)",
-    list(message = rex("reference to non-existent argument 3")),
+    list(message = rex::rex("reference to non-existent argument 3")),
     linter
   )
 
   expect_lint(
     "sprintf('hello %1$s %1$s %2$d %3$d', x, y, 1.5)",
-    list(message = rex("invalid format '%d'; use format %f, %e, %g or %a for numeric objects")),
+    list(message = rex::rex("invalid format '%d'; use format %f, %e, %g or %a for numeric objects")),
     linter
   )
 
@@ -131,7 +131,7 @@ test_that("edge cases are detected correctly", {
 
   expect_lint(
     "sprintf(x, fmt = 'hello %1$s %1$s %3$d', y)",
-    list(message = rex("reference to non-existent argument 3")),
+    list(message = rex::rex("reference to non-existent argument 3")),
     linter
   )
 })

--- a/tests/testthat/test-trailing_blank_lines_linter.R
+++ b/tests/testthat/test-trailing_blank_lines_linter.R
@@ -1,7 +1,7 @@
 test_that("returns the correct linting", {
   linter <- trailing_blank_lines_linter()
-  msg <- rex("Trailing blank lines are superfluous.")
-  msg2 <- rex("Missing terminal newline.")
+  msg <- rex::rex("Trailing blank lines are superfluous.")
+  msg2 <- rex::rex("Missing terminal newline.")
 
   expect_lint("blah", NULL, linter)
   expect_lint("blah <- 1  ", NULL, linter)

--- a/tests/testthat/test-trailing_whitespace_linter.R
+++ b/tests/testthat/test-trailing_whitespace_linter.R
@@ -5,19 +5,19 @@ test_that("returns the correct linting", {
 
   expect_lint(
     "blah <- 1  ",
-    list(message = rex("Trailing whitespace is superfluous."), column_number = 10L),
+    list(message = rex::rex("Trailing whitespace is superfluous."), column_number = 10L),
     linter
   )
 
   expect_lint(
     "blah <- 1  \n'hi'",
-    rex("Trailing whitespace is superfluous."),
+    rex::rex("Trailing whitespace is superfluous."),
     linter
   )
 
   expect_lint(
     "blah <- 1\n'hi'\na <- 2  ",
-    list(message = rex("Trailing whitespace is superfluous."), line_number = 3L),
+    list(message = rex::rex("Trailing whitespace is superfluous."), line_number = 3L),
     linter
   )
 })
@@ -27,13 +27,13 @@ test_that("also handles completely empty lines per allow_empty_lines argument", 
 
   expect_lint(
     "blah <- 1\n  \n'hi'\na <- 2",
-    list(message = rex("Trailing whitespace is superfluous."), line_number = 2L),
+    list(message = rex::rex("Trailing whitespace is superfluous."), line_number = 2L),
     linter
   )
 
   expect_lint(
     "blah <- 1  ",
-    list(message = rex("Trailing whitespace is superfluous."), column_number = 10L),
+    list(message = rex::rex("Trailing whitespace is superfluous."), column_number = 10L),
     trailing_whitespace_linter(allow_empty_lines = TRUE)
   )
 

--- a/tests/testthat/test-use_lintr.R
+++ b/tests/testthat/test-use_lintr.R
@@ -8,11 +8,11 @@ test_that("use_lintr works as expected", {
   expect_error(use_lintr(path = tmp), "Found an existing configuration")
 
   # read_settings() works with the generated file
-  expect_silent(read_settings(tmp))
-  read_settings(NULL)
+  expect_silent(lintr:::read_settings(tmp))
+  lintr:::read_settings(NULL)
 
   expect_equal(
-    normalizePath(find_config(tmp)),
+    normalizePath(lintr:::find_config(tmp)),
     normalizePath(lintr_file)
   )
 })
@@ -22,6 +22,6 @@ test_that("use_lintr with type = full also works", {
 
   # type = "full" also works with read_settings()
   use_lintr(path = tmp, type = "full")
-  expect_silent(read_settings(tmp))
-  read_settings(NULL)
+  expect_silent(lintr:::read_settings(tmp))
+  lintr:::read_settings(NULL)
 })


### PR DESCRIPTION
I did a run of running our tests directly with `source()` rather than through `testthat` functions, so we can tell where private functions are used.

I think in general we should try and replace these tests with tests on the public API, and resort to private API tests only for crucial internal code that's too gnarly to test the "proper" way.

But for now, happy to just make clear where these private API tests are by qualifying `:::`.

Also ensured `rex::rex()` is used everywhere for consistency.