### PR TITLE
Reorganize tests for `unneeded_concatenation_linter()`

### DIFF
--- a/tests/testthat/test-unneeded_concatenation_linter.R
+++ b/tests/testthat/test-unneeded_concatenation_linter.R
@@ -1,9 +1,5 @@
-test_that("returns the correct linting", {
+test_that("unneeded_concatenation_linter skips allowed usages", {
   linter <- unneeded_concatenation_linter()
-  msg_c <- rex::escape("Unneeded concatenation of a constant. Remove the \"c\" call.")
-  msg_e <- rex::escape(
-    "Unneeded concatenation without arguments. Replace the \"c\" call by NULL or, whenever possible, vector()"
-  )
 
   expect_lint("c(x)", NULL, linter)
   expect_lint("c(1, 2)", NULL, linter)
@@ -12,11 +8,33 @@ test_that("returns the correct linting", {
   expect_lint("lapply(1, c)", NULL, linter)
   expect_lint("c(a = 1)", NULL, linter)
   expect_lint("c('a' = 1)", NULL, linter)
+})
 
-  expect_lint("c()", list(message = msg_e, line_number = 1L, column_number = 1L), linter)
-  expect_lint("c(NULL)", list(message = msg_c, line_number = 1L, column_number = 1L), linter)
-  expect_lint("c(1)", list(message = msg_c, line_number = 1L, column_number = 1L), linter)
-  expect_lint("c (\n'a' )", list(message = msg_c, line_number = 1L, column_number = 1L), linter)
+test_that("unneeded_concatenation_linter blocks disallowed usages", {
+  linter <- unneeded_concatenation_linter()
+  msg_c <- rex::escape("Unneeded concatenation of a constant. Remove the \"c\" call.")
+  msg_e <- rex::escape("Unneeded concatenation without arguments. Replace the \"c\" call by NULL")
+
+  expect_lint(
+    "c()",
+    list(message = msg_e, line_number = 1L, column_number = 1L),
+    linter
+  )
+  expect_lint(
+    "c(NULL)",
+    list(message = msg_c, line_number = 1L, column_number = 1L),
+    linter
+  )
+  expect_lint(
+    "c(1)",
+    list(message = msg_c, line_number = 1L, column_number = 1L),
+    linter
+  )
+  expect_lint(
+    "c (\n'a' )",
+    list(message = msg_c, line_number = 1L, column_number = 1L),
+    linter
+  )
   expect_lint(
     "c(y, c('c('),\nc())",
     list(

--- a/tests/testthat/test-unneeded_concatenation_linter.R
+++ b/tests/testthat/test-unneeded_concatenation_linter.R
@@ -12,8 +12,8 @@ test_that("unneeded_concatenation_linter skips allowed usages", {
 
 test_that("unneeded_concatenation_linter blocks disallowed usages", {
   linter <- unneeded_concatenation_linter()
-  msg_c <- rex::escape("Unneeded concatenation of a constant. Remove the \"c\" call.")
-  msg_e <- rex::escape("Unneeded concatenation without arguments. Replace the \"c\" call by NULL")
+  msg_c <- rex::escape('Unneeded concatenation of a constant. Remove the "c" call.')
+  msg_e <- rex::escape('Unneeded concatenation without arguments. Replace the "c" call by NULL')
 
   expect_lint(
     "c()",


### PR DESCRIPTION
Follow the skip vs block pattern in tests layout