### PR TITLE
Anticipate "no exceptions" case for `implicit_assignment_linter()`

### DIFF
--- a/R/implicit_assignment_linter.R
+++ b/R/implicit_assignment_linter.R
@@ -45,9 +45,16 @@ implicit_assignment_linter <- function(except = c(
   "expect_output", "expect_silent",
   "local", "quo", "quos", "quote", "test_that"
 )) {
-  exceptions <- xp_text_in_table(except)
-  xpath_exceptions <- glue::glue("
+  stopifnot(is.character(except))
+
+  if (length(except) > 0L) {
+    exceptions <- xp_text_in_table(except)
+    xpath_exceptions <- glue::glue("
     //SYMBOL_FUNCTION_CALL[ not({exceptions}) ]")
+  } else {
+    xpath_exceptions <- "
+    //SYMBOL_FUNCTION_CALL"
+  }
 
   assignments <- c(
     "LEFT_ASSIGN", # e.g. mean(x <- 1:4)

--- a/tests/testthat/test-implicit_assignment_linter.R
+++ b/tests/testthat/test-implicit_assignment_linter.R
@@ -76,6 +76,26 @@ test_that("implicit_assignment_linter skips allowed usages", {
   )
 })
 
+test_that("implicit_assignment_linter respects except argument", {
+  expect_lint(
+    "local({ a <- 1L })",
+    NULL,
+    implicit_assignment_linter(except = character(0L))
+  )
+
+  expect_lint(
+    "local(a <- 1L)",
+    rex::rex("Avoid implicit assignments in function calls."),
+    implicit_assignment_linter(except = character(0L))
+  )
+
+  expect_lint(
+    "local(a <- 1L)",
+    NULL,
+    implicit_assignment_linter(except = "local")
+  )
+})
+
 test_that("implicit_assignment_linter makes exceptions for functions that capture side-effects", {
   linter <- implicit_assignment_linter()
 


### PR DESCRIPTION
Closes #1822