### PR TITLE
Additional test for `namespace_linter()`+ clean-up

### DIFF
--- a/tests/testthat/test-namespace_linter.R
+++ b/tests/testthat/test-namespace_linter.R
@@ -1,35 +1,25 @@
-test_that("returns the correct linting", {
+test_that("namespace_linter skips allowed usages", {
   linter <- namespace_linter()
 
-  expect_lint(
-    "stats::sd",
-    NULL,
-    linter
-  )
+  expect_lint("stats::sd", NULL, linter)
+  expect_lint("stats::sd(c(1,2,3))", NULL, linter)
+  expect_lint('"stats"::sd(c(1,2,3))', NULL, linter)
+  expect_lint('stats::"sd"(c(1,2,3))', NULL, linter)
+  expect_lint("stats::`sd`(c(1,2,3))", NULL, linter)
 
-  expect_lint(
-    "stats::sd(c(1,2,3))",
-    NULL,
-    linter
-  )
+  expect_lint("datasets::mtcars", NULL, linter)
+  expect_lint("stats:::print.formula", NULL, linter)
+  expect_lint('"stats":::print.formula', NULL, linter)
+})
 
-  expect_lint(
-    '"stats"::sd(c(1,2,3))',
-    NULL,
-    linter
-  )
+test_that("namespace_linter respects check_exports and check_nonexports arguments", {
+  expect_lint("stats::ssd(c(1,2,3))", NULL, namespace_linter(check_exports = FALSE))
+  expect_lint("stats:::ssd(c(1,2,3))", NULL, namespace_linter(check_nonexports = FALSE))
+  expect_lint("stats:::ssd(c(1,2,3))", NULL, namespace_linter(check_exports = FALSE, check_nonexports = FALSE))
+})
 
-  expect_lint(
-    'stats::"sd"(c(1,2,3))',
-    NULL,
-    linter
-  )
-
-  expect_lint(
-    "stats::`sd`(c(1,2,3))",
-    NULL,
-    linter
-  )
+test_that("namespace_linter blocks disallowed usages", {
+  linter <- namespace_linter()
 
   expect_lint(
     "statts::sd(c(1,2,3))",
@@ -40,24 +30,6 @@ test_that("returns the correct linting", {
   expect_lint(
     "stats::ssd(c(1,2,3))",
     list(message = rex::rex("'ssd' is not exported from {stats}")),
-    linter
-  )
-
-  expect_lint(
-    "stats::ssd(c(1,2,3))",
-    NULL,
-    namespace_linter(check_exports = FALSE)
-  )
-
-  expect_lint(
-    "datasets::mtcars",
-    NULL,
-    linter
-  )
-
-  expect_lint(
-    "stats:::print.formula",
-    NULL,
     linter
   )
 
@@ -77,12 +49,6 @@ test_that("returns the correct linting", {
     "stats:::sdd(c(1,2,3))",
     list(message = rex::rex("'sdd' does not exist in {stats}")),
     linter
-  )
-
-  expect_lint(
-    "stats:::sdd(c(1,2,3))",
-    NULL,
-    namespace_linter(check_nonexports = FALSE)
   )
 
   expect_lint(


### PR DESCRIPTION
I also wanted to add a test for Case-2 here, which currently isn't tested. But I couldn't come up with one. 
Is it even possible for a package to be installed with a broken `NAMESPACE`?

https://github.com/r-lib/lintr/blob/0af31f53a1007e464cf975bf9d62e79b484a7f35/R/namespace_linter.R#L54-L71