### PR TITLE
Include only names of linters in example outputs

### DIFF
--- a/R/with.R
+++ b/R/with.R
@@ -80,11 +80,11 @@ modify_defaults <- function(defaults, ...) {
 #' # `linters_with_defaults()` and `linters_with_tags("default")` are the same:
 #' all.equal(linters_with_defaults(), linters_with_tags("default"))
 #'
-#' # Get names of all linters useful for package development
+#' # Get all linters useful for package development
 #' linters <- linters_with_tags(tags = "package_development")
 #' names(linters)
 #'
-#' # Get names of all linters provided by lintr
+#' # Get all linters provided by lintr
 #' linters <- linters_with_tags(tags = NULL)
 #' names(linters)
 #'

--- a/R/with.R
+++ b/R/with.R
@@ -81,10 +81,12 @@ modify_defaults <- function(defaults, ...) {
 #' all.equal(linters_with_defaults(), linters_with_tags("default"))
 #'
 #' # Get names of all linters useful for package development
-#' names(linters_with_tags(tags = "package_development"))
+#' linters <- linters_with_tags(tags = "package_development")
+#' names(linters)
 #'
 #' # Get names of all linters provided by lintr
-#' names(linters_with_tags(tags = NULL))
+#' linters <- linters_with_tags(tags = NULL)
+#' names(linters)
 #'
 #' # Get all linters tagged as "default" from lintr and mypkg
 #' if (FALSE) {

--- a/R/with.R
+++ b/R/with.R
@@ -80,11 +80,11 @@ modify_defaults <- function(defaults, ...) {
 #' # `linters_with_defaults()` and `linters_with_tags("default")` are the same:
 #' all.equal(linters_with_defaults(), linters_with_tags("default"))
 #'
-#' # Get all linters useful for package development
-#' linters_with_tags(tags = "package_development")
+#' # Get names of all linters useful for package development
+#' names(linters_with_tags(tags = "package_development"))
 #'
-#' # Get all linters provided by lintr
-#' linters_with_tags(tags = NULL)
+#' # Get names of all linters provided by lintr
+#' names(linters_with_tags(tags = NULL))
 #'
 #' # Get all linters tagged as "default" from lintr and mypkg
 #' if (FALSE) {

--- a/man/linters_with_tags.Rd
+++ b/man/linters_with_tags.Rd
@@ -31,11 +31,11 @@ or to be put in your configuration file.
 # `linters_with_defaults()` and `linters_with_tags("default")` are the same:
 all.equal(linters_with_defaults(), linters_with_tags("default"))
 
-# Get names of all linters useful for package development
+# Get all linters useful for package development
 linters <- linters_with_tags(tags = "package_development")
 names(linters)
 
-# Get names of all linters provided by lintr
+# Get all linters provided by lintr
 linters <- linters_with_tags(tags = NULL)
 names(linters)
 

--- a/man/linters_with_tags.Rd
+++ b/man/linters_with_tags.Rd
@@ -32,10 +32,12 @@ or to be put in your configuration file.
 all.equal(linters_with_defaults(), linters_with_tags("default"))
 
 # Get names of all linters useful for package development
-names(linters_with_tags(tags = "package_development"))
+linters <- linters_with_tags(tags = "package_development")
+names(linters)
 
 # Get names of all linters provided by lintr
-names(linters_with_tags(tags = NULL))
+linters <- linters_with_tags(tags = NULL)
+names(linters)
 
 # Get all linters tagged as "default" from lintr and mypkg
 if (FALSE) {

--- a/man/linters_with_tags.Rd
+++ b/man/linters_with_tags.Rd
@@ -31,11 +31,11 @@ or to be put in your configuration file.
 # `linters_with_defaults()` and `linters_with_tags("default")` are the same:
 all.equal(linters_with_defaults(), linters_with_tags("default"))
 
-# Get all linters useful for package development
-linters_with_tags(tags = "package_development")
+# Get names of all linters useful for package development
+names(linters_with_tags(tags = "package_development"))
 
-# Get all linters provided by lintr
-linters_with_tags(tags = NULL)
+# Get names of all linters provided by lintr
+names(linters_with_tags(tags = NULL))
 
 # Get all linters tagged as "default" from lintr and mypkg
 if (FALSE) {


### PR DESCRIPTION
Including definitions of functions makes the output on the website quite overwhelming.

cf. https://lintr.r-lib.org/dev/reference/linters_with_tags.html#ref-examples