### PR TITLE
Fix missing row names in `available_linters()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -22,7 +22,7 @@
 
 * `linters_with_defaults()` no longer erroneously marks linter factories as linters (#1725, @AshesITR).
 
-* Row names for `available_linters()` data frame no longer have missing entries (#1781, @IndrajeetPatil).
+* Row names for `available_linters()` data frame are now contiguous (#1781, @IndrajeetPatil).
 
 ## Changes to defaults
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -22,6 +22,8 @@
 
 * `linters_with_defaults()` no longer erroneously marks linter factories as linters (#1725, @AshesITR).
 
+* Row names for `available_linters()` data frame no longer have missing entries (#1781, @IndrajeetPatil).
+
 ## Changes to defaults
 
 * Set the default for the `except` argument in `duplicate_argument_linter()` to `c("mutate", "transmute")`.

--- a/R/linter_tags.R
+++ b/R/linter_tags.R
@@ -90,7 +90,7 @@ build_available_linters <- function(available, package, tags, exclude_tags) {
 
   # Due to removal of deprecated linters in the returned data frame, there can be gaps in row numbers.
   # To avoid this inconsistency, regenerate row names.
-  rownames(available_df) <- seq(1L:nrow(available_df))
+  rownames(available_df) <- seq_len(nrow(available_df))
   available_df
 }
 

--- a/R/linter_tags.R
+++ b/R/linter_tags.R
@@ -90,7 +90,7 @@ build_available_linters <- function(available, package, tags, exclude_tags) {
 
   # Due to removal of deprecated linters in the returned data frame, there can be gaps in row numbers.
   # To avoid this inconsistency, regenerate row names.
-  rownames(available_df) <- seq_len(nrow(available_df))
+  rownames(available_df) <- NULL
   available_df
 }
 

--- a/R/linter_tags.R
+++ b/R/linter_tags.R
@@ -87,6 +87,10 @@ build_available_linters <- function(available, package, tags, exclude_tags) {
     matches_exclude <- vapply(available_df$tags, function(linter_tags) any(linter_tags %in% exclude_tags), logical(1L))
     available_df <- available_df[!matches_exclude, ]
   }
+
+  # Due to removal of deprecated linters in the returned data frame, there can be gaps in row numbers.
+  # To avoid this inconsistency, regenerate row names.
+  rownames(available_df) <- seq(1L:nrow(available_df))
   available_df
 }
 

--- a/tests/testthat/test-linter_tags.R
+++ b/tests/testthat/test-linter_tags.R
@@ -86,6 +86,14 @@ test_that("available_linters matches the set of linters available from lintr", {
   expect_identical(sort(linters_in_namespace), sort(exported_linters))
 })
 
+test_that("rownames for available_linters data frame doesn't have missing entries", {
+  lintr_db <- available_linters()
+  expect_identical(
+    tail(rownames(lintr_db), 1L),
+    as.character(nrow(lintr_db))
+  )
+})
+
 # See the roxygen helpers in R/linter_tags.R for the code used to generate the docs.
 #   This test helps ensure the documentation is up to date with the available_linters() database
 test_that("lintr help files are up to date", {

--- a/tests/testthat/test-linter_tags.R
+++ b/tests/testthat/test-linter_tags.R
@@ -92,6 +92,12 @@ test_that("rownames for available_linters data frame doesn't have missing entrie
     tail(rownames(lintr_db), 1L),
     as.character(nrow(lintr_db))
   )
+
+  lintr_db2 <- available_linters(exclude_tags = NULL)
+  expect_identical(
+    tail(rownames(lintr_db2), 1L),
+    as.character(nrow(lintr_db2))
+  )
 })
 
 # See the roxygen helpers in R/linter_tags.R for the code used to generate the docs.


### PR DESCRIPTION
Closes #1781

``` r
library(lintr)
rownames(available_linters())
#>  [1] "1"  "2"  "3"  "4"  "5"  "6"  "7"  "8"  "9"  "10" "11" "12" "13" "14" "15"
#> [16] "16" "17" "18" "19" "20" "21" "22" "23" "24" "25" "26" "27" "28" "29" "30"
#> [31] "31" "32" "33" "34" "35" "36" "37" "38" "39" "40" "41" "42" "43" "44" "45"
#> [46] "46" "47" "48" "49" "50" "51" "52" "53" "54" "55" "56" "57" "58" "59" "60"
#> [61] "61" "62" "63" "64" "65" "66" "67" "68" "69" "70" "71" "72" "73" "74" "75"
#> [76] "76" "77" "78" "79" "80" "81" "82" "83" "84" "85" "86"
```

<sup>Created on 2022-12-08 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>