### PR TITLE
Add tests for multi-line anonymous functions for `implicit_assignment_linter()`

### DIFF
--- a/tests/testthat/test-implicit_assignment_linter.R
+++ b/tests/testthat/test-implicit_assignment_linter.R
@@ -77,19 +77,53 @@ test_that("implicit_assignment_linter skips allowed usages", {
 
   expect_lint(
     trim_some("
-      lapply(x, function(xi) {
-        xi <- xi + 1
-        xi
-      })"),
+      map(
+        .x = 1:4,
+        .f = ~ (x <- .x + 1)
+      )"),
     NULL,
     linter
   )
 
   expect_lint(
     trim_some("
-      map(x, function(xi) {
-        xi <- xi + 1
-        xi
+      map(
+        .x = 1:4,
+        .f = ~ .x + 1 -> x
+      )"),
+    NULL,
+    linter
+  )
+
+  expect_lint(
+    trim_some("
+      map(
+        .x = 1:4,
+        .f = ~ {
+          x <- .x + 1
+          x
+        }
+      )"),
+    NULL,
+    linter
+  )
+
+  expect_lint(
+    trim_some("
+      lapply(1:4, function(x) {
+        x <- x + 1
+        x
+      })"),
+    NULL,
+    linter
+  )
+
+  skip_if_not_r_version("4.1")
+  expect_lint(
+    trim_some("
+      map(1:4, \\(x) {
+        x <- x + 1
+        x
       })"),
     NULL,
     linter

--- a/tests/testthat/test-implicit_assignment_linter.R
+++ b/tests/testthat/test-implicit_assignment_linter.R
@@ -74,6 +74,26 @@ test_that("implicit_assignment_linter skips allowed usages", {
     NULL,
     linter
   )
+
+  expect_lint(
+    trim_some("
+      lapply(x, function(xi) {
+        xi <- xi + 1
+        xi
+      })"),
+    NULL,
+    linter
+  )
+
+  expect_lint(
+    trim_some("
+      map(x, function(xi) {
+        xi <- xi + 1
+        xi
+      })"),
+    NULL,
+    linter
+  )
 })
 
 test_that("implicit_assignment_linter makes exceptions for functions that capture side-effects", {


### PR DESCRIPTION
Follow-up on #1814