### PR TITLE
Fix examples and add a new workflow to catch any future failures

### DIFF
--- a/.github/workflows/check-all-examples.yaml
+++ b/.github/workflows/check-all-examples.yaml
@@ -1,0 +1,42 @@
+# Make sure all examples run successfully, even the ones that are not supposed
+# to be run or tested on CRAN machines by default.
+#
+# The examples that fail should use
+#  - `if (FALSE) { ... }` (if example is included only for illustrative purposes)
+#  - `try({ ... })` (if the intent is to show the error)
+#
+# This workflow helps find such failing examples that need to be modified.
+
+on:
+  push:
+    branches: [main, master]
+  pull_request:
+    branches: [main, master]
+
+name: check-all-examples
+
+jobs:
+  check-all-examples:
+    runs-on: ubuntu-latest
+    env:
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: r-lib/actions/setup-r@v2
+        with:
+          use-public-rspm: true
+
+      - uses: r-lib/actions/setup-r-dependencies@v2
+        with:
+          pak-version: devel
+          extra-packages: |
+            any::devtools
+            local::.
+
+      - name: Run examples
+        run: |
+          options(crayon.enabled = TRUE)
+          devtools::run_examples(fresh = TRUE, run_dontrun = TRUE, run_donttest = TRUE)
+        shell: Rscript {0}

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -54,7 +54,7 @@ Config/Needs/website: tidyverse/tidytemplate
 Config/testthat/edition: 3
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.2.1
+RoxygenNote: 7.2.2
 Collate:
     'T_and_F_symbol_linter.R'
     'utils.R'

--- a/R/lint.R
+++ b/R/lint.R
@@ -119,17 +119,17 @@ lint <- function(filename, linters = NULL, ..., cache = FALSE, parse_settings = 
 #' .R, .Rmd, .qmd, .Rnw, .Rhtml, .Rrst, .Rtex, .Rtxt allowing for lowercase r (.r, ...).
 #'
 #' @examples
-#' \dontrun{
-#' lint_dir()
+#' if (FALSE) {
+#'   lint_dir()
 #'
-#' lint_dir(
-#'   linters = list(semicolon_linter()),
-#'   exclusions = list(
-#'     "inst/doc/creating_linters.R" = 1,
-#'     "inst/example/bad.R",
-#'     "renv"
+#'   lint_dir(
+#'     linters = list(semicolon_linter()),
+#'     exclusions = list(
+#'       "inst/doc/creating_linters.R" = 1,
+#'       "inst/example/bad.R",
+#'       "renv"
+#'     )
 #'   )
-#' )
 #' }
 #' @export
 #' @rdname lint
@@ -216,13 +216,13 @@ drop_excluded <- function(files, exclusions) {
 }
 
 #' @examples
-#' \dontrun{
-#' lint_package()
+#' if (FALSE) {
+#'   lint_package()
 #'
-#' lint_package(
-#'   linters = linters_with_defaults(semicolon_linter = semicolon_linter()),
-#'   exclusions = list("inst/doc/creating_linters.R" = 1, "inst/example/bad.R")
-#' )
+#'   lint_package(
+#'     linters = linters_with_defaults(semicolon_linter = semicolon_linter()),
+#'     exclusions = list("inst/doc/creating_linters.R" = 1, "inst/example/bad.R")
+#'   )
 #' }
 #' @export
 #' @rdname lint

--- a/R/use_lintr.R
+++ b/R/use_lintr.R
@@ -15,14 +15,14 @@
 #' @export
 #' @seealso `vignette("lintr")` for detailed introduction to using and configuring lintr.
 #' @examples
-#' \dontrun{
-#' # use the default set of linters
-#' lintr::use_lintr()
-#' # or try all linters
-#' lintr::use_lintr(type = "full")
+#' if (FALSE) {
+#'   # use the default set of linters
+#'   lintr::use_lintr()
+#'   # or try all linters
+#'   lintr::use_lintr(type = "full")
 #'
-#' # then
-#' lintr::lint_dir()
+#'   # then
+#'   lintr::lint_dir()
 #' }
 use_lintr <- function(path = ".", type = c("tidyverse", "full")) {
   config_file <- normalizePath(file.path(path, getOption("lintr.linter_file")), mustWork = FALSE)

--- a/R/with.R
+++ b/R/with.R
@@ -87,8 +87,8 @@ modify_defaults <- function(defaults, ...) {
 #' linters_with_tags(tags = NULL)
 #'
 #' # Get all linters tagged as "default" from lintr and mypkg
-#' \dontrun{
-#' linters_with_tags("default", packages = c("lintr", "mypkg"))
+#' if (FALSE) {
+#'   linters_with_tags("default", packages = c("lintr", "mypkg"))
 #' }
 #' @export
 linters_with_tags <- function(tags, ..., packages = "lintr", exclude_tags = "deprecated") {

--- a/man/lint.Rd
+++ b/man/lint.Rd
@@ -90,24 +90,24 @@ lint(f)                # linting a file
 lint("a = 123\n")      # linting inline-code
 lint(text = "a = 123") # linting inline-code
 \dontshow{\}) # examplesIf}
-\dontrun{
-lint_dir()
+if (FALSE) {
+  lint_dir()
 
-lint_dir(
-  linters = list(semicolon_linter()),
-  exclusions = list(
-    "inst/doc/creating_linters.R" = 1,
-    "inst/example/bad.R",
-    "renv"
+  lint_dir(
+    linters = list(semicolon_linter()),
+    exclusions = list(
+      "inst/doc/creating_linters.R" = 1,
+      "inst/example/bad.R",
+      "renv"
+    )
   )
-)
 }
-\dontrun{
-lint_package()
+if (FALSE) {
+  lint_package()
 
-lint_package(
-  linters = linters_with_defaults(semicolon_linter = semicolon_linter()),
-  exclusions = list("inst/doc/creating_linters.R" = 1, "inst/example/bad.R")
-)
+  lint_package(
+    linters = linters_with_defaults(semicolon_linter = semicolon_linter()),
+    exclusions = list("inst/doc/creating_linters.R" = 1, "inst/example/bad.R")
+  )
 }
 }

--- a/man/linters_with_tags.Rd
+++ b/man/linters_with_tags.Rd
@@ -38,8 +38,8 @@ linters_with_tags(tags = "package_development")
 linters_with_tags(tags = NULL)
 
 # Get all linters tagged as "default" from lintr and mypkg
-\dontrun{
-linters_with_tags("default", packages = c("lintr", "mypkg"))
+if (FALSE) {
+  linters_with_tags("default", packages = c("lintr", "mypkg"))
 }
 }
 \seealso{

--- a/man/use_lintr.Rd
+++ b/man/use_lintr.Rd
@@ -24,14 +24,14 @@ Path to the generated configuration, invisibly.
 Create a minimal lintr config file as a starting point for customization
 }
 \examples{
-\dontrun{
-# use the default set of linters
-lintr::use_lintr()
-# or try all linters
-lintr::use_lintr(type = "full")
+if (FALSE) {
+  # use the default set of linters
+  lintr::use_lintr()
+  # or try all linters
+  lintr::use_lintr(type = "full")
 
-# then
-lintr::lint_dir()
+  # then
+  lintr::lint_dir()
 }
 }
 \seealso{


### PR DESCRIPTION
Closes #1775 

`\donttest` examples are run in [an additional check](https://www.stats.ox.ac.uk/pub/bdr/donttest/) by BDR, and probably `\dontrun` examples are also run in some other checks. 

Therefore, making sure all examples run successfully (or are never run if they are just for illustrative purposes) is a good preventive practice, in general. This is currently not true for lintr-main branch, and is remedied in this PR.