### PR TITLE
Minor cleanup in tests

### DIFF
--- a/tests/testthat/test-for_loop_index_linter.R
+++ b/tests/testthat/test-for_loop_index_linter.R
@@ -1,9 +1,11 @@
 test_that("for_loop_index_linter skips allowed usages", {
-  expect_lint("for (xi in x) {}", NULL, for_loop_index_linter())
+  linter <- for_loop_index_linter()
+
+  expect_lint("for (xi in x) {}", NULL, linter)
 
   # this is OK, so not every symbol is problematic
-  expect_lint("for (col in DF$col) {}", NULL, for_loop_index_linter())
-  expect_lint("for (col in DT[, col]) {}", NULL, for_loop_index_linter())
+  expect_lint("for (col in DF$col) {}", NULL, linter)
+  expect_lint("for (col in DT[, col]) {}", NULL, linter)
 })
 
 test_that("for_loop_index_linter blocks simple disallowed usages", {

--- a/tests/testthat/test-missing_package_linter.R
+++ b/tests/testthat/test-missing_package_linter.R
@@ -1,4 +1,4 @@
-test_that("returns the correct linting", {
+test_that("missing_package_linter skips allowed usages", {
   linter <- missing_package_linter()
   lint_msg <- list(message = rex::rex("Package 'statts' is not installed."))
 
@@ -8,8 +8,21 @@ test_that("returns the correct linting", {
   expect_lint("library(`stats`)", NULL, linter)
   expect_lint("library(stats, quietly)", NULL, linter)
   expect_lint("library(stats, quietly = TRUE)", NULL, linter)
+  expect_lint("require(stats)", NULL, linter)
+  expect_lint("require(stats, quietly = TRUE)", NULL, linter)
+  expect_lint('loadNamespace("stats")', NULL, linter)
+  expect_lint('requireNamespace("stats")', NULL, linter)
+})
 
+test_that("missing_package_linter blocks disallowed usages", {
+  linter <- missing_package_linter()
+  lint_msg <- list(message = rex::rex("Package 'statts' is not installed."))
+
+  expect_lint("require(statts)", lint_msg, linter)
   expect_lint("library(statts, quietly = TRUE)", lint_msg, linter)
+  expect_lint("library(statts, quietly = TRUE)", lint_msg, linter)
+  expect_lint('loadNamespace("statts")', lint_msg, linter)
+  expect_lint('requireNamespace("statts")', lint_msg, linter)
 
   expect_lint(
     trim_some("
@@ -19,18 +32,6 @@ test_that("returns the correct linting", {
     list(line = "library(statts)"),
     linter
   )
-
-  expect_lint("library(statts, quietly = TRUE)", lint_msg, linter)
-
-  expect_lint("require(stats)", NULL, linter)
-  expect_lint("require(stats, quietly = TRUE)", NULL, linter)
-  expect_lint("require(statts)", lint_msg, linter)
-
-  expect_lint('loadNamespace("stats")', NULL, linter)
-  expect_lint('loadNamespace("statts")', lint_msg, linter)
-
-  expect_lint('requireNamespace("stats")', NULL, linter)
-  expect_lint('requireNamespace("statts")', lint_msg, linter)
 })
 
 test_that("loadNamespace and requireNamespace allow plain symbols", {
@@ -41,8 +42,8 @@ test_that("loadNamespace and requireNamespace allow plain symbols", {
 test_that("character.only=TRUE case is handled", {
   expect_lint("library(statts, character.only = TRUE)", NULL, missing_package_linter())
   expect_lint("require(statts, character.only = TRUE)", NULL, missing_package_linter())
-
   expect_lint('library("stats", character.only = TRUE)', NULL, missing_package_linter())
+
   expect_lint(
     'library("statts", character.only = TRUE)',
     rex::rex("Package 'statts' is not installed."),

--- a/tests/testthat/test-settings.R
+++ b/tests/testthat/test-settings.R
@@ -1,5 +1,5 @@
 test_that("it uses default settings if none provided", {
-  read_settings(NULL)
+  lintr:::read_settings(NULL)
 
   lapply(ls(settings), function(setting) {
     expect_identical(settings[[setting]], default_settings[[setting]])
@@ -9,7 +9,7 @@ test_that("it uses default settings if none provided", {
 test_that("it uses option settings if provided", {
   withr::local_options(list(lintr.exclude = "test"))
 
-  read_settings(NULL)
+  lintr:::read_settings(NULL)
 
   expect_equal(settings$exclude, "test")
 })
@@ -19,7 +19,7 @@ test_that("it uses config settings in same directory if provided", {
   file <- withr::local_tempfile(tmpdir = test_dir)
   local_config(test_dir, 'exclude: "test"')
 
-  read_settings(file)
+  lintr:::read_settings(file)
 
   lapply(setdiff(ls(settings), "exclude"), function(setting) {
     expect_identical(settings[[setting]], default_settings[[setting]])
@@ -34,7 +34,7 @@ test_that("it uses config home directory settings if provided", {
   file <- withr::local_tempfile(tmpdir = path)
   local_config(home_path, 'exclude: "test"')
 
-  withr::with_envvar(c(HOME = home_path), read_settings(file))
+  withr::with_envvar(c(HOME = home_path), lintr:::read_settings(file))
 
   lapply(setdiff(ls(settings), "exclude"), function(setting) {
     expect_identical(settings[[setting]], default_settings[[setting]])
@@ -47,7 +47,7 @@ test_that("it errors if the config file does not end in a newline", {
   f <- withr::local_tempfile()
   cat("linters: linters_with_defaults(closed_curly_linter = NULL)", file = f)
   withr::local_options(list(lintr.linter_file = f))
-  expect_error(read_settings("foo"), "Malformed config file")
+  expect_error(lintr:::read_settings("foo"), "Malformed config file")
 })
 
 test_that("rot utility works as intended", {
@@ -95,7 +95,7 @@ test_that("linters_with_defaults doesn't break on very long input", {
 })
 
 test_that("it has a smart default for encodings", {
-  read_settings(NULL)
+  lintr:::read_settings(NULL)
   expect_equal(settings$encoding, "UTF-8")
 
   proj_file <- test_path("dummy_projects", "project", "metropolis-hastings-rho.R")
@@ -113,9 +113,9 @@ test_that("it has a smart default for encodings", {
   expect_equal(find_default_encoding(proj_file), "ISO8859-1")
   expect_equal(find_default_encoding(pkg_file), "ISO8859-1")
 
-  read_settings(proj_file)
+  lintr:::read_settings(proj_file)
   expect_equal(settings$encoding, "ISO8859-1")
 
-  read_settings(pkg_file)
+  lintr:::read_settings(pkg_file)
   expect_equal(settings$encoding, "ISO8859-1")
 })

--- a/tests/testthat/test-undesirable_operator_linter.R
+++ b/tests/testthat/test-undesirable_operator_linter.R
@@ -5,8 +5,16 @@ test_that("linter returns correct linting", {
 
   expect_lint("x <- foo:::getObj()", NULL, linter)
   expect_lint("cat(\"10$\")", NULL, linter)
-  expect_lint("a <<- log(10)", list(message = msg_assign, line_number = 1L, column_number = 3L), linter)
-  expect_lint("data$parsed == c(1, 2)", list(message = msg_dollar, line_number = 1L, column_number = 5L), linter)
+  expect_lint(
+    "a <<- log(10)",
+    list(message = msg_assign, line_number = 1L, column_number = 3L),
+    linter
+  )
+  expect_lint(
+    "data$parsed == c(1, 2)",
+    list(message = msg_dollar, line_number = 1L, column_number = 5L),
+    linter
+  )
 })
 
 test_that("undesirable_operator_linter handles '=' consistently", {
@@ -43,8 +51,16 @@ test_that("undesirable_operator_linter vectorizes messages", {
 })
 
 test_that("invalid inputs fail correctly", {
-  expect_error(undesirable_operator_linter("***"), "'op' should be a named character vector", fixed = TRUE)
-  expect_error(undesirable_operator_linter(c("***" = NA, NA)), "'op' should be a named character vector", fixed = TRUE)
+  expect_error(
+    undesirable_operator_linter("***"),
+    "'op' should be a named character vector",
+    fixed = TRUE
+  )
+  expect_error(
+    undesirable_operator_linter(c("***" = NA, NA)),
+    "'op' should be a named character vector",
+    fixed = TRUE
+  )
   expect_error(
     undesirable_operator_linter(c("***" = NA)),
     "Did not recognize any valid operators in request for: ***",


### PR DESCRIPTION
- formatting
- use `:::` for internals
- skip vs block division of tests