### PR TITLE
Get rid of `expect_identical_linter()` lints: Part-2

### DIFF
--- a/tests/testthat/test-linter_tags.R
+++ b/tests/testthat/test-linter_tags.R
@@ -73,7 +73,7 @@ test_that("warnings occur only for deprecated linters", {
       }
     )
   })
-  expect_equal(deprecation_warns_seen, num_deprecated_linters)
+  expect_identical(deprecation_warns_seen, num_deprecated_linters)
 })
 
 test_that("available_linters matches the set of linters available from lintr", {

--- a/tests/testthat/test-use_lintr.R
+++ b/tests/testthat/test-use_lintr.R
@@ -11,7 +11,7 @@ test_that("use_lintr works as expected", {
   expect_silent(lintr:::read_settings(tmp))
   lintr:::read_settings(NULL)
 
-  expect_equal(
+  expect_identical(
     normalizePath(lintr:::find_config(tmp)),
     normalizePath(lintr_file)
   )

--- a/tests/testthat/test-with_id.R
+++ b/tests/testthat/test-with_id.R
@@ -4,8 +4,8 @@ test_that("with_id works as expected", {
     source_expression = source_expression,
     ids_with_token(source_expression = source_expression, value = "expr")
   )
-  expect_equal(ref, source_expression$parsed_content[c(1L, 3L, 6L), ])
-  expect_equal(ref$token, rep_len("expr", nrow(ref)))
+  expect_identical(ref, source_expression$parsed_content[c(1L, 3L, 6L), ])
+  expect_identical(ref$token, rep_len("expr", nrow(ref)))
 
   # deprecated argument
   expect_warning(
@@ -15,5 +15,5 @@ test_that("with_id works as expected", {
     ),
     "Argument source_file was deprecated"
   )
-  expect_equal(old_arg, ref)
+  expect_identical(old_arg, ref)
 })


### PR DESCRIPTION
Missed a few in https://github.com/r-lib/lintr/pull/1712