### PR TITLE
Remove unnecessary `loadNamespace()` call for `{rex}`

### DIFF
--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -1,10 +1,10 @@
 library(testthat)
 library(lintr)
+
 # suppress printing environment name (noisy)
 invisible({
-  loadNamespace("rex")
-  loadNamespace("withr")
   loadNamespace("patrick")
+  loadNamespace("withr")
 })
 
 test_check("lintr")


### PR DESCRIPTION
cf. https://github.com/r-lib/lintr/pull/1739#discussion_r999745186