### PR TITLE
Remove redundant nocov annotations in addins file

### DIFF
--- a/R/addins.R
+++ b/R/addins.R
@@ -1,7 +1,7 @@
 # nocov start
 addin_lint <- function() {
   if (!requireNamespace("rstudioapi", quietly = TRUE)) {
-    stop("'rstudioapi' is required for add-ins.") # nocov
+    stop("'rstudioapi' is required for add-ins.")
   }
   filename <- rstudioapi::getSourceEditorContext()
   if (filename$path == "") {
@@ -27,7 +27,7 @@ addin_lint <- function() {
 
 addin_lint_package <- function() {
   if (!requireNamespace("rstudioapi", quietly = TRUE)) {
-    stop("'rstudioapi' is required for add-ins.") # nocov
+    stop("'rstudioapi' is required for add-ins.")
   }
   project <- rstudioapi::getActiveProject()
   project_path <- if (is.null(project)) getwd() else project


### PR DESCRIPTION
The entire file has been nocov-ed, so these two annotations are redundant. 