### PR TITLE
Fix `sarif_output()` format when no linting produces no results

### DIFF
--- a/R/lint.R
+++ b/R/lint.R
@@ -702,6 +702,11 @@ sarif_output <- function(lints, filename = "lintr_results.sarif") {
     sarif$runs[[1L]]$results <- append(sarif$runs[[1L]]$results, list(one_result))
   }
 
+  # if lints is empty, add empty results list
+  if (length(lints) == 0L) {
+    sarif$runs[[1L]]$results <- list()
+  }
+
   write(jsonlite::toJSON(sarif, pretty = TRUE, auto_unbox = TRUE), filename)
 }
 

--- a/tests/testthat/test-sarif_output.R
+++ b/tests/testthat/test-sarif_output.R
@@ -22,3 +22,24 @@ test_that("`sarif_output` writes expected files", {
     expect_true(file.exists("myfile.sarif"))
   })
 })
+
+test_that("`sarif_output` produces valid files", {
+  l <- lint_package(
+    test_path("dummy_packages", "clean"),
+    linters = default_linters,
+    parse_settings = FALSE
+  )
+
+  withr::with_tempdir({
+    sarif <- sarif_output(l)
+    sarif <- fromJSON(
+      "lintr_results.sarif",
+      simplifyVector = TRUE,
+      simplifyDataFrame = FALSE,
+      simplifyMatrix = FALSE
+    )
+
+    expect_false(is.null(sarif$runs))
+    expect_false(is.null(sarif$runs[[1L]]$results))
+  })
+})

--- a/tests/testthat/test-sarif_output.R
+++ b/tests/testthat/test-sarif_output.R
@@ -32,7 +32,7 @@ test_that("`sarif_output` produces valid files", {
 
   withr::with_tempdir({
     sarif <- sarif_output(l)
-    sarif <- fromJSON(
+    sarif <- jsonlite::fromJSON(
       "lintr_results.sarif",
       simplifyVector = TRUE,
       simplifyDataFrame = FALSE,


### PR DESCRIPTION
* Ensure all `sarif_output()` generated files include `results` array even if linting results in no issues
* `results` is required to be present in a SARIF file to be successfully uploaded to GitHub

fixes #1836 