### PR TITLE
Consistently use `lint_msg` instead of `msg`

### DIFF
--- a/tests/testthat/test-absolute_path_linter.R
+++ b/tests/testthat/test-absolute_path_linter.R
@@ -129,7 +129,7 @@ test_that("is_long_path", {
 
 
 test_that("returns the correct linting", {
-  msg <- rex::escape("Do not use absolute paths.")
+  lint_msg <- rex::escape("Do not use absolute paths.")
 
   # strict mode
   linter <- absolute_path_linter(lax = FALSE)
@@ -158,8 +158,8 @@ test_that("returns the correct linting", {
     "/as:df"
   )
   for (path in absolute_path_strings) {
-    expect_lint(single_quote(path), msg, linter)
-    expect_lint(double_quote(path), msg, linter)
+    expect_lint(single_quote(path), lint_msg, linter)
+    expect_lint(double_quote(path), lint_msg, linter)
   }
 
   # lax mode: no check for strings that are likely not paths (too short or with special characters)

--- a/tests/testthat/test-assignment_linter.R
+++ b/tests/testthat/test-assignment_linter.R
@@ -1,21 +1,21 @@
 test_that("returns the correct linting", {
   linter <- assignment_linter()
-  msg <- rex::rex("Use <-, not =, for assignment.")
+  lint_msg <- rex::rex("Use <-, not =, for assignment.")
 
   expect_lint("blah", NULL, linter)
   expect_lint("blah <- 1", NULL, linter)
   expect_lint("blah<-1", NULL, linter)
   expect_lint("fun(blah=1)", NULL, linter)
 
-  expect_lint("blah=1", msg, linter)
-  expect_lint("blah = 1", msg, linter)
-  expect_lint("blah = fun(1)", msg, linter)
-  expect_lint("fun((blah = fun(1)))", msg, linter)
+  expect_lint("blah=1", lint_msg, linter)
+  expect_lint("blah = 1", lint_msg, linter)
+  expect_lint("blah = fun(1)", lint_msg, linter)
+  expect_lint("fun((blah = fun(1)))", lint_msg, linter)
 
   expect_lint(
     "blah = fun(1) {",
     list(
-      msg,
+      lint_msg,
       c(type = "error", "unexpected")
     ),
     linter

--- a/tests/testthat/test-brace_linter.R
+++ b/tests/testthat/test-brace_linter.R
@@ -224,12 +224,12 @@ test_that("brace_linter lints braces correctly", {
 
 test_that("brace_linter lints spaces before open braces", {
   linter <- brace_linter()
-  msg <- rex::rex("There should be a space before an opening curly brace.")
+  lint_msg <- rex::rex("There should be a space before an opening curly brace.")
 
   expect_lint(
     "blah <- function(){\n}",
     list(
-      message = msg,
+      message = lint_msg,
       column_number = 19L
     ),
     linter
@@ -238,7 +238,7 @@ test_that("brace_linter lints spaces before open braces", {
   expect_lint(
     "\nblah <- function(){\n\n\n}",
     list(
-      message = msg,
+      message = lint_msg,
       column_number = 19L
     ),
     linter
@@ -248,8 +248,8 @@ test_that("brace_linter lints spaces before open braces", {
   expect_lint(
     "a <- if (a){\n} else{\n}",
     list(
-      list(message = msg, line_number = 1L, column_number = 12L),
-      list(message = msg, line_number = 2L, column_number = 7L)
+      list(message = lint_msg, line_number = 1L, column_number = 12L),
+      list(message = lint_msg, line_number = 2L, column_number = 7L)
     ),
     linter
   )
@@ -257,7 +257,7 @@ test_that("brace_linter lints spaces before open braces", {
   # should lint repeat{
   expect_lint(
     "repeat{\nblah\n}",
-    list(message = msg, line_number = 1L, column_number = 7L),
+    list(message = lint_msg, line_number = 1L, column_number = 7L),
     linter
   )
 
@@ -277,7 +277,7 @@ test_that("brace_linter lints spaces before open braces", {
     list(
       rex::rex("Opening curly braces should never go on their own line and should always be followed by a new line."),
       rex::rex("Closing curly-braces should always be on their own line, unless they are followed by an else.")
-    ), # , but not msg
+    ), # , but not lint_msg
     linter
   )
 })

--- a/tests/testthat/test-class_equals_linter.R
+++ b/tests/testthat/test-class_equals_linter.R
@@ -11,19 +11,19 @@ test_that("class_equals_linter skips allowed usages", {
 
 test_that("class_equals_linter blocks simple disallowed usages", {
   linter <- class_equals_linter()
-  msg <- rex::rex("Instead of comparing class(x) with ==")
+  lint_msg <- rex::rex("Instead of comparing class(x) with ==")
 
-  expect_lint("if (class(x) == 'character') stop('no')", msg, linter)
-  expect_lint("is_regression <- class(x) == 'lm'", msg, linter)
-  expect_lint("is_regression <- 'lm' == class(x)", msg, linter)
+  expect_lint("if (class(x) == 'character') stop('no')", lint_msg, linter)
+  expect_lint("is_regression <- class(x) == 'lm'", lint_msg, linter)
+  expect_lint("is_regression <- 'lm' == class(x)", lint_msg, linter)
 })
 
 test_that("class_equals_linter blocks usage of %in% for checking class", {
   linter <- class_equals_linter()
-  msg <- rex::rex("Instead of comparing class(x) with %in%")
+  lint_msg <- rex::rex("Instead of comparing class(x) with %in%")
 
-  expect_lint("if ('character' %in% class(x)) stop('no')", msg, linter)
-  expect_lint("if (class(x) %in% 'character') stop('no')", msg, linter)
+  expect_lint("if ('character' %in% class(x)) stop('no')", lint_msg, linter)
+  expect_lint("if (class(x) %in% 'character') stop('no')", lint_msg, linter)
 })
 
 test_that("class_equals_linter blocks class(x) != 'klass'", {

--- a/tests/testthat/test-commented_code_linter.R
+++ b/tests/testthat/test-commented_code_linter.R
@@ -1,21 +1,21 @@
 test_that("returns the correct linting", {
-  msg <- rex::rex("Commented code should be removed.")
+  lint_msg <- rex::rex("Commented code should be removed.")
   linter <- commented_code_linter()
   expect_s3_class(linter, "linter")
 
   expect_lint("blah", NULL, linter)
 
-  expect_lint("# blah <- 1", msg, linter)
+  expect_lint("# blah <- 1", lint_msg, linter)
 
   expect_lint(
     "bleurgh <- fun_call(1) # other_call()",
-    list(message = msg, column_number = 26L),
+    list(message = lint_msg, column_number = 26L),
     linter
   )
 
   expect_lint(
     " #blah <- 1",
-    list(message = msg, column_number = 3L),
+    list(message = lint_msg, column_number = 3L),
     linter
   )
 
@@ -26,7 +26,7 @@ test_that("returns the correct linting", {
     line_without_comment <- 42L
      #blah <- 1
     "),
-    list(message = msg, line_number = 3L, column_number = 3L),
+    list(message = lint_msg, line_number = 3L, column_number = 3L),
     linter
   )
 
@@ -59,7 +59,7 @@ test_that("returns the correct linting", {
         mu = 175
       )
     "),
-    list(message = msg, line_number = 3L),
+    list(message = lint_msg, line_number = 3L),
     linter
   )
 
@@ -72,7 +72,7 @@ test_that("returns the correct linting", {
         , mu = 175
       )
     "),
-    list(message = msg, line_number = 3L),
+    list(message = lint_msg, line_number = 3L),
     linter
   )
 
@@ -80,7 +80,7 @@ test_that("returns the correct linting", {
   for (op in test_ops) {
     expect_lint(paste("i", op, "1", collapse = ""), NULL, linter)
     expect_lint(paste("# something like i", op, "1", collapse = ""), NULL, linter)
-    expect_lint(paste("# i", op, "1", collapse = ""), msg, linter)
+    expect_lint(paste("# i", op, "1", collapse = ""), lint_msg, linter)
   }
 
   expect_lint("TRUE", NULL, linter)
@@ -93,8 +93,8 @@ test_that("returns the correct linting", {
 
   expect_lint("1+1  # for example cat(\"123\")", NULL, linter)
 
-  expect_lint("1+1 # cat('123')", msg, linter)
-  expect_lint("#expect_ftype(1e-12 , t)", msg, linter)
+  expect_lint("1+1 # cat('123')", lint_msg, linter)
+  expect_lint("#expect_ftype(1e-12 , t)", lint_msg, linter)
 
   # regression test for #451
   expect_lint("c('#a#' = 1)", NULL, linter)

--- a/tests/testthat/test-cyclocomp_linter.R
+++ b/tests/testthat/test-cyclocomp_linter.R
@@ -1,10 +1,10 @@
 test_that("returns the correct linting", {
   cc_linter_1 <- cyclocomp_linter(1L)
   cc_linter_2 <- cyclocomp_linter(2L)
-  msg <- rex::rex("Functions should have cyclomatic complexity")
+  lint_msg <- rex::rex("Functions should have cyclomatic complexity")
 
   expect_lint("if (TRUE) 1 else 2", NULL, cc_linter_2)
-  expect_lint("if (TRUE) 1 else 2", msg, cc_linter_1)
+  expect_lint("if (TRUE) 1 else 2", lint_msg, cc_linter_1)
 
   expect_lint(
     "function(x) {not parsing}",
@@ -14,7 +14,7 @@ test_that("returns the correct linting", {
   complexity <- readLines(
     system.file("example/complexity.R", package = "lintr")
   )
-  expect_lint(complexity, msg, cc_linter_2)
+  expect_lint(complexity, lint_msg, cc_linter_2)
   expect_lint(
     complexity,
     "should have cyclomatic complexity of less than 2, this has 10",

--- a/tests/testthat/test-duplicate_argument_linter.R
+++ b/tests/testthat/test-duplicate_argument_linter.R
@@ -11,21 +11,21 @@ test_that("duplicate_argument_linter doesn't block allowed usages", {
 
 test_that("duplicate_argument_linter blocks disallowed usages", {
   linter <- duplicate_argument_linter()
-  msg <- rex::rex("Duplicate arguments in function call.")
+  lint_msg <- rex::rex("Duplicate arguments in function call.")
 
-  expect_lint("fun(arg = 1, arg = 2)", msg, linter)
-  expect_lint("fun(arg = 1, 'arg' = 2)", msg, linter)
-  expect_lint("fun(arg = 1, `arg` = 2)", msg, linter)
-  expect_lint("'fun'(arg = 1, arg = 2)", msg, linter)
-  expect_lint("(function(x, y) x + y)(x = 1, x = 2)", msg, linter)
-  expect_lint("dt[i = 1, i = 2]", msg, linter)
+  expect_lint("fun(arg = 1, arg = 2)", lint_msg, linter)
+  expect_lint("fun(arg = 1, 'arg' = 2)", lint_msg, linter)
+  expect_lint("fun(arg = 1, `arg` = 2)", lint_msg, linter)
+  expect_lint("'fun'(arg = 1, arg = 2)", lint_msg, linter)
+  expect_lint("(function(x, y) x + y)(x = 1, x = 2)", lint_msg, linter)
+  expect_lint("dt[i = 1, i = 2]", lint_msg, linter)
 
   expect_lint(
     "list(
       var = 1,
       var = 2
     )",
-    msg,
+    lint_msg,
     linter
   )
 })

--- a/tests/testthat/test-equals_na_linter.R
+++ b/tests/testthat/test-equals_na_linter.R
@@ -13,7 +13,7 @@ test_that("equals_na_linter skips allowed usages", {
 
   # equals_na_linter should ignore strings and comments
   expect_lint("is.na(x) # dont flag x == NA if inside a comment", NULL, linter)
-  expect_lint("msg <- 'dont flag x == NA if inside a string'", NULL, linter)
+  expect_lint("lint_msg <- 'dont flag x == NA if inside a string'", NULL, linter)
 
   # nested NAs are okay
   expect_lint("x==f(1, ignore = NA)", NULL, linter)
@@ -45,14 +45,14 @@ patrick::with_parameters_test_that(
 
 test_that("equals_na_linter blocks disallowed usages in edge cases", {
   linter <- equals_na_linter()
-  msg <- rex::rex("Use is.na for comparisons to NA (not == or !=)")
+  lint_msg <- rex::rex("Use is.na for comparisons to NA (not == or !=)")
 
   # missing spaces around operators
-  expect_lint("x==NA", list(message = msg, line_number = 1L, column_number = 1L), linter)
-  expect_lint("x!=NA", list(message = msg, line_number = 1L, column_number = 1L), linter)
+  expect_lint("x==NA", list(message = lint_msg, line_number = 1L, column_number = 1L), linter)
+  expect_lint("x!=NA", list(message = lint_msg, line_number = 1L, column_number = 1L), linter)
 
   # order doesn't matter
-  expect_lint("NA == x", list(message = msg, line_number = 1L, column_number = 1L), linter)
+  expect_lint("NA == x", list(message = lint_msg, line_number = 1L, column_number = 1L), linter)
 
   # correct line number for multiline code
   expect_lint("x ==\nNA", list(line_number = 1L, column_number = 1L, ranges = list(c(1L, 4L))), linter)

--- a/tests/testthat/test-expect_identical_linter.R
+++ b/tests/testthat/test-expect_identical_linter.R
@@ -17,28 +17,28 @@ test_that("expect_identical_linter skips allowed usages", {
 
 test_that("expect_identical_linter blocks simple disallowed usages", {
   linter <- expect_identical_linter()
-  msg <- rex::rex("Use expect_identical(x, y) by default; resort to expect_equal() only when needed")
+  lint_msg <- rex::rex("Use expect_identical(x, y) by default; resort to expect_equal() only when needed")
 
-  expect_lint("expect_equal(x, y)", msg, linter)
+  expect_lint("expect_equal(x, y)", lint_msg, linter)
 
   # different usage to redirect to expect_identical
-  expect_lint("expect_true(identical(x, y))", msg, linter)
+  expect_lint("expect_true(identical(x, y))", lint_msg, linter)
 })
 
 test_that("expect_identical_linter skips cases likely testing numeric equality", {
   linter <- expect_identical_linter()
-  msg <- rex::rex("Use expect_identical(x, y) by default; resort to expect_equal() only when needed")
+  lint_msg <- rex::rex("Use expect_identical(x, y) by default; resort to expect_equal() only when needed")
 
   expect_lint("expect_equal(x, 1.034)", NULL, linter)
   expect_lint("expect_equal(x, c(1.01, 1.02))", NULL, linter)
   # whole numbers with explicit decimals are OK, even in mixed scenarios
   expect_lint("expect_equal(x, c(1.0, 2))", NULL, linter)
   # plain numbers are still caught, however
-  expect_lint("expect_equal(x, 1L)", msg, linter)
-  expect_lint("expect_equal(x, 1)", msg, linter)
+  expect_lint("expect_equal(x, 1L)", lint_msg, linter)
+  expect_lint("expect_equal(x, 1)", lint_msg, linter)
   # NB: TRUE is a NUM_CONST so we want test matching it, even though this test is
   #   also a violation of expect_true_false_linter()
-  expect_lint("expect_equal(x, TRUE)", msg, linter)
+  expect_lint("expect_equal(x, TRUE)", lint_msg, linter)
 })
 
 test_that("expect_identical_linter skips 3e cases needing expect_equal", {

--- a/tests/testthat/test-expect_lint.R
+++ b/tests/testthat/test-expect_lint.R
@@ -3,7 +3,7 @@
 # for failure, always put the lint check or lint field that must fail first.
 
 linter <- assignment_linter()
-msg <- "Use <-, not ="
+lint_msg <- "Use <-, not ="
 
 test_that("no checks", {
   expect_success(expect_lint("a", NULL, linter))
@@ -12,36 +12,36 @@ test_that("no checks", {
 })
 
 test_that("single check", {
-  expect_failure(expect_lint(character(), msg, linter))
-  expect_failure(expect_lint("", msg, linter))
+  expect_failure(expect_lint(character(), lint_msg, linter))
+  expect_failure(expect_lint("", lint_msg, linter))
 
-  expect_success(expect_lint(content = "a=1", checks = msg, linters = linter))
-  expect_success(expect_lint("a=1", msg, linter))
+  expect_success(expect_lint(content = "a=1", checks = lint_msg, linters = linter))
+  expect_success(expect_lint("a=1", lint_msg, linter))
   expect_failure(expect_lint("a=1", "asdf", linter))
-  expect_success(expect_lint("a=1", c(message = msg), linter))
+  expect_success(expect_lint("a=1", c(message = lint_msg), linter))
   expect_failure(expect_lint("a=1", c(message = NULL), linter))
-  expect_success(expect_lint("a=1", c(message = msg, line_number = 1L), linter))
-  expect_failure(expect_lint("a=1", c(line_number = 2L, message = msg), linter))
+  expect_success(expect_lint("a=1", c(message = lint_msg, line_number = 1L), linter))
+  expect_failure(expect_lint("a=1", c(line_number = 2L, message = lint_msg), linter))
 
-  expect_error(expect_lint("a=1", c(message = msg, lineXXX = 1L), linter), "invalid field")
+  expect_error(expect_lint("a=1", c(message = lint_msg, lineXXX = 1L), linter), "invalid field")
 
   expect_failure(expect_lint("foo ()", list(ranges = list(c(2L, 2L))), function_left_parentheses_linter()))
   expect_success(expect_lint("\t1", list(ranges = list(c(1L, 1L))), no_tab_linter()))
-  expect_success(expect_lint("a=1", list(message = msg, line_number = 1L), linter))
-  expect_failure(expect_lint("a=1", list(2L, msg), linter))
+  expect_success(expect_lint("a=1", list(message = lint_msg, line_number = 1L), linter))
+  expect_failure(expect_lint("a=1", list(2L, lint_msg), linter))
 
   expect_error(expect_lint("1:nrow(x)", "(group)", seq_linter()), "Invalid regex result", fixed = TRUE)
 })
 
 test_that("multiple checks", {
   expect_success(
-    expect_lint(file = "exclusions-test", checks = as.list(rep(msg, 9L)), linters = linter, parse_settings = FALSE)
+    expect_lint(file = "exclusions-test", checks = as.list(rep(lint_msg, 9L)), linters = linter, parse_settings = FALSE)
   )
 
-  expect_success(expect_lint("a=1; b=2", list(msg, msg), linter))
-  expect_success(expect_lint("a=1; b=2", list(c(message = msg), c(message = msg)), linter))
+  expect_success(expect_lint("a=1; b=2", list(lint_msg, lint_msg), linter))
+  expect_success(expect_lint("a=1; b=2", list(c(message = lint_msg), c(message = lint_msg)), linter))
   expect_success(expect_lint("a=1; b=2", list(c(line_number = 1L), c(linter = "assignment_linter")), linter))
-  expect_success(expect_lint("a=1; b=2", list(msg, c(line = "a=1; b=2", type = "warning")), linter))
+  expect_success(expect_lint("a=1; b=2", list(lint_msg, c(line = "a=1; b=2", type = "warning")), linter))
   expect_success(expect_lint(c("a=1", "b=2"), list(c(line_number = 1L), c(line_number = 2L)), linter))
   expect_failure(expect_lint(c("a=1", "b=2"), list(c(line_number = 2L), c(line_number = 2L)), linter))
 

--- a/tests/testthat/test-get_source_expressions.R
+++ b/tests/testthat/test-get_source_expressions.R
@@ -111,16 +111,16 @@ test_that("Warns if encoding is misspecified", {
   the_lint <- lint(filename = file, parse_settings = FALSE)[[1L]]
   expect_s3_class(the_lint, "lint")
 
-  msg <- "Invalid multibyte character in parser. Is the encoding correct?"
+  lint_msg <- "Invalid multibyte character in parser. Is the encoding correct?"
   if (!isTRUE(l10n_info()[["UTF-8"]])) {
     # Prior to R 4.2.0, the Windows parser throws a different error message because the source code is converted to
     # native encoding.
     # This results in line 4 becoming <fc> <- 42 before the parser sees it.
-    msg <- "unexpected '<'"
+    lint_msg <- "unexpected '<'"
   }
 
   expect_identical(the_lint$linter, "error")
-  expect_identical(the_lint$message, msg)
+  expect_identical(the_lint$message, lint_msg)
   expect_identical(the_lint$line_number, 4L)
 
   file <- test_path("dummy_projects", "project", "cp1252_parseable.R")

--- a/tests/testthat/test-line_length_linter.R
+++ b/tests/testthat/test-line_length_linter.R
@@ -1,12 +1,12 @@
 test_that("returns the correct linting", {
   linter <- line_length_linter(80L)
-  msg <- rex::rex("Lines should not be more than 80 characters")
+  lint_msg <- rex::rex("Lines should not be more than 80 characters")
 
   expect_lint("blah", NULL, linter)
   expect_lint(strrep("x", 80L), NULL, linter)
   expect_lint(
     strrep("x", 81L), list(
-      message = msg,
+      message = lint_msg,
       column_number = 81L
     ),
     linter
@@ -16,11 +16,11 @@ test_that("returns the correct linting", {
     paste(rep(strrep("x", 81L), 2L), collapse = "\n"),
     list(
       list(
-        message = msg,
+        message = lint_msg,
         column_number = 81L
       ),
       list(
-        message = msg,
+        message = lint_msg,
         column_number = 81L
       )
     ),
@@ -28,11 +28,11 @@ test_that("returns the correct linting", {
   )
 
   linter <- line_length_linter(20L)
-  msg <- rex::rex("Lines should not be more than 20 characters")
+  lint_msg <- rex::rex("Lines should not be more than 20 characters")
   expect_lint(strrep("a", 20L), NULL, linter)
   expect_lint(
     strrep("a", 22L), list(
-      message = msg,
+      message = lint_msg,
       column_number = 21L
     ),
     linter

--- a/tests/testthat/test-missing_argument_linter.R
+++ b/tests/testthat/test-missing_argument_linter.R
@@ -1,6 +1,6 @@
 test_that("returns the correct linting", {
   linter <- missing_argument_linter()
-  msg <- rex::rex("Missing argument in function call.")
+  lint_msg <- rex::rex("Missing argument in function call.")
 
   expect_lint("fun(x, a = 1)", NULL, linter)
   expect_lint("fun(x = 1, a = 1)", NULL, linter)
@@ -12,12 +12,12 @@ test_that("returns the correct linting", {
 
   expect_lint("test(a =, b =, c = 1, 0)", NULL, missing_argument_linter("test"))
 
-  expect_lint("fun(, a = 1)", list(message = msg), linter)
+  expect_lint("fun(, a = 1)", list(message = lint_msg), linter)
   expect_lint("f <- function(x, y) x\nf(, y = 1)\n", list(line = "f(, y = 1)"), linter)
-  expect_lint("fun(a = 1,, b = 2)", list(message = msg), linter)
-  expect_lint("fun(a = 1, b =)", list(message = msg), linter)
-  expect_lint("fun(a = 1,)", list(message = msg), linter)
-  expect_lint("fun(a = )", list(message = msg), linter)
+  expect_lint("fun(a = 1,, b = 2)", list(message = lint_msg), linter)
+  expect_lint("fun(a = 1, b =)", list(message = lint_msg), linter)
+  expect_lint("fun(a = 1,)", list(message = lint_msg), linter)
+  expect_lint("fun(a = )", list(message = lint_msg), linter)
 
   expect_lint(
     trim_some("
@@ -26,16 +26,16 @@ test_that("returns the correct linting", {
         b = 2,
       )
     "),
-    list(message = msg),
+    list(message = lint_msg),
     linter
   )
 
-  expect_lint("stats::median(1:10, na.rm =)", list(message = msg), linter)
-  expect_lint("env$get(1:10, default =)", list(message = msg), linter)
+  expect_lint("stats::median(1:10, na.rm =)", list(message = lint_msg), linter)
+  expect_lint("env$get(1:10, default =)", list(message = lint_msg), linter)
 
   # except list can be empty
-  expect_lint("switch(a =, b = 1, 0)", list(message = msg), missing_argument_linter(character()))
-  expect_lint("alist(a =)", list(message = msg), missing_argument_linter(character()))
+  expect_lint("switch(a =, b = 1, 0)", list(message = lint_msg), missing_argument_linter(character()))
+  expect_lint("alist(a =)", list(message = lint_msg), missing_argument_linter(character()))
 
   # allow_trailing can allow trailing empty args also for non-excepted functions
   expect_lint("fun(a = 1,)", NULL, missing_argument_linter(allow_trailing = TRUE))
@@ -50,7 +50,7 @@ test_that("returns the correct linting", {
     missing_argument_linter(allow_trailing = TRUE)
   )
   # ... but not if the final argument is named
-  expect_lint("fun(a = 1, b = )", list(message = msg), missing_argument_linter(allow_trailing = TRUE))
+  expect_lint("fun(a = 1, b = )", list(message = lint_msg), missing_argument_linter(allow_trailing = TRUE))
 
   # Fixes https://github.com/r-lib/lintr/issues/906
   # Comments should be ignored so that missing arguments could be
@@ -63,7 +63,7 @@ test_that("returns the correct linting", {
         # comment
       )
     "),
-    list(message = msg),
+    list(message = lint_msg),
     linter
   )
 
@@ -75,7 +75,7 @@ test_that("returns the correct linting", {
         1
       )
     "),
-    list(message = msg),
+    list(message = lint_msg),
     linter
   )
 
@@ -87,7 +87,7 @@ test_that("returns the correct linting", {
         1
       )
     "),
-    list(message = msg),
+    list(message = lint_msg),
     linter
   )
 })

--- a/tests/testthat/test-missing_package_linter.R
+++ b/tests/testthat/test-missing_package_linter.R
@@ -1,6 +1,6 @@
 test_that("returns the correct linting", {
   linter <- missing_package_linter()
-  msg <- list(message = rex::rex("Package 'statts' is not installed."))
+  lint_msg <- list(message = rex::rex("Package 'statts' is not installed."))
 
   expect_lint("library(stats)", NULL, linter)
   expect_lint('library("stats")', NULL, linter)
@@ -9,7 +9,7 @@ test_that("returns the correct linting", {
   expect_lint("library(stats, quietly)", NULL, linter)
   expect_lint("library(stats, quietly = TRUE)", NULL, linter)
 
-  expect_lint("library(statts, quietly = TRUE)", msg, linter)
+  expect_lint("library(statts, quietly = TRUE)", lint_msg, linter)
 
   expect_lint(
     trim_some("
@@ -20,17 +20,17 @@ test_that("returns the correct linting", {
     linter
   )
 
-  expect_lint("library(statts, quietly = TRUE)", msg, linter)
+  expect_lint("library(statts, quietly = TRUE)", lint_msg, linter)
 
   expect_lint("require(stats)", NULL, linter)
   expect_lint("require(stats, quietly = TRUE)", NULL, linter)
-  expect_lint("require(statts)", msg, linter)
+  expect_lint("require(statts)", lint_msg, linter)
 
   expect_lint('loadNamespace("stats")', NULL, linter)
-  expect_lint('loadNamespace("statts")', msg, linter)
+  expect_lint('loadNamespace("statts")', lint_msg, linter)
 
   expect_lint('requireNamespace("stats")', NULL, linter)
-  expect_lint('requireNamespace("statts")', msg, linter)
+  expect_lint('requireNamespace("statts")', lint_msg, linter)
 })
 
 test_that("loadNamespace and requireNamespace allow plain symbols", {

--- a/tests/testthat/test-no_tab_linter.R
+++ b/tests/testthat/test-no_tab_linter.R
@@ -1,6 +1,6 @@
 test_that("returns the correct linting", {
   linter <- no_tab_linter()
-  msg <- rex::rex("Use spaces to indent, not tabs.")
+  lint_msg <- rex::rex("Use spaces to indent, not tabs.")
 
   expect_lint("blah", NULL, linter)
   expect_lint("  blah", NULL, linter)
@@ -9,25 +9,25 @@ test_that("returns the correct linting", {
 
   expect_lint(
     "\tblah",
-    list(message = msg, line_number = 1L, column_number = 1L, ranges = list(c(1L, 1L))),
+    list(message = lint_msg, line_number = 1L, column_number = 1L, ranges = list(c(1L, 1L))),
     linter
   )
 
   expect_lint(
     "\n\t\t\tblah",
-    list(message = msg, line_number = 2L, column_number = 1L),
+    list(message = lint_msg, line_number = 2L, column_number = 1L),
     linter
   )
 
   # ignore strings
   expect_lint(
-    'msg <- "dont flag tabs if\tthey are inside a string."',
+    'lint_msg <- "dont flag tabs if\tthey are inside a string."',
     NULL,
     linter
   )
   # ignore multi-line strings
   expect_lint(
-    'msg <- "dont flag tabs if\n\tthey are inside multiline strings."',
+    'lint_msg <- "dont flag tabs if\n\tthey are inside multiline strings."',
     NULL,
     linter
   )

--- a/tests/testthat/test-nonportable_path_linter.R
+++ b/tests/testthat/test-nonportable_path_linter.R
@@ -1,6 +1,6 @@
 test_that("Non-portable path linter", {
   linter <- nonportable_path_linter(lax = FALSE)
-  msg <- rex::escape("Use file.path() to construct portable file paths.")
+  lint_msg <- rex::escape("Use file.path() to construct portable file paths.")
 
   # various strings
   non_path_strings <- c(
@@ -36,8 +36,8 @@ test_that("Non-portable path linter", {
     encodeString("/a\nsdf")
   )
   for (path in slash_path_strings) {
-    expect_lint(single_quote(path), msg, linter)
-    expect_lint(double_quote(path), msg, linter)
+    expect_lint(single_quote(path), lint_msg, linter)
+    expect_lint(double_quote(path), lint_msg, linter)
   }
 
   # lax mode: no check for strings that are likely not paths (too short or with special characters)

--- a/tests/testthat/test-object_name_linter.R
+++ b/tests/testthat/test-object_name_linter.R
@@ -52,21 +52,21 @@ test_that("linter ignores some objects", {
 })
 
 test_that("linter returns correct linting", {
-  msg <- "Variable and function name style should be camelCase."
+  lint_msg <- "Variable and function name style should be camelCase."
   linter <- object_name_linter("camelCase")
 
   expect_lint("myObject <- 123", NULL, linter)
   expect_lint("`myObject` <- 123", NULL, linter)
-  expect_lint("my.confused_NAME <- 1;", list(message = msg, line_number = 1L, column_number = 1L), linter)
-  expect_lint("1 ->> read.data.frame;", list(message = msg, line_number = 1L, column_number = 7L), linter)
+  expect_lint("my.confused_NAME <- 1;", list(message = lint_msg, line_number = 1L, column_number = 1L), linter)
+  expect_lint("1 ->> read.data.frame;", list(message = lint_msg, line_number = 1L, column_number = 7L), linter)
   expect_lint("object_name_linter <- function(...) {}",
-              list(message = msg, line_number = 1L, column_number = 1L), linter)
+              list(message = lint_msg, line_number = 1L, column_number = 1L), linter)
 
   expect_lint(
     "Z = sapply('function', function(x=function(x){1}, b.a.z=F, ...){identity(b.a.z)}, USE.NAMES=TRUE)",
     list(
-      list(message = msg, line_number = 1L, column_number = 1L),
-      list(message = msg, line_number = 1L, column_number = 51L)
+      list(message = lint_msg, line_number = 1L, column_number = 1L),
+      list(message = lint_msg, line_number = 1L, column_number = 51L)
     ),
     linter
   )
@@ -82,12 +82,12 @@ test_that("linter returns correct linting", {
 })
 
 test_that("linter accepts vector of styles", {
-  msg <- "Variable and function name style should be camelCase or dotted.case."
+  lint_msg <- "Variable and function name style should be camelCase or dotted.case."
   linter <- object_name_linter(styles = c("camelCase", "dotted.case"))
 
   expect_lint(
     c("var.one <- 1", "varTwo <- 2", "var_three <- 3"),
-    list(message = msg, line_number = 3L, column_number = 1L),
+    list(message = lint_msg, line_number = 3L, column_number = 1L),
     linter
   )
 })
@@ -95,17 +95,17 @@ test_that("linter accepts vector of styles", {
 test_that("dollar subsetting only lints the first expression", {
   # Regression test for #582
   linter <- object_name_linter()
-  msg <- "Variable and function name style should be snake_case or symbols."
+  lint_msg <- "Variable and function name style should be snake_case or symbols."
 
   expect_lint("my_var$MY_COL <- 42L", NULL, linter)
-  expect_lint("MY_VAR$MY_COL <- 42L", msg, linter)
+  expect_lint("MY_VAR$MY_COL <- 42L", lint_msg, linter)
   expect_lint("my_var$MY_SUB$MY_COL <- 42L", NULL, linter)
-  expect_lint("MY_VAR$MY_SUB$MY_COL <- 42L", msg, linter)
+  expect_lint("MY_VAR$MY_SUB$MY_COL <- 42L", lint_msg, linter)
 })
 
 test_that("assignment targets of compound lhs are correctly identified", {
   linter <- object_name_linter()
-  msg <- "Variable and function name style should be snake_case or symbols."
+  lint_msg <- "Variable and function name style should be snake_case or symbols."
 
   # (recursive) [, $, and [[ subsetting
   expect_lint("good_name[badName] <- badName2", NULL, linter)
@@ -116,33 +116,33 @@ test_that("assignment targets of compound lhs are correctly identified", {
   expect_lint("good_name[[badName]]$badName2 <- badName3", NULL, linter)
   expect_lint("good_name$badName[[badName2]][badName3]$badName4 <- badName5", NULL, linter)
 
-  expect_lint("badName[badName] <- badName2", msg, linter)
-  expect_lint("badName[1L][badName] <- badName2", msg, linter)
-  expect_lint("badName[[badName]] <- badName2", msg, linter)
-  expect_lint("badName[[1L]][[badName]] <- badName2", msg, linter)
-  expect_lint("badName[[fun(badName)]] <- badName2", msg, linter)
-  expect_lint("badName[[badName]]$badName2 <- badName3", msg, linter)
-  expect_lint("badName$badName[[badName2]][badName3]$badName4 <- badName5", msg, linter)
+  expect_lint("badName[badName] <- badName2", lint_msg, linter)
+  expect_lint("badName[1L][badName] <- badName2", lint_msg, linter)
+  expect_lint("badName[[badName]] <- badName2", lint_msg, linter)
+  expect_lint("badName[[1L]][[badName]] <- badName2", lint_msg, linter)
+  expect_lint("badName[[fun(badName)]] <- badName2", lint_msg, linter)
+  expect_lint("badName[[badName]]$badName2 <- badName3", lint_msg, linter)
+  expect_lint("badName$badName[[badName2]][badName3]$badName4 <- badName5", lint_msg, linter)
 
   # setters
-  expect_lint("setter(badName) <- good_name", msg, linter)
+  expect_lint("setter(badName) <- good_name", lint_msg, linter)
   expect_lint("setter(good_name[[badName]]) <- good_name2", NULL, linter)
 
   # quotation
   expect_lint("\"good_name\" <- 42", NULL, linter)
-  expect_lint("\"badName\" <- 42", msg, linter)
+  expect_lint("\"badName\" <- 42", lint_msg, linter)
   expect_lint("'good_name' <- 42", NULL, linter)
-  expect_lint("'badName' <- 42", msg, linter)
+  expect_lint("'badName' <- 42", lint_msg, linter)
   expect_lint("`good_name` <- 42", NULL, linter)
-  expect_lint("`badName` <- 42", msg, linter)
+  expect_lint("`badName` <- 42", lint_msg, linter)
 
   # subsetting with quotation
   expect_lint("good_name$\"badName\" <- 42", NULL, linter)
   expect_lint("good_name$'badName' <- 42", NULL, linter)
-  expect_lint("badName$\"good_name\" <- 42", msg, linter)
-  expect_lint("badName$'good_name' <- 42", msg, linter)
-  expect_lint("`badName`$\"good_name\" <- 42", msg, linter)
-  expect_lint("`badName`$'good_name' <- 42", msg, linter)
+  expect_lint("badName$\"good_name\" <- 42", lint_msg, linter)
+  expect_lint("badName$'good_name' <- 42", lint_msg, linter)
+  expect_lint("`badName`$\"good_name\" <- 42", lint_msg, linter)
+  expect_lint("`badName`$'good_name' <- 42", lint_msg, linter)
 })
 
 test_that("object_name_linter won't fail if an imported namespace is unavailable", {

--- a/tests/testthat/test-paren_body_linter.R
+++ b/tests/testthat/test-paren_body_linter.R
@@ -1,13 +1,13 @@
 testthat::test_that("paren_body_linter returns correct lints", {
   linter <- paren_body_linter()
-  msg <- "There should be a space between a right parenthesis and a body expression."
+  lint_msg <- "There should be a space between a right parenthesis and a body expression."
 
   # No space after the closing parenthesis prompts a lint
-  expect_lint("function()test", msg, linter)
-  expect_lint("print('hello')\nx <- function(x)NULL\nprint('hello')", msg, linter)
-  expect_lint("if (TRUE)test", msg, linter)
-  expect_lint("while (TRUE)test", msg, linter)
-  expect_lint("for (i in seq_along(1))test", msg, linter)
+  expect_lint("function()test", lint_msg, linter)
+  expect_lint("print('hello')\nx <- function(x)NULL\nprint('hello')", lint_msg, linter)
+  expect_lint("if (TRUE)test", lint_msg, linter)
+  expect_lint("while (TRUE)test", lint_msg, linter)
+  expect_lint("for (i in seq_along(1))test", lint_msg, linter)
 
   # A space after the closing parenthesis does not prompt a lint
   expect_lint("function() test", NULL, linter)
@@ -41,11 +41,11 @@ testthat::test_that("paren_body_linter returns correct lints", {
   expect_lint("#function()test", NULL, linter)
 
   # multiple lints on the same line
-  expect_lint("function()if(TRUE)while(TRUE)test", list(msg, msg, msg), linter)
+  expect_lint("function()if(TRUE)while(TRUE)test", list(lint_msg, lint_msg, lint_msg), linter)
 
   # No space after the closing parenthesis of an anonymous function prompts a lint
   skip_if_not_r_version("4.1.0")
-  expect_lint("\\()test", msg, linter)
+  expect_lint("\\()test", lint_msg, linter)
 })
 
 test_that("multi-line versions are caught", {

--- a/tests/testthat/test-paren_brace_linter.R
+++ b/tests/testthat/test-paren_brace_linter.R
@@ -4,7 +4,7 @@ test_that("returns the correct linting", {
     "Linter paren_brace_linter was deprecated",
     fixed = TRUE
   )
-  msg <- rex::rex("There should be a space between right parenthesis and an opening curly brace.")
+  lint_msg <- rex::rex("There should be a space between right parenthesis and an opening curly brace.")
 
   expect_lint("blah", NULL, linter)
   expect_lint("blah <- function() {}", NULL, linter)
@@ -13,7 +13,7 @@ test_that("returns the correct linting", {
   expect_lint(
     "blah <- function(){}",
     list(
-      message = msg,
+      message = lint_msg,
       column_number = 19L
     ),
     linter
@@ -22,7 +22,7 @@ test_that("returns the correct linting", {
   expect_lint(
     "\nblah <- function(){\n\n\n}",
     list(
-      message = msg,
+      message = lint_msg,
       column_number = 19L
     ),
     linter

--- a/tests/testthat/test-redundant_equals_linter.R
+++ b/tests/testthat/test-redundant_equals_linter.R
@@ -25,9 +25,9 @@ skip_if_not_installed("patrick")
 patrick::with_parameters_test_that(
   "redundant_equals_linter blocks simple disallowed usages",
   {
-    msg <- rex::rex(paste("Using", op, "on a logical vector is redundant."))
+    lint_msg <- rex::rex(paste("Using", op, "on a logical vector is redundant."))
     code <- paste("x", op, bool)
-    expect_lint(code, msg, redundant_equals_linter())
+    expect_lint(code, lint_msg, redundant_equals_linter())
   },
   .cases = tibble::tribble(
     ~.test_name, ~op, ~bool,

--- a/tests/testthat/test-single_quotes_linter.R
+++ b/tests/testthat/test-single_quotes_linter.R
@@ -1,6 +1,6 @@
 test_that("returns the correct linting", {
   linter <- single_quotes_linter()
-  msg <- rex::rex("Only use double-quotes.")
+  lint_msg <- rex::rex("Only use double-quotes.")
 
   expect_lint("blah", NULL, linter)
   expect_lint("\"blah\"", NULL, linter)
@@ -11,9 +11,9 @@ test_that("returns the correct linting", {
   expect_lint("'\"'", NULL, linter)
   expect_lint("'\"blah\"'", NULL, linter)
 
-  expect_lint("'blah'", msg, linter)
-  expect_lint("fun('blah')", msg, linter)
-  expect_lint("{'blah'}", msg, linter)
+  expect_lint("'blah'", lint_msg, linter)
+  expect_lint("fun('blah')", lint_msg, linter)
+  expect_lint("{'blah'}", lint_msg, linter)
 
   expect_lint(
     "

--- a/tests/testthat/test-spaces_left_parentheses_linter.R
+++ b/tests/testthat/test-spaces_left_parentheses_linter.R
@@ -1,6 +1,6 @@
 test_that("returns the correct linting", {
   linter <- spaces_left_parentheses_linter()
-  msg <- rex::rex("Place a space before left parenthesis, except in a function call.")
+  lint_msg <- rex::rex("Place a space before left parenthesis, except in a function call.")
 
   expect_lint("blah", NULL, linter)
   expect_lint("print(blah)", NULL, linter)
@@ -22,11 +22,11 @@ test_that("returns the correct linting", {
   expect_lint("function(){function(){}}()()", NULL, linter)
   expect_lint("c(function(){})[1]()", NULL, linter)
 
-  expect_lint("if(blah) { }", msg, linter)
-  expect_lint("for(i in j) { }", msg, linter)
-  expect_lint("1*(1 + 1)", msg, linter)
-  expect_lint("test <- function(x) { if(1 + 1) 'hi' }", msg, linter)
-  expect_lint("test <- function(x) { if(`+`(1, 1)) 'hi' }", msg, linter)
+  expect_lint("if(blah) { }", lint_msg, linter)
+  expect_lint("for(i in j) { }", lint_msg, linter)
+  expect_lint("1*(1 + 1)", lint_msg, linter)
+  expect_lint("test <- function(x) { if(1 + 1) 'hi' }", lint_msg, linter)
+  expect_lint("test <- function(x) { if(`+`(1, 1)) 'hi' }", lint_msg, linter)
 
   expect_lint("\"test <- function(x) { if(1 + 1) 'hi' }\"", NULL, linter)
   expect_lint("res <- c((mat - 1L) %*% combs + 1L)", NULL, linter)
@@ -39,14 +39,14 @@ test_that("returns the correct linting", {
   expect_lint("-(!!!symb)", NULL, linter)
 
   # more complicated cases for parse tree
-  expect_lint("y1<-(abs(yn)>90)*1", msg, linter)
-  expect_lint("c(a,(a+b))", msg, linter)
-  expect_lint("if (x>y) 1 else(2)", msg, linter)
-  expect_lint("y~(x+z)", msg, linter)
-  expect_lint("if (x>y) {(x+y) / (x-y)}", msg, linter)
-  expect_lint("for (ii in(1:10)) { }", msg, linter)
-  expect_lint("x = 1;(x + 2)*3", msg, linter)
-  expect_lint("foo <- function(x=(1+2)) { }", msg, linter)
+  expect_lint("y1<-(abs(yn)>90)*1", lint_msg, linter)
+  expect_lint("c(a,(a+b))", lint_msg, linter)
+  expect_lint("if (x>y) 1 else(2)", lint_msg, linter)
+  expect_lint("y~(x+z)", lint_msg, linter)
+  expect_lint("if (x>y) {(x+y) / (x-y)}", lint_msg, linter)
+  expect_lint("for (ii in(1:10)) { }", lint_msg, linter)
+  expect_lint("x = 1;(x + 2)*3", lint_msg, linter)
+  expect_lint("foo <- function(x=(1+2)) { }", lint_msg, linter)
 
   expect_lint("'[[<-.data.frame'(object, y)", NULL, linter)
   expect_lint("object@data@get('input')", NULL, linter)

--- a/tests/testthat/test-strings_as_factors_linter.R
+++ b/tests/testthat/test-strings_as_factors_linter.R
@@ -18,55 +18,55 @@ test_that("strings_as_factors_linter skips allowed usages", {
 })
 
 test_that("strings_as_factors_linter blocks simple disallowed usages", {
-  msg <- "This code relies on the default value of stringsAsFactors"
+  lint_msg <- "This code relies on the default value of stringsAsFactors"
 
-  expect_lint("data.frame('a')", msg, strings_as_factors_linter())
-  expect_lint("data.frame(c('a', 'b'))", msg, strings_as_factors_linter())
-  expect_lint("data.frame(x = 1:5, y = 'b')", msg, strings_as_factors_linter())
-  expect_lint("data.frame(x = 1:5, y, z = 'b')", msg, strings_as_factors_linter())
+  expect_lint("data.frame('a')", lint_msg, strings_as_factors_linter())
+  expect_lint("data.frame(c('a', 'b'))", lint_msg, strings_as_factors_linter())
+  expect_lint("data.frame(x = 1:5, y = 'b')", lint_msg, strings_as_factors_linter())
+  expect_lint("data.frame(x = 1:5, y, z = 'b')", lint_msg, strings_as_factors_linter())
 
   # catch row.names when combined with a character vector
-  expect_lint("data.frame(x = c('c', 'd', 'e'), row.names = c('a', 'b', 'c'))", msg, strings_as_factors_linter())
-  expect_lint("data.frame(row.names = c('c', 'd', 'e'), x = c('a', 'b', 'c'))", msg, strings_as_factors_linter())
+  expect_lint("data.frame(x = c('c', 'd', 'e'), row.names = c('a', 'b', 'c'))", lint_msg, strings_as_factors_linter())
+  expect_lint("data.frame(row.names = c('c', 'd', 'e'), x = c('a', 'b', 'c'))", lint_msg, strings_as_factors_linter())
 
   # when everything is a literal, type promotion means the column is character
-  expect_lint("data.frame(x = c(TRUE, 'a'))", msg, strings_as_factors_linter())
+  expect_lint("data.frame(x = c(TRUE, 'a'))", lint_msg, strings_as_factors_linter())
 })
 
 test_that("strings_as_factors_linters catches rep(char) usages", {
-  msg <- "This code relies on the default value of stringsAsFactors"
+  lint_msg <- "This code relies on the default value of stringsAsFactors"
 
-  expect_lint("data.frame(rep('a', 10L))", msg, strings_as_factors_linter())
-  expect_lint("data.frame(rep(c('a', 'b'), 10L))", msg, strings_as_factors_linter())
+  expect_lint("data.frame(rep('a', 10L))", lint_msg, strings_as_factors_linter())
+  expect_lint("data.frame(rep(c('a', 'b'), 10L))", lint_msg, strings_as_factors_linter())
 
   # literal char, not mixed or non-char
   expect_lint("data.frame(rep(1L, 10L))", NULL, strings_as_factors_linter())
   expect_lint("data.frame(rep(c(x, 'a'), 10L))", NULL, strings_as_factors_linter())
   # however, type promotion of literals is caught
-  expect_lint("data.frame(rep(c(TRUE, 'a'), 10L))", msg, strings_as_factors_linter())
+  expect_lint("data.frame(rep(c(TRUE, 'a'), 10L))", lint_msg, strings_as_factors_linter())
 })
 
 test_that("strings_as_factors_linter catches character(), as.character() usages", {
-  msg <- "This code relies on the default value of stringsAsFactors"
+  lint_msg <- "This code relies on the default value of stringsAsFactors"
 
-  expect_lint("data.frame(a = character())", msg, strings_as_factors_linter())
-  expect_lint("data.frame(a = character(1L))", msg, strings_as_factors_linter())
-  expect_lint("data.frame(a = as.character(x))", msg, strings_as_factors_linter())
+  expect_lint("data.frame(a = character())", lint_msg, strings_as_factors_linter())
+  expect_lint("data.frame(a = character(1L))", lint_msg, strings_as_factors_linter())
+  expect_lint("data.frame(a = as.character(x))", lint_msg, strings_as_factors_linter())
 
   # but not for row.names
   expect_lint("data.frame(a = 1:10, row.names = as.character(1:10))", NULL, strings_as_factors_linter())
 })
 
 test_that("strings_as_factors_linter catches more functions with string output", {
-  msg <- "This code relies on the default value of stringsAsFactors"
+  lint_msg <- "This code relies on the default value of stringsAsFactors"
 
-  expect_lint("data.frame(a = paste(1, 2, 3))", msg, strings_as_factors_linter())
-  expect_lint("data.frame(a = sprintf('%d', 1:10))", msg, strings_as_factors_linter())
-  expect_lint("data.frame(a = format(x, just = 'right'))", msg, strings_as_factors_linter())
-  expect_lint("data.frame(a = formatC(x, format = '%d'))", msg, strings_as_factors_linter())
-  expect_lint("data.frame(a = prettyNum(x, big.mark = ','))", msg, strings_as_factors_linter())
-  expect_lint("data.frame(a = toString(x))", msg, strings_as_factors_linter())
-  expect_lint("data.frame(a = encodeString(x))", msg, strings_as_factors_linter())
+  expect_lint("data.frame(a = paste(1, 2, 3))", lint_msg, strings_as_factors_linter())
+  expect_lint("data.frame(a = sprintf('%d', 1:10))", lint_msg, strings_as_factors_linter())
+  expect_lint("data.frame(a = format(x, just = 'right'))", lint_msg, strings_as_factors_linter())
+  expect_lint("data.frame(a = formatC(x, format = '%d'))", lint_msg, strings_as_factors_linter())
+  expect_lint("data.frame(a = prettyNum(x, big.mark = ','))", lint_msg, strings_as_factors_linter())
+  expect_lint("data.frame(a = toString(x))", lint_msg, strings_as_factors_linter())
+  expect_lint("data.frame(a = encodeString(x))", lint_msg, strings_as_factors_linter())
   # but not for row.names
   expect_lint("data.frame(a = 1:10, row.names = paste(1:10))", NULL, strings_as_factors_linter())
 })

--- a/tests/testthat/test-todo_comment_linter.R
+++ b/tests/testthat/test-todo_comment_linter.R
@@ -1,24 +1,24 @@
 test_that("returns the correct linting", {
   linter <- todo_comment_linter(todo = c("todo", "fixme"))
-  msg <- "TODO comments should be removed."
+  lint_msg <- "TODO comments should be removed."
 
   expect_lint("a <- \"you#need#to#fixme\"", NULL, linter)
   expect_lint("# something todo", NULL, linter)
   expect_lint(
     "cat(x) ### fixme",
-    list(message = msg, line_number = 1L, column_number = 8L),
+    list(message = lint_msg, line_number = 1L, column_number = 8L),
     linter
   )
   expect_lint(
     "x <- \"1.0\n2.0 #FIXME\n3 #TODO 4\"; y <- 2; z <- 3 # todo later",
-    list(message = msg, line_number = 3L, column_number = 28L),
+    list(message = lint_msg, line_number = 3L, column_number = 28L),
     linter
   )
   expect_lint(
     "function() {\n# TODO\n  function() {\n  # fixme\n  }\n}",
     list(
-      list(message = msg, line_number = 2L, column_number = 1L),
-      list(message = msg, line_number = 4L, column_number = 3L)
+      list(message = lint_msg, line_number = 2L, column_number = 1L),
+      list(message = lint_msg, line_number = 4L, column_number = 3L)
     ), linter
   )
 })

--- a/tests/testthat/test-trailing_blank_lines_linter.R
+++ b/tests/testthat/test-trailing_blank_lines_linter.R
@@ -12,13 +12,13 @@ test_that("trailing_blank_lines_linter doesn't block allowed usages", {
 
 test_that("trailing_blank_lines_linter detects disallowed usages", {
   linter <- trailing_blank_lines_linter()
-  msg <- rex::rex("Trailing blank lines are superfluous.")
+  lint_msg <- rex::rex("Trailing blank lines are superfluous.")
 
-  expect_lint("blah <- 1\n", msg, linter)
-  expect_lint("blah <- 1\n  ", msg, linter)
-  expect_lint("blah <- 1\n \n ", list(msg, msg), linter)
-  expect_lint("blah <- 1\n\n", list(msg, msg), linter)
-  expect_lint("blah <- 1\n\t\n", list(msg, msg), linter)
+  expect_lint("blah <- 1\n", lint_msg, linter)
+  expect_lint("blah <- 1\n  ", lint_msg, linter)
+  expect_lint("blah <- 1\n \n ", list(lint_msg, lint_msg), linter)
+  expect_lint("blah <- 1\n\n", list(lint_msg, lint_msg), linter)
+  expect_lint("blah <- 1\n\t\n", list(lint_msg, lint_msg), linter)
 
   # Construct a test file without terminal newline
   # cf. test-get_source_expressions.R

--- a/tests/testthat/test-trailing_whitespace_linter.R
+++ b/tests/testthat/test-trailing_whitespace_linter.R
@@ -46,26 +46,26 @@ test_that("also handles completely empty lines per allow_empty_lines argument", 
 
 test_that("also handles trailing whitespace in string constants", {
   linter <- trailing_whitespace_linter()
-  msg <- rex::rex("Trailing whitespace is superfluous.")
+  lint_msg <- rex::rex("Trailing whitespace is superfluous.")
 
   expect_lint("blah <- '  \n  \n'", NULL, linter)
   # Don't exclude past the end of string
   expect_lint(
     "blah <- '  \n  \n'  ",
-    list(message = msg, line_number = 3L),
+    list(message = lint_msg, line_number = 3L),
     linter
   )
   # can be enabled with allow_in_strings = FALSE
   expect_lint(
     "blah <- '  \n  \n'",
-    list(message = msg, line_number = 1L),
+    list(message = lint_msg, line_number = 1L),
     trailing_whitespace_linter(allow_empty_lines = TRUE, allow_in_strings = FALSE)
   )
   expect_lint(
     "blah <- '  \n  \n'",
     list(
-      list(message = msg, line_number = 1L),
-      list(message = msg, line_number = 2L)
+      list(message = lint_msg, line_number = 1L),
+      list(message = lint_msg, line_number = 2L)
     ),
     trailing_whitespace_linter(allow_in_strings = FALSE)
   )

--- a/tests/testthat/test-unused_import_linter.R
+++ b/tests/testthat/test-unused_import_linter.R
@@ -16,13 +16,13 @@ test_that("unused_import_linter lints as expected", {
   # SYMBOL calls with character.only = TRUE are ignored, even if the argument is a package name
   expect_lint("library(dplyr, character.only = TRUE)\n1 + 1", NULL, linter)
 
-  msg <- rex::rex("Package 'dplyr' is attached but never used")
+  lint_msg <- rex::rex("Package 'dplyr' is attached but never used")
   msg_ns <- rex::rex("Package 'dplyr' is only used by namespace")
 
-  expect_lint("library(dplyr)\n1 + 1", msg, linter)
-  expect_lint("require(dplyr)\n1 + 1", msg, linter)
-  expect_lint("library('dplyr')\n1 + 1", msg, linter)
-  expect_lint("library('dplyr', character.only = TRUE)\n1 + 1", msg, linter)
+  expect_lint("library(dplyr)\n1 + 1", lint_msg, linter)
+  expect_lint("require(dplyr)\n1 + 1", lint_msg, linter)
+  expect_lint("library('dplyr')\n1 + 1", lint_msg, linter)
+  expect_lint("library('dplyr', character.only = TRUE)\n1 + 1", lint_msg, linter)
   # ignore namespaced usages by default, but provide custom lint message
   expect_lint("library(dplyr)\ndplyr::tibble(a = 1)", msg_ns, linter)
   expect_lint("library(dplyr)\ndplyr::tibble(a = 1)", NULL, unused_import_linter(allow_ns_usage = TRUE))

--- a/tests/testthat/test-with.R
+++ b/tests/testthat/test-with.R
@@ -1,7 +1,7 @@
 test_that("modify_defaults produces error with missing or incorrect defaults", {
-  msg <- "`defaults` must be a named list."
-  expect_error(modify_defaults(), msg, fixed = TRUE)
-  expect_error(modify_defaults("assignment_linter"), msg, fixed = TRUE)
+  lint_msg <- "`defaults` must be a named list."
+  expect_error(modify_defaults(), lint_msg, fixed = TRUE)
+  expect_error(modify_defaults("assignment_linter"), lint_msg, fixed = TRUE)
 })
 
 test_that("linters_with_tags produces error with incorrect tags", {

--- a/tests/testthat/test-xml_nodes_to_lints.R
+++ b/tests/testthat/test-xml_nodes_to_lints.R
@@ -8,7 +8,7 @@ test_that("it creates basic lints", {
   l <- xml_nodes_to_lints(
     xml = node,
     source_expression = expr,
-    lint_message = "msg",
+    lint_message = "lint_msg",
     type = "warning"
   )
 
@@ -17,7 +17,7 @@ test_that("it creates basic lints", {
   expect_identical(l$line_number, 1L)
   expect_identical(l$column_number, as.integer(xml2::xml_attr(node, "col1")))
   expect_identical(l$type, "warning")
-  expect_identical(l$message, "msg")
+  expect_identical(l$message, "lint_msg")
   expect_identical(l$line, code)
   expect_identical(l$ranges, list(as.integer(c(xml2::xml_attr(node, "col1"), xml2::xml_attr(node, "col2")))))
 
@@ -25,7 +25,7 @@ test_that("it creates basic lints", {
   l_before_col <- xml_nodes_to_lints(
     xml = node,
     source_expression = expr,
-    lint_message = "msg",
+    lint_message = "lint_msg",
     column_number_xpath = "number(./preceding-sibling::*[1]/@col2 + 1)",
     range_start_xpath = "number(./preceding-sibling::*[1]/@col1)",
     range_end_xpath = "number(./following-sibling::*[1]/@col2)"
@@ -37,7 +37,7 @@ test_that("it creates basic lints", {
   ll <- xml_nodes_to_lints(
     xml = xml2::xml_find_all(xml, "//expr"),
     source_expression = expr,
-    lint_message = "msg"
+    lint_message = "lint_msg"
   )
   expect_s3_class(ll, "lints")
   expect_length(ll, 3L)
@@ -47,7 +47,7 @@ test_that("it creates basic lints", {
   ll_unclassed <- xml_nodes_to_lints(
     xml = unclass(xml2::xml_find_all(xml, "//expr")),
     source_expression = expr,
-    lint_message = "msg"
+    lint_message = "lint_msg"
   )
   expect_s3_class(ll_unclassed, "lints")
   expect_length(ll_unclassed, 3L)
@@ -73,7 +73,7 @@ test_that("it handles multi-line lints correctly", {
   l <- xml_nodes_to_lints(
     xml = node,
     source_expression = expr,
-    lint_message = "msg"
+    lint_message = "lint_msg"
   )
 
   expect_s3_class(l, "lint")
@@ -81,7 +81,7 @@ test_that("it handles multi-line lints correctly", {
   expect_identical(l$line_number, 1L)
   expect_identical(l$column_number, as.integer(xml2::xml_attr(node, "col1")))
   expect_identical(l$type, "style")
-  expect_identical(l$message, "msg")
+  expect_identical(l$message, "lint_msg")
   expect_identical(l$line, code[[1L]])
   expect_identical(l$ranges, list(as.integer(c(xml2::xml_attr(node, "col1"), nchar(code[1L])))))
 })


### PR DESCRIPTION
Currently, in some tests we use `msg`, while in others `lint_msg`.