### PR TITLE
always close con

### DIFF
--- a/R/expect_lint.R
+++ b/R/expect_lint.R
@@ -52,8 +52,10 @@ expect_lint <- function(content, checks, ..., file = NULL, language = "en") {
     file <- tempfile()
     con <- base::file(file, encoding = "UTF-8")
     on.exit(unlink(file), add = TRUE)
-    writeLines(content, con = con, sep = "\n")
-    close(con)
+    local({
+      on.exit(close(con))
+      writeLines(content, con = con, sep = "\n")
+    })
   }
 
   lints <- lint(file, ...)

--- a/R/expect_lint.R
+++ b/R/expect_lint.R
@@ -52,10 +52,10 @@ expect_lint <- function(content, checks, ..., file = NULL, language = "en") {
     file <- tempfile()
     con <- base::file(file, encoding = "UTF-8")
     on.exit(unlink(file), add = TRUE)
-    local({
-      on.exit(close(con))
+    withr::with_connection(
+      list(con = con),
       writeLines(content, con = con, sep = "\n")
-    })
+    )
   }
 
   lints <- lint(file, ...)


### PR DESCRIPTION
I believe this is the source of a warning about unclosed connections I get occasionally.

My thinking is like this:

```
expect_lint(stop(), NULL, linter())
```

`stop()` won't evaluate until after the temporary connection is opened, then `close()` won't run.

We also can't add this `close()` to the overall `on.exit()` call since we need the connection to close in order to lint it.