### PR TITLE
Improve formatting for `brace_linter()` file

### DIFF
--- a/R/brace_linter.R
+++ b/R/brace_linter.R
@@ -153,42 +153,61 @@ brace_linter <- function(allow_single_line = FALSE) {
     xml <- source_expression$xml_parsed_content
     lints <- list()
 
-    lints <- c(lints, xml_nodes_to_lints(
-      xml2::xml_find_all(xml, xp_open_curly),
-      source_expression = source_expression,
-      lint_message =
-        "Opening curly braces should never go on their own line and should always be followed by a new line."
-    ))
+    lints <- c(
+      lints,
+      xml_nodes_to_lints(
+        xml2::xml_find_all(xml, xp_open_curly),
+        source_expression = source_expression,
+        lint_message =
+          "Opening curly braces should never go on their own line and should always be followed by a new line."
+      )
+    )
 
-    lints <- c(lints, xml_nodes_to_lints(
-      xml2::xml_find_all(xml, xp_paren_brace),
-      source_expression = source_expression,
-      lint_message = "There should be a space before an opening curly brace."
-    ))
+    lints <- c(
+      lints,
+      xml_nodes_to_lints(
+        xml2::xml_find_all(xml, xp_paren_brace),
+        source_expression = source_expression,
+        lint_message = "There should be a space before an opening curly brace."
+      )
+    )
 
-    lints <- c(lints, xml_nodes_to_lints(
-      xml2::xml_find_all(xml, xp_closed_curly),
-      source_expression = source_expression,
-      lint_message = "Closing curly-braces should always be on their own line, unless they are followed by an else."
-    ))
+    lints <- c(
+      lints,
+      xml_nodes_to_lints(
+        xml2::xml_find_all(xml, xp_closed_curly),
+        source_expression = source_expression,
+        lint_message =
+          "Closing curly-braces should always be on their own line, unless they are followed by an else."
+      )
+    )
 
-    lints <- c(lints, xml_nodes_to_lints(
-      xml2::xml_find_all(xml, xp_else_same_line),
-      source_expression = source_expression,
-      lint_message = "`else` should come on the same line as the previous `}`."
-    ))
+    lints <- c(
+      lints,
+      xml_nodes_to_lints(
+        xml2::xml_find_all(xml, xp_else_same_line),
+        source_expression = source_expression,
+        lint_message = "`else` should come on the same line as the previous `}`."
+      )
+    )
 
-    lints <- c(lints, xml_nodes_to_lints(
-      xml2::xml_find_all(xml, xp_function_brace),
-      source_expression = source_expression,
-      lint_message = "Any function spanning multiple lines should use curly braces."
-    ))
+    lints <- c(
+      lints,
+      xml_nodes_to_lints(
+        xml2::xml_find_all(xml, xp_function_brace),
+        source_expression = source_expression,
+        lint_message = "Any function spanning multiple lines should use curly braces."
+      )
+    )
 
-    lints <- c(lints, xml_nodes_to_lints(
-      xml2::xml_find_all(xml, xp_if_else_match_brace),
-      source_expression = source_expression,
-      lint_message = "Either both or neither branch in `if`/`else` should use curly braces."
-    ))
+    lints <- c(
+      lints,
+      xml_nodes_to_lints(
+        xml2::xml_find_all(xml, xp_if_else_match_brace),
+        source_expression = source_expression,
+        lint_message = "Either both or neither branch in `if`/`else` should use curly braces."
+      )
+    )
 
     lints
   })


### PR DESCRIPTION
Definitely a subjective choice, but I wonder if you feel the same way as I do; i.e., the formatting in this PR is better and more readable.