### PR TITLE
Handle <<reference_chunks>> in Rnw,Rmd

### DIFF
--- a/.lintr_new
+++ b/.lintr_new
@@ -12,13 +12,17 @@ linters: linters_with_defaults(
     expect_s4_class_linter(),
     expect_true_false_linter(),
     expect_type_linter(),
+    for_loop_index_linter(),
     implicit_integer_linter(),
     line_length_linter(120),
     missing_argument_linter(),
     nested_ifelse_linter(),
     numeric_leading_zero_linter(),
+    paste_linter(),
     redundant_equals_linter(),
-    redundant_ifelse_linter()
+    redundant_ifelse_linter(),
+    unnecessary_lambda_linter(),
+    unneeded_concatenation_linter()
   )
 exclusions: list(
     "inst/doc/creating_linters.R" = 1,

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,7 +4,8 @@
 
 * `fixed_regex_linter()` no longer fails with regular expression pattern `"\\;"` (#1545, @IndrajeetPatil).
 
-* `get_source_expressions()` can handle reference chunks in Sweave and Rmd files like `<<ref_file>>` (#779, @MichaelChirico)
+* `get_source_expressions()` can handle Sweave/Rmarkdown documents with reference chunks like `<<ref_file>>` (#779, @MichaelChirico).
+  Note that these are simply skipped, rather than attempting to retrieve the reference & also lint it.
 
 ## Changes to defaults
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,8 @@
 
 * `fixed_regex_linter()` no longer fails with regular expression pattern `"\\;"` (#1545, @IndrajeetPatil).
 
+* `get_source_expressions()` can handle reference chunks in Sweave and Rmd files like `<<ref_file>>` (#779, @MichaelChirico)
+
 ## Changes to defaults
 
 * Set the default for the `except` argument in `duplicate_argument_linter()` to `c("mutate", "transmute")`.

--- a/R/extract.R
+++ b/R/extract.R
@@ -20,7 +20,7 @@ extract_r_source <- function(filename, lines, error = identity) {
     return(output)
   }
 
-  output_env <- environment()
+  output_env <- environment() # nolint: object_usage_linter. False positive-ish -- used below.
   Map(
     function(start, end) {
       line_seq <- seq(start + 1L, end - 1L)

--- a/R/extract.R
+++ b/R/extract.R
@@ -20,13 +20,17 @@ extract_r_source <- function(filename, lines, error = identity) {
     return(output)
   }
 
+  output_env <- environment()
   Map(
     function(start, end) {
-      output[seq(start + 1L, end - 1L)] <<- lines[seq(start + 1L, end - 1L)]
+      line_seq <- seq(start + 1L, end - 1L)
+      output_env$output[line_seq] <- lines[line_seq]
     },
     chunks[["starts"]],
     chunks[["ends"]]
   )
+  # drop <<chunk>> references, too
+  is.na(output) <- grep(pattern$ref.chunk, output)
   replace_prefix(output, pattern$chunk.code)
 }
 

--- a/tests/testthat/test-get_source_expressions.R
+++ b/tests/testthat/test-get_source_expressions.R
@@ -309,6 +309,13 @@ test_that("Syntax errors in Rmd or qmd don't choke lintr", {
   expect_silent(get_source_expressions(tmp))
 })
 
+test_that("Reference chunks in Sweave/Rmd are ignored", {
+  example_rnw <- system.file("Sweave", "example-1.Rnw", package = "utils")
+  # ensure such a chunk continues to exist upstream
+  expect_true(any(grepl("^\\s*<<[^>]*>>\\s*$", readLines(example_rnw))))
+  expect_silent(lint(example_rnw))
+})
+
 skip_if_not_installed("patrick")
 # NB: this is just a cursory test for linters not to
 #   fail on files where the XML content is xml_missing;


### PR DESCRIPTION
Closes #779

I didn't see any `<<examples>>` included with {knitr}, but the solution is simple enough & basically re-uses stuff directly from {knitr}, so I didn't feel too compelled to add any more tests.