### PR TITLE
Don't mark linter factory functions as linters in `modify_defaults()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -15,6 +15,8 @@
 
 * `lint_package()` correctly finds a package from within a subdir if the `path` points to anywhere within the package (#1759, @AshesITR)
 
+* `linters_with_defaults()` no longer erroneously marks linter factories as linters (#1725, @AshesITR).
+
 ## Changes to defaults
 
 * Set the default for the `except` argument in `duplicate_argument_linter()` to `c("mutate", "transmute")`.

--- a/R/with.R
+++ b/R/with.R
@@ -48,14 +48,6 @@ modify_defaults <- function(defaults, ...) {
   defaults[nms] <- vals
 
   res <- defaults[!vapply(defaults, is.null, logical(1L))]
-
-  res[] <- lapply(res, function(x) {
-    prev_class <- class(x)
-    if (is.function(x) && !is_linter_factory(x) && !is_linter(x)) {
-      class(x) <- c("linter", prev_class)
-    }
-    x
-  })
   res <- res[platform_independent_order(names(res))]
   res
 }

--- a/R/with.R
+++ b/R/with.R
@@ -51,7 +51,7 @@ modify_defaults <- function(defaults, ...) {
 
   res[] <- lapply(res, function(x) {
     prev_class <- class(x)
-    if (is.function(x) && !is_linter(x)) {
+    if (is.function(x) && !is_linter_factory(x) && !is_linter(x)) {
       class(x) <- c("linter", prev_class)
     }
     x

--- a/tests/testthat/test-lint_file.R
+++ b/tests/testthat/test-lint_file.R
@@ -171,6 +171,17 @@ test_that("compatibility warnings work", {
     fixed = TRUE
   )
 
+  # Also within `linters_with_defaults()` (#1725)
+  expect_warning(
+    expect_lint(
+      "a = 42",
+      "Use <-",
+      linters = linters_with_defaults(assignment_linter)
+    ),
+    regexp = "Passing linters as variables",
+    fixed = TRUE
+  )
+
   expect_warning(
     expect_lint(
       "a == NA",


### PR DESCRIPTION
fixes #1725 

``` r
# on main
waldo::compare(lintr::linters_with_defaults(assignment_linter = lintr::assignment_linter)["assignment_linter"], list(assignment_linter = lintr::assignment_linter))
#> `old$assignment_linter` is an S3 object of class <linter/function>, a function
#> `new$assignment_linter` is a function
```

<sup>Created on 2022-12-03 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>

``` r
# new branch
waldo::compare(lintr::linters_with_defaults(assignment_linter = lintr::assignment_linter)["assignment_linter"], list(assignment_linter = lintr::assignment_linter))
#> ✔ No differences
lintr::lint(text = "a = 1", linters = lintr::linters_with_defaults(assignment_linter = lintr::assignment_linter))
#> Warning: Passing linters as variables was deprecated in lintr version 3.0.0. Use
#> a call to the linters (see ?linters) instead.
#> <text>:1:3: style: [assignment_linter] Use <-, not =, for assignment.
#> a = 1
#>   ^
```

<sup>Created on 2022-12-03 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>