### PR TITLE
devtools -> remotes in installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,8 @@ install.packages("lintr")
 Or the development version from GitHub:
 
 ```R
-devtools::install_github("r-lib/lintr")
+# install.packages("remotes")
+remotes::install_github("r-lib/lintr")
 ```
 
 ## Usage


### PR DESCRIPTION
Since `{remotes}` is the lightweight option.

``` r
length(tools::package_dependencies("devtools", recursive = TRUE)[[1L]])
#> [1] 100

length(tools::package_dependencies("remotes", recursive = TRUE)[[1L]])
#> [1] 4
```

<sup>Created on 2022-12-05 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>