### PR TITLE
Use {withr} more comprehensively in tests to manage state

### DIFF
--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -1,6 +1,9 @@
 library(testthat)
 library(lintr)
-loadNamespace("rex")
-loadNamespace("withr")
+# suppress printing environment name (noisy)
+invisible({
+  loadNamespace("rex")
+  loadNamespace("withr")
+})
 
 test_check("lintr")

--- a/tests/testthat/helper.R
+++ b/tests/testthat/helper.R
@@ -45,6 +45,13 @@ trim_some <- function(x, num = NULL) {
   rex::re_substitutes(x, rex::rex(start, n_times(any, num)), "", global = TRUE, options = "multi-line")
 }
 
+local_config <- function(config_dir, contents, .local_envir = parent.frame()) {
+  config_path <- file.path(config_dir, ".lintr")
+  cat(contents, file = config_path)
+  withr::defer(unlink(config_path), envir = .local_envir)
+  config_path
+}
+
 skip_if_not_r_version <- function(min_version) {
   if (getRversion() < min_version) {
     testthat::skip(paste("R version at least", min_version, "is required"))

--- a/tests/testthat/helper.R
+++ b/tests/testthat/helper.R
@@ -47,7 +47,7 @@ trim_some <- function(x, num = NULL) {
 
 local_config <- function(config_dir, contents, .local_envir = parent.frame()) {
   config_path <- file.path(config_dir, ".lintr")
-  cat(contents, file = config_path)
+  writeLines(contents, config_path)
   withr::defer(unlink(config_path), envir = .local_envir)
   config_path
 }

--- a/tests/testthat/test-backport_linter.R
+++ b/tests/testthat/test-backport_linter.R
@@ -13,8 +13,7 @@ test_that("backport_linter detects backwards-incompatibility", {
   expect_lint(".getNamespaceInfo(dir.exists(lapply(x, toTitleCase)))", NULL, backport_linter("devel"))
 
   # don't allow dependencies older than we've recorded
-  writeLines("x <- x + 1", tmp <- tempfile())
-  on.exit(unlink(tmp))
+  tmp <- withr::local_tempfile(lines = "x <- x + 1")
 
   expect_warning(l <- lint(tmp, backport_linter("2.0.0")), "version older than 3.0.0", fixed = TRUE)
   expect_identical(l, lint(tmp, backport_linter("3.0.0")))

--- a/tests/testthat/test-cache.R
+++ b/tests/testthat/test-cache.R
@@ -147,9 +147,7 @@ test_that("save_cache saves all non-hidden objects from the environment", {
 test_that("cache_file generates the same cache with different lints", {
   e1 <- new.env(parent = emptyenv())
 
-  f1 <- tempfile()
-  writeLines("foobar", f1)
-  on.exit(unlink(f1))
+  f1 <- withr::local_tempfile(lines = "foobar")
 
   lintr:::cache_file(e1, f1, list(), list())
   lintr:::cache_file(e1, f1, list(), list(1L))
@@ -160,9 +158,7 @@ test_that("cache_file generates the same cache with different lints", {
 test_that("cache_file generates different caches for different linters", {
   e1 <- new.env(parent = emptyenv())
 
-  f1 <- tempfile()
-  writeLines("foobar", f1)
-  on.exit(unlink(f1))
+  f1 <- withr::local_tempfile(lines = "foobar")
 
   lintr:::cache_file(e1, f1, list(), list())
   lintr:::cache_file(e1, f1, list(1L), list())
@@ -175,9 +171,7 @@ test_that("cache_file generates different caches for different linters", {
 test_that("retrieve_file returns NULL if there is no cached result", {
   e1 <- new.env(parent = emptyenv())
 
-  f1 <- tempfile()
-  writeLines("foobar", f1)
-  on.exit(unlink(f1))
+  f1 <- withr::local_tempfile(lines = "foobar")
 
   expect_null(lintr:::retrieve_file(e1, f1, list()))
 })
@@ -185,9 +179,7 @@ test_that("retrieve_file returns NULL if there is no cached result", {
 test_that("retrieve_file returns the cached result if found", {
   e1 <- new.env(parent = emptyenv())
 
-  f1 <- tempfile()
-  writeLines("foobar", f1)
-  on.exit(unlink(f1))
+  f1 <- withr::local_tempfile(lines = "foobar")
 
   lintr:::cache_file(e1, f1, list(), list("foobar"))
   expect_equal(lintr:::retrieve_file(e1, f1, list()), list("foobar"))
@@ -446,8 +438,7 @@ test_that("cache = TRUE workflow works", {
 
 test_that("cache = TRUE works with nolint", {
   linters <- list(infix_spaces_linter())
-  file <- tempfile()
-  on.exit(unlink(file))
+  file <- withr::local_tempfile()
 
   writeLines("1+1\n", file)
   expect_length(lint(file, linters, cache = TRUE), 1L)

--- a/tests/testthat/test-cache.R
+++ b/tests/testthat/test-cache.R
@@ -34,7 +34,7 @@ test_that("clear_cache deletes the file if a file is given", {
   mockery::stub(clear_cache, "unlink", function(...) list(...))
 
   e1 <- new.env(parent = emptyenv())
-  d1 <- tempfile(pattern = "lintr_cache_")
+  d1 <- withr::local_tempfile(pattern = "lintr_cache_")
   f1 <- "R/test.R"
   lintr:::save_cache(cache = e1, file = f1, path = d1)
 
@@ -55,7 +55,7 @@ test_that("clear_cache deletes the directory if no file is given", {
 test_that("load_cache loads the saved file in a new empty environment", {
   e1 <- new.env(parent = emptyenv())
   e1[["x"]] <- "foobar"
-  d1 <- tempfile(pattern = "lintr_cache_")
+  d1 <- withr::local_tempfile(pattern = "lintr_cache_")
   f1 <- "R/test.R"
   lintr:::save_cache(cache = e1, file = f1, path = d1)
   e2 <- lintr:::load_cache(file = f1, path = d1)
@@ -65,7 +65,7 @@ test_that("load_cache loads the saved file in a new empty environment", {
 
 test_that("load_cache returns an empty environment if no cache file exists", {
   e1 <- new.env(parent = emptyenv())
-  d1 <- tempfile(pattern = "lintr_cache_")
+  d1 <- withr::local_tempfile(pattern = "lintr_cache_")
   f1 <- "R/test.R"
   f2 <- "test.R"
 
@@ -78,7 +78,7 @@ test_that("load_cache returns an empty environment if no cache file exists", {
 test_that("load_cache returns an empty environment if reading cache file fails", {
   e1 <- new.env(parent = emptyenv())
   e1[["x"]] <- "foobar"
-  d1 <- tempfile(pattern = "lintr_cache_")
+  d1 <- withr::local_tempfile(pattern = "lintr_cache_")
   f1 <- "R/test.R"
   lintr:::save_cache(cache = e1, file = f1, path = d1)
   cache_f1 <- file.path(d1, fhash(f1))
@@ -96,7 +96,7 @@ test_that("load_cache returns an empty environment if reading cache file fails",
 
 test_that("save_cache creates a directory if needed", {
   e1 <- new.env(parent = emptyenv())
-  d1 <- tempfile(pattern = "lintr_cache_")
+  d1 <- withr::local_tempfile(pattern = "lintr_cache_")
   f1 <- "R/test.R"
 
   expect_false(file.exists(d1))
@@ -111,7 +111,7 @@ test_that("save_cache creates a directory if needed", {
 
 test_that("save_cache uses unambiguous cache file names", {
   e1 <- new.env(parent = emptyenv())
-  d1 <- tempfile(pattern = "lintr_cache_")
+  d1 <- withr::local_tempfile(pattern = "lintr_cache_")
   f1 <- "R/test.R"
   f2 <- "test.R"
 
@@ -131,7 +131,7 @@ test_that("save_cache saves all non-hidden objects from the environment", {
   e1$t1 <- 1L
   e1$t2 <- 2L
 
-  d1 <- tempfile(pattern = "lintr_cache_")
+  d1 <- withr::local_tempfile(pattern = "lintr_cache_")
   f1 <- "R/test.R"
 
   lintr:::save_cache(cache = e1, file = f1, path = d1)
@@ -393,8 +393,7 @@ test_that("find_new_line returns the correct line if it is after the current lin
 #
 
 test_that("lint with cache uses the provided relative cache directory", {
-  path <- "./my_cache_dir"
-  expect_false(dir.exists(path))
+  path <- withr::local_tempdir("my_cache_dir")
   linter <- assignment_linter()
 
   # create the cache
@@ -405,15 +404,13 @@ test_that("lint with cache uses the provided relative cache directory", {
   # read the cache
   expect_lint("a <- 1", NULL, linter, cache = path)
   expect_true(dir.exists(path))
-
-  unlink(path, recursive = TRUE)
 })
 
 test_that("it works outside of a package", {
   linter <- assignment_linter()
 
   mockery::stub(lintr:::find_default_encoding, "find_package", function(...) NULL)
-  path <- tempfile(pattern = "my_cache_dir_")
+  path <- withr::local_tempfile(pattern = "my_cache_dir_")
   expect_false(dir.exists(path))
   expect_lint("a <- 1", NULL, linter, cache = path)
   expect_true(dir.exists(path))

--- a/tests/testthat/test-checkstyle_output.R
+++ b/tests/testthat/test-checkstyle_output.R
@@ -28,8 +28,8 @@ test_that("return lint report as checkstyle xml", {
     ),
     class = "lints"
   )
-  tmp <- tempfile()
+  tmp <- withr::local_tempfile()
   checkstyle_output(lints, tmp)
 
-  expect_equal(readLines(tmp), readLines("checkstyle.xml"))
+  expect_identical(readLines(tmp), readLines(test_path("checkstyle.xml")))
 })

--- a/tests/testthat/test-get_source_expressions.R
+++ b/tests/testthat/test-get_source_expressions.R
@@ -1,9 +1,10 @@
 with_content_to_parse <- function(content, code) {
-  f <- tempfile()
-  con <- file(f, open = "w", encoding = "UTF-8")
-  on.exit(unlink(f))
-  writeLines(content, con)
-  close(con)
+  f <- withr::local_tempfile()
+  local({
+    con <- file(f, open = "w", encoding = "UTF-8")
+    on.exit(close(con))
+    writeLines(content, con)
+  })
   source_expressions <- get_source_expressions(f)
   content_env <- new.env()
   content_env$pc <- lapply(source_expressions[["expressions"]], `[[`, "parsed_content")
@@ -69,14 +70,11 @@ test_that("tab positions have been corrected", {
 })
 
 test_that("Terminal newlines are detected correctly", {
-  writeLines("lm(y ~ x)", tmp <- tempfile())
-  on.exit(unlink(tmp), add = TRUE)
-  writeBin(
-    # strip the last (two) element(s) (\r\n or \n)
-    head(readBin(tmp, raw(), file.size(tmp)), if (.Platform$OS.type == "windows") -2L else -1L),
-    tmp2 <- tempfile()
-  )
-  on.exit(unlink(tmp2), add = TRUE)
+  content <- "lm(y ~ x)"
+  # NB: need to specify terminal newline explicitly with cat, not writeLines()
+  tmp <- withr::local_tempfile(lines = content)
+  tmp2 <- withr::local_tempfile()
+  cat(content, file = tmp2)
 
   expect_true(get_source_expressions(tmp)$expressions[[2L]]$terminal_newline)
   expect_false(get_source_expressions(tmp2)$expressions[[2L]]$terminal_newline)

--- a/tests/testthat/test-lint_file.R
+++ b/tests/testthat/test-lint_file.R
@@ -110,12 +110,7 @@ test_that("lint uses linter names", {
 
 test_that("lint() results from file or text should be consistent", {
   linters <- list(assignment_linter(), infix_spaces_linter())
-  file <- tempfile()
-  lines <- c(
-    "x<-1",
-    "x+1"
-  )
-  writeLines(lines, file)
+  file <- withr::local_tempfile(lines = c("x<-1", "x+1"))
   text <- paste0(lines, collapse = "\n")
   file <- normalizePath(file)
 
@@ -125,7 +120,7 @@ test_that("lint() results from file or text should be consistent", {
 
   # Remove file before linting to ensure that lint works and do not
   # assume that file exists when both filename and text are supplied.
-  unlink(file)
+  expect_identical(unlink(file), 0L)
   lint_from_text2 <- lint(file, linters = linters, text = text)
 
   expect_length(lint_from_file, 2L)

--- a/tests/testthat/test-lint_file.R
+++ b/tests/testthat/test-lint_file.R
@@ -11,7 +11,7 @@ test_that("lint() results do not depend on the working directory", {
   pkg_path <- test_path("dummy_packages", "assignmentLinter")
 
   # put a .lintr in the package root that excludes the first line of `R/jkl.R`
-  local_config(pkg_path, "exclusions: list('R/jkl.R' = 1)\n")
+  local_config(pkg_path, "exclusions: list('R/jkl.R' = 1)")
 
   # linting the `R/jkl.R` should identify the following assignment lint on the
   # second line of the file
@@ -77,7 +77,7 @@ test_that("lint() results do not depend on the position of the .lintr", {
     pkg_path,
     lint_with_config(
       config_dir = ".",
-      config_string = "exclusions: list('R/jkl.R' = 1)\n",
+      config_string = "exclusions: list('R/jkl.R' = 1)",
       filename = file.path("R", "jkl.R")
     )
   )
@@ -86,7 +86,7 @@ test_that("lint() results do not depend on the position of the .lintr", {
     pkg_path,
     lint_with_config(
       config_dir = "R",
-      config_string = "exclusions: list('jkl.R' = 1)\n",
+      config_string = "exclusions: list('jkl.R' = 1)",
       filename = file.path("R", "jkl.R")
     )
   )

--- a/tests/testthat/test-lint_file.R
+++ b/tests/testthat/test-lint_file.R
@@ -110,7 +110,8 @@ test_that("lint uses linter names", {
 
 test_that("lint() results from file or text should be consistent", {
   linters <- list(assignment_linter(), infix_spaces_linter())
-  file <- withr::local_tempfile(lines = c("x<-1", "x+1"))
+  lines <- c("x<-1", "x+1")
+  file <- withr::local_tempfile(lines = lines)
   text <- paste0(lines, collapse = "\n")
   file <- normalizePath(file)
 

--- a/tests/testthat/test-lint_file.R
+++ b/tests/testthat/test-lint_file.R
@@ -11,10 +11,7 @@ test_that("lint() results do not depend on the working directory", {
   pkg_path <- test_path("dummy_packages", "assignmentLinter")
 
   # put a .lintr in the package root that excludes the first line of `R/jkl.R`
-  config_path <- file.path(pkg_path, ".lintr")
-  config_string <- "exclusions: list('R/jkl.R' = 1)\n"
-  cat(config_string, file = config_path)
-  on.exit(unlink(config_path))
+  local_config(pkg_path, "exclusions: list('R/jkl.R' = 1)\n")
 
   # linting the `R/jkl.R` should identify the following assignment lint on the
   # second line of the file
@@ -60,9 +57,8 @@ test_that("lint() results do not depend on the position of the .lintr", {
   # - the same directory as filepath
   # - the project directory
   # - the user's home directory
-  lint_with_config <- function(config_path, config_string, filename) {
-    cat(config_string, file = config_path)
-    on.exit(unlink(config_path))
+  lint_with_config <- function(config_dir, config_string, filename) {
+    local_config(config_dir, config_string)
     lint(filename, linters = assignment_linter())
   }
 
@@ -80,7 +76,7 @@ test_that("lint() results do not depend on the position of the .lintr", {
   lints_with_config_at_pkg_root <- withr::with_dir(
     pkg_path,
     lint_with_config(
-      config_path = ".lintr",
+      config_dir = ".",
       config_string = "exclusions: list('R/jkl.R' = 1)\n",
       filename = file.path("R", "jkl.R")
     )
@@ -89,7 +85,7 @@ test_that("lint() results do not depend on the position of the .lintr", {
   lints_with_config_in_r_dir <- withr::with_dir(
     pkg_path,
     lint_with_config(
-      config_path = "R/.lintr",
+      config_dir = "R",
       config_string = "exclusions: list('jkl.R' = 1)\n",
       filename = file.path("R", "jkl.R")
     )

--- a/tests/testthat/test-lint_package.R
+++ b/tests/testthat/test-lint_package.R
@@ -75,15 +75,10 @@ test_that(
     # the test checks both approaches
 
     pkg_path <- test_path("dummy_packages", "assignmentLinter")
-    config_path <- file.path(pkg_path, ".lintr")
 
     # Add a .lintr that excludes the whole of `abc.R` and the first line of
     # `jkl.R` (and remove it on finishing this test)
-    cat(
-      "exclusions: list('R/abc.R', 'R/jkl.R' = 1)\n",
-      file = config_path
-    )
-    on.exit(unlink(config_path))
+    local_config(pkg_path, "exclusions: list('R/abc.R', 'R/jkl.R' = 1)\n")
 
     expected_lines <- "mno = 789"
     lints_from_outside <- lint_package(

--- a/tests/testthat/test-lint_package.R
+++ b/tests/testthat/test-lint_package.R
@@ -78,7 +78,7 @@ test_that(
 
     # Add a .lintr that excludes the whole of `abc.R` and the first line of
     # `jkl.R` (and remove it on finishing this test)
-    local_config(pkg_path, "exclusions: list('R/abc.R', 'R/jkl.R' = 1)\n")
+    local_config(pkg_path, "exclusions: list('R/abc.R', 'R/jkl.R' = 1)")
 
     expected_lines <- "mno = 789"
     lints_from_outside <- lint_package(

--- a/tests/testthat/test-methods.R
+++ b/tests/testthat/test-methods.R
@@ -134,16 +134,14 @@ test_that("print.lint works for inline data, even in RStudio", {
 
 test_that("print.lints works", {
   withr::local_options(lintr.rstudio_source_markers = FALSE)
-  tmp <- tempfile()
-  file.create(tmp)
-  on.exit(unlink(tmp))
+  tmp <- withr::local_tempfile()
 
+  expect_true(file.create(tmp))
   expect_invisible(print(lint(tmp)))
 })
 
 test_that("split.lint works as intended", {
-  writeLines("1:nrow(x)\n1:ncol(x)", tmp <- tempfile())
-  on.exit(unlink(tmp))
+  tmp <- withr::local_tempfile(lines = c("1:nrow(x)", "1:ncol(x)"))
 
   l <- lint(tmp, seq_linter())
   expect_true(all(vapply(split(l), inherits, logical(1L), "lints")))

--- a/tests/testthat/test-normalize_exclusions.R
+++ b/tests/testthat/test-normalize_exclusions.R
@@ -1,12 +1,12 @@
-old_ops <- options(
+withr::local_options(list(
   lintr.exclude = "#TeSt_NoLiNt",
   lintr.exclude_start = "#TeSt_NoLiNt_StArT",
   lintr.exclude_end = "#TeSt_NoLiNt_EnD"
-)
+))
 
-a <- tempfile()
-b <- tempfile()
-c <- tempfile(tmpdir = ".")
+a <- withr::local_tempfile()
+b <- withr::local_tempfile()
+c <- withr::local_tempfile(tmpdir = ".")
 file.create(a, b, c)
 a <- normalizePath(a)
 b <- normalizePath(b)
@@ -149,6 +149,3 @@ test_that("it errors for invalid specifications", {
   msg_full_lines <- "Full line exclusions must be numeric or integer vectors."
   expect_error(lintr:::normalize_exclusions(list("a.R" = "Inf")), msg_full_lines)
 })
-
-unlink(c(a, b, c))
-options(old_ops)

--- a/tests/testthat/test-parse_exclusions.R
+++ b/tests/testthat/test-parse_exclusions.R
@@ -1,8 +1,8 @@
-old_ops <- options(
+withr::local_options(list(
   lintr.exclude = "#TeSt_NoLiNt",
   lintr.exclude_start = "#TeSt_NoLiNt_StArT",
   lintr.exclude_end = "#TeSt_NoLiNt_EnD"
-)
+))
 
 test_that("it returns an empty list if there are no exclusions", {
   lintr:::read_settings(NULL)
@@ -18,67 +18,55 @@ test_that("it returns an empty list if there are no exclusions", {
 test_that("it returns the line if one line is excluded", {
   lintr:::read_settings(NULL)
 
-  t1 <- tempfile()
-  on.exit(unlink(t1))
-  writeLines(trim_some("
+  t1 <- withr::local_tempfile(lines = trim_some("
     this
     is #TeSt_NoLiNt
     a
     test
-  "), t1)
+  "))
   expect_equal(lintr:::parse_exclusions(t1), list(2L))
 
-  t2 <- tempfile()
-  on.exit(unlink(t2))
-  writeLines(trim_some("
+  t2 <- withr::local_tempfile(lines = trim_some("
     this
     is #TeSt_NoLiNt
     a
     test #TeSt_NoLiNt
-  "), t2)
+  "))
   expect_equal(lintr:::parse_exclusions(t2), list(c(2L, 4L)))
 })
 
 test_that("it supports specific linter exclusions", {
   lintr:::read_settings(NULL)
 
-  t1 <- tempfile()
-  on.exit(unlink(t1))
-  writeLines(trim_some("
+  t1 <- withr::local_tempfile(lines = trim_some("
     this
     is #TeSt_NoLiNt: my_linter.
     a
     test
-  "), t1)
+  "))
   expect_equal(lintr:::parse_exclusions(t1), list(my_linter = 2L))
 
-  t2 <- tempfile()
-  on.exit(unlink(t2))
-  writeLines(trim_some("
+  t2 <- withr::local_tempfile(lines = trim_some("
     this
     is #TeSt_NoLiNt: my_linter.
     a
     test #TeSt_NoLiNt: my_linter2.
-  "), t2)
+  "))
   expect_equal(lintr:::parse_exclusions(t2), list(my_linter = 2L, my_linter2 = 4L))
 
-  t3 <- tempfile()
-  on.exit(unlink(t3))
-  writeLines(trim_some("
+  t3 <- withr::local_tempfile(lines = trim_some("
     this
     is #TeSt_NoLiNt: my_linter.
     another
     useful #TeSt_NoLiNt: my_linter.
     test
     testing #TeSt_NoLiNt: my_linter2.
-  "), t2)
-  expect_equal(lintr:::parse_exclusions(t2), list(my_linter = c(2L, 4L), my_linter2 = 6L))
+  "))
+  expect_equal(lintr:::parse_exclusions(t3), list(my_linter = c(2L, 4L), my_linter2 = 6L))
 })
 
 test_that("it supports multiple linter exclusions", {
-  t1 <- tempfile()
-  on.exit(unlink(t1))
-  writeLines(trim_some("
+  t1 <- withr::local_tempfile(lines = trim_some("
     this #TeSt_NoLiNt
     is #TeSt_NoLiNt: a, b.
     a
@@ -91,7 +79,7 @@ test_that("it supports multiple linter exclusions", {
     with
     each #TeSt_NoLiNt_EnD
     other
-  "), t1)
+  "))
   expect_equal(lintr:::parse_exclusions(t1), list(
     a = c(2L, 4L:6L),
     b = c(2L, 4L:6L),
@@ -101,9 +89,7 @@ test_that("it supports multiple linter exclusions", {
 })
 
 test_that("it supports overlapping exclusion ranges", {
-  t1 <- tempfile()
-  on.exit(unlink(t1))
-  writeLines(trim_some("
+  t1 <- withr::local_tempfile(lines = trim_some("
     this #TeSt_NoLiNt_StArT: a.
     is
     a #TeSt_NoLiNt_StArT: b.
@@ -111,7 +97,7 @@ test_that("it supports overlapping exclusion ranges", {
     with #TeSt_NoLiNt_EnD
     overlapping #TeSt_NoLiNt_EnD
     ranges
-  "), t1)
+  "))
   expect_equal(lintr:::parse_exclusions(t1), list(
     a = 1L:5L,
     b = 3L:6L
@@ -121,19 +107,15 @@ test_that("it supports overlapping exclusion ranges", {
 test_that("it returns all lines between start and end", {
   lintr:::read_settings(NULL)
 
-  t1 <- tempfile()
-  on.exit(unlink(t1))
-  writeLines(trim_some("
+  t1 <- withr::local_tempfile(lines = trim_some("
     this #TeSt_NoLiNt_StArT
     is
     a #TeSt_NoLiNt_EnD
     test
-  "), t1)
+  "))
   expect_equal(lintr:::parse_exclusions(t1), list(c(1L, 2L, 3L)))
 
-  t2 <- tempfile()
-  on.exit(unlink(t2))
-  writeLines(trim_some("
+  t2 <- withr::local_tempfile(lines = trim_some("
     this #TeSt_NoLiNt_StArT
     is
     a #TeSt_NoLiNt_EnD
@@ -143,49 +125,39 @@ test_that("it returns all lines between start and end", {
     emergency #TeSt_NoLiNt_EnD
     broadcast
     system
-  "), t2)
+  "))
   expect_equal(lintr:::parse_exclusions(t2), list(c(1L, 2L, 3L, 6L, 7L)))
 })
 
 test_that("it ignores exclude coverage lines within start and end", {
   lintr:::read_settings(NULL)
 
-  t1 <- tempfile()
-  on.exit(unlink(t1))
-  writeLines(
-    c(
-      "this #TeSt_NoLiNt_StArT",
-      "is #TeSt_NoLiNt",
-      "a #TeSt_NoLiNt_EnD",
-      "test"
-    ), t1
-  )
+  t1 <- withr::local_tempfile(lines = c(
+    "this #TeSt_NoLiNt_StArT",
+    "is #TeSt_NoLiNt",
+    "a #TeSt_NoLiNt_EnD",
+    "test"
+  ))
   expect_equal(lintr:::parse_exclusions(t1), list(c(1L, 2L, 3L)))
 })
 
 test_that("it throws an error if start and end are unpaired", {
   lintr:::read_settings(NULL)
 
-  t1 <- tempfile()
-  on.exit(unlink(t1))
-  writeLines(trim_some("
+  t1 <- withr::local_tempfile(lines = trim_some("
     this #TeSt_NoLiNt_StArT
     is #TeSt_NoLiNt
     a
     test
-  "), t1)
+  "))
   expect_error(lintr:::parse_exclusions(t1), "but only")
 
 
-  t2 <- tempfile()
-  on.exit(unlink(t2))
-  writeLines(trim_some("
+  t2 <- withr::local_tempfile(lines = trim_some("
     this #TeSt_NoLiNt_StArT
     is #TeSt_NoLiNt_EnD
     a  #TeSt_NoLiNt_EnD
     test
-  "), t2)
+  "))
   expect_error(lintr:::parse_exclusions(t2), "but only")
 })
-
-options(old_ops)

--- a/tests/testthat/test-settings.R
+++ b/tests/testthat/test-settings.R
@@ -17,7 +17,7 @@ test_that("it uses option settings if provided", {
 test_that("it uses config settings in same directory if provided", {
   test_dir <- tempdir()
   file <- withr::local_tempfile(tmpdir = test_dir)
-  local_config(test_dir, 'exclude: "test"\n')
+  local_config(test_dir, 'exclude: "test"')
 
   read_settings(file)
 
@@ -32,7 +32,7 @@ test_that("it uses config home directory settings if provided", {
   path <- withr::local_tempdir()
   home_path <- withr::local_tempdir()
   file <- withr::local_tempfile(tmpdir = path)
-  local_config(home_path, 'exclude: "test"\n')
+  local_config(home_path, 'exclude: "test"')
 
   withr::with_envvar(c(HOME = home_path), read_settings(file))
 

--- a/tests/testthat/test-settings.R
+++ b/tests/testthat/test-settings.R
@@ -7,8 +7,7 @@ test_that("it uses default settings if none provided", {
 })
 
 test_that("it uses option settings if provided", {
-  old_opts <- options("lintr.exclude" = "test")
-  on.exit(options(old_opts))
+  withr::local_options(list(lintr.exclude = "test"))
 
   read_settings(NULL)
 
@@ -16,17 +15,9 @@ test_that("it uses option settings if provided", {
 })
 
 test_that("it uses config settings in same directory if provided", {
-  path <- tempdir()
-  file <- tempfile(tmpdir = path)
-  config_file <- file.path(path, ".lintr")
-  writeLines("exclude: \"test\"", config_file)
-  on.exit(
-    {
-      unlink(file)
-      unlink(config_file)
-    },
-    add = TRUE
-  )
+  test_dir <- tempdir()
+  file <- withr::local_tempfile(tmpdir = test_dir)
+  local_config(test_dir, 'exclude: "test"\n')
 
   read_settings(file)
 
@@ -38,22 +29,10 @@ test_that("it uses config settings in same directory if provided", {
 })
 
 test_that("it uses config home directory settings if provided", {
-  path <- tempfile()
-  home_path <- tempfile()
-  dir.create(path)
-  dir.create(home_path)
-  file <- tempfile(tmpdir = path)
-  config_file <- file.path(home_path, ".lintr")
-  writeLines("exclude: \"test\"", config_file)
-  on.exit(
-    {
-      unlink(file)
-      unlink(config_file)
-      unlink(path)
-      unlink(home_path)
-    },
-    add = TRUE
-  )
+  path <- withr::local_tempdir()
+  home_path <- withr::local_tempdir()
+  file <- withr::local_tempfile(tmpdir = path)
+  local_config(home_path, 'exclude: "test"\n')
 
   withr::with_envvar(c(HOME = home_path), read_settings(file))
 
@@ -65,11 +44,9 @@ test_that("it uses config home directory settings if provided", {
 })
 
 test_that("it errors if the config file does not end in a newline", {
-  f <- tempfile()
+  f <- withr::local_tempfile()
   cat("linters: linters_with_defaults(closed_curly_linter = NULL)", file = f)
-  old <- options()
-  on.exit(options(old))
-  options("lintr.linter_file" = f)
+  withr::local_options(list(lintr.linter_file = f))
   expect_error(read_settings("foo"), "Malformed config file")
 })
 


### PR DESCRIPTION
I couldn't remove all `on.exit()` usages, here's what remains:

```r
tests/testthat/test-error.R:29:  on.exit(lintr:::reset_lang(old_lang), add = TRUE)
tests/testthat/test-get_source_expressions.R:5:    on.exit(close(con))
tests/testthat/test-object_usage_linter.R:312:  on.exit(utils::globalVariables(old_globals, package = globalenv(), add = FALSE))
tests/testthat/test-settings.R:61:  on.exit(if (is.na(old)) Sys.unsetenv(test_env) else sym_set_env(test_env, old))
```

Of those

 - test-error.R: can't be removed unless we add a custom unexported `local_lang()`
 - test-get_source_expressions.R: see https://github.com/r-lib/withr/issues/210
 - test-object_usage_linter.R: I support we could use `withr::defer()`, but `on.exit()` seems fine here
 - test-settings.R: this _may_ be replaced by `withr::local_envvar()`, but I was too lazy to play around with it & ensure it works