### PR TITLE
Add nolint for `ids_with_token()` definition

### DIFF
--- a/R/ids_with_token.R
+++ b/R/ids_with_token.R
@@ -27,7 +27,7 @@
 #' entry of the list of source expressions. Indices correspond to the
 #' *rows* where `fun` evaluates to `TRUE` for the `value` in the *token* column.
 #' @export
-ids_with_token <- function(source_expression, value, fun = `==`, source_file) { # nolint: function_argument_linter.
+ids_with_token <- function(source_expression, value, fun = `==`, source_file = NULL) {
   if (!missing(source_file)) {
     lintr_deprecated(old = "source_file", new = "source_expression", version = "3.0.0", type = "Argument")
     source_expression <- source_file

--- a/R/ids_with_token.R
+++ b/R/ids_with_token.R
@@ -27,7 +27,7 @@
 #' entry of the list of source expressions. Indices correspond to the
 #' *rows* where `fun` evaluates to `TRUE` for the `value` in the *token* column.
 #' @export
-ids_with_token <- function(source_expression, value, fun = `==`, source_file) {
+ids_with_token <- function(source_expression, value, fun = `==`, source_file) { # nolint: function_argument_linter.
   if (!missing(source_file)) {
     lintr_deprecated(old = "source_file", new = "source_expression", version = "3.0.0", type = "Argument")
     source_expression <- source_file

--- a/man/ids_with_token.Rd
+++ b/man/ids_with_token.Rd
@@ -5,7 +5,7 @@
 \alias{with_id}
 \title{Get parsed IDs by token}
 \usage{
-ids_with_token(source_expression, value, fun = `==`, source_file)
+ids_with_token(source_expression, value, fun = `==`, source_file = NULL)
 
 with_id(source_expression, id, source_file)
 }


### PR DESCRIPTION
Triggers `function_argument_linter()`:

> Arguments without defaults should come before arguments with defaults.