### PR TITLE
Use `xp_text_in_table()` to create XPath variables

### DIFF
--- a/R/unnecessary_placeholder_linter.R
+++ b/R/unnecessary_placeholder_linter.R
@@ -34,10 +34,11 @@
 #' @export
 unnecessary_placeholder_linter <- function() {
   magrittr_pipes <- c("%>%", "%T>%", "%<>%")
+  magrittr_pipes_xpath <- xp_text_in_table(magrittr_pipes)
 
   # TODO(michaelchirico): handle R4.2.0 native placeholder _ as well
   xpath <- glue::glue("
-  //SPECIAL[ { xp_text_in_table(magrittr_pipes) } ]
+  //SPECIAL[ { magrittr_pipes_xpath } ]
     /following-sibling::expr[
       expr/SYMBOL_FUNCTION_CALL
       and not(expr[

--- a/R/unnecessary_placeholder_linter.R
+++ b/R/unnecessary_placeholder_linter.R
@@ -33,9 +33,11 @@
 #' @seealso [linters] for a complete list of linters available in lintr.
 #' @export
 unnecessary_placeholder_linter <- function() {
+  magrittr_pipes <- c("%>%", "%T>%", "%<>%")
+
   # TODO(michaelchirico): handle R4.2.0 native placeholder _ as well
-  xpath <- "
-  //SPECIAL[text() = '%>%' or text() = '%T>%' or text() = '%<>%']
+  xpath <- glue::glue("
+  //SPECIAL[ { xp_text_in_table(magrittr_pipes) } ]
     /following-sibling::expr[
       expr/SYMBOL_FUNCTION_CALL
       and not(expr[
@@ -47,7 +49,7 @@ unnecessary_placeholder_linter <- function() {
       SYMBOL[text() = '.']
       and not(preceding-sibling::*[1][self::EQ_SUB])
     ]
-  "
+  ")
 
   Linter(function(source_expression) {
     if (!is_lint_level(source_expression, "expression")) {

--- a/R/yoda_test_linter.R
+++ b/R/yoda_test_linter.R
@@ -45,8 +45,10 @@ yoda_test_linter <- function() {
     or (STR_CONST and not(OP-DOLLAR))
     or ((OP-PLUS or OP-MINUS) and count(expr[NUM_CONST]) = 2)
   "
+  expectations <- c("expect_equal", "expect_identical", "expect_setequal")
+
   xpath <- glue::glue("
-  //SYMBOL_FUNCTION_CALL[text() = 'expect_equal' or text() = 'expect_identical' or text() = 'expect_setequal']
+  //SYMBOL_FUNCTION_CALL[ { xp_text_in_table(expectations) } ]
     /parent::expr
     /following-sibling::expr[1][ {const_condition} ]
     /parent::expr[not(preceding-sibling::*[self::PIPE or self::SPECIAL[text() = '%>%']])]

--- a/R/yoda_test_linter.R
+++ b/R/yoda_test_linter.R
@@ -46,9 +46,10 @@ yoda_test_linter <- function() {
     or ((OP-PLUS or OP-MINUS) and count(expr[NUM_CONST]) = 2)
   "
   expectations <- c("expect_equal", "expect_identical", "expect_setequal")
+  expectations_xpath <- xp_text_in_table(expectations)
 
   xpath <- glue::glue("
-  //SYMBOL_FUNCTION_CALL[ { xp_text_in_table(expectations) } ]
+  //SYMBOL_FUNCTION_CALL[ { expectations_xpath } ]
     /parent::expr
     /following-sibling::expr[1][ {const_condition} ]
     /parent::expr[not(preceding-sibling::*[self::PIPE or self::SPECIAL[text() = '%>%']])]


### PR DESCRIPTION
Before I do this more widely, here is a POC PR.

I think using `xp_text_in_table()` to create XPath variables is more readable and easily extendable than listing each possible option with `text() = ` in the XPath itself.

Additionally, just looking at the values, it's sometimes difficult to gather what do they represent. But when stored in a vector and assigned to a variable with a meaningful name, this is no longer the case.  

We do this in [some places](https://github.com/r-lib/lintr/blob/080613e29644290a835658d7019ebad05b4b60f3/R/literal_coercion_linter.R#L48-L53) already. 

WDYT?