### PR TITLE
`spaces_inside_linter()` lints spaces after `[[`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -7,6 +7,8 @@
 * `get_source_expressions()` can handle Sweave/Rmarkdown documents with reference chunks like `<<ref_file>>` (#779, @MichaelChirico).
   Note that these are simply skipped, rather than attempting to retrieve the reference and also lint it.
 
+* `spaces_inside_linter()` produces lints for spaces inside `[[` (#1673, @IndrajeetPatil).
+
 ## Changes to defaults
 
 * Set the default for the `except` argument in `duplicate_argument_linter()` to `c("mutate", "transmute")`.

--- a/NEWS.md
+++ b/NEWS.md
@@ -7,8 +7,6 @@
 * `get_source_expressions()` can handle Sweave/Rmarkdown documents with reference chunks like `<<ref_file>>` (#779, @MichaelChirico).
   Note that these are simply skipped, rather than attempting to retrieve the reference and also lint it.
 
-* `spaces_inside_linter()` produces lints for spaces inside `[[` (#1673, @IndrajeetPatil).
-
 ## Changes to defaults
 
 * Set the default for the `except` argument in `duplicate_argument_linter()` to `c("mutate", "transmute")`.
@@ -40,6 +38,8 @@
 
 * `paste_linter()` also catches usages like `paste(rep("*", 10L), collapse = "")` that can be written more
   concisely as `strrep("*", 10L)` (#1108, @MichaelChirico)
+
+* `spaces_inside_linter()` produces lints for spaces inside `[[` (#1673, @IndrajeetPatil).
 
 ### New linters
 

--- a/R/spaces_inside_linter.R
+++ b/R/spaces_inside_linter.R
@@ -38,7 +38,10 @@ spaces_inside_linter <- function() {
     and @end != following-sibling::*[1]/@start - 1
     and @line1 = following-sibling::*[1]/@line1
   "
-  left_xpath <- glue::glue("//OP-LEFT-BRACKET[{left_xpath_condition}] | //OP-LEFT-PAREN[{left_xpath_condition}]")
+  left_xpath <- glue::glue("
+  //OP-LEFT-BRACKET[{left_xpath_condition}]
+  | //LBB[{left_xpath_condition}]
+  | //OP-LEFT-PAREN[{left_xpath_condition}]")
 
   right_xpath_condition <- "
     not(preceding-sibling::*[1][self::OP-COMMA])
@@ -58,7 +61,7 @@ spaces_inside_linter <- function() {
 
     left_expr <- xml2::xml_find_all(xml, left_xpath)
     left_msg <- ifelse(
-      xml2::xml_text(left_expr) == "[",
+      xml2::xml_text(left_expr) %in% c("[", "[["),
       "Do not place spaces after square brackets.",
       "Do not place spaces after parentheses."
     )

--- a/tests/testthat/test-spaces_inside_linter.R
+++ b/tests/testthat/test-spaces_inside_linter.R
@@ -102,12 +102,42 @@ test_that("spaces_inside_linter blocks diallowed usages", {
   )
 
   expect_lint(
+    "a[[ 1]]",
+    list(
+      message = "Do not place spaces after square brackets",
+      line_number = 1L,
+      column_number = 4L,
+      type = "style"
+    ),
+    linter
+  )
+
+  expect_lint(
     "a( 1)",
     list(
       message = "Do not place spaces after parentheses",
       line_number = 1L,
       column_number = 3L,
       type = "style"
+    ),
+    linter
+  )
+
+  expect_lint(
+    "x[[ 1L ]]",
+    list(
+      list(
+        message = "Do not place spaces after square brackets",
+        line_number = 1L,
+        column_number = 4L,
+        type = "style"
+      ),
+      list(
+        message = "Do not place spaces before square brackets",
+        line_number = 1L,
+        column_number = 7L,
+        type = "style"
+      )
     ),
     linter
   )


### PR DESCRIPTION
Closes #1673