### PR TITLE
Avoid implicit type coercion in conditional expressions using `length()`

### DIFF
--- a/R/duplicate_argument_linter.R
+++ b/R/duplicate_argument_linter.R
@@ -49,7 +49,7 @@ duplicate_argument_linter <- function(except = c("mutate", "transmute")) {
 
     calls <- xml2::xml_find_all(xml, xpath_call_with_args)
 
-    if (length(except)) {
+    if (length(except) > 0L) {
       calls_text <- get_r_string(xp_call_name(calls))
       calls <- calls[!(calls_text %in% except)]
     }

--- a/R/extract.R
+++ b/R/extract.R
@@ -90,7 +90,7 @@ filter_chunk_end_positions <- function(starts, ends) {
   code_ends <- positions[pmin(1L + code_start_indexes, length(positions))]
 
   bad_end_indexes <- grep("starts", names(code_ends), fixed = TRUE)
-  if (length(bad_end_indexes)) {
+  if (length(bad_end_indexes) > 0L) {
     bad_start_positions <- positions[code_start_indexes[bad_end_indexes]]
     # This error message is formatted like a parse error
     stop(sprintf(

--- a/R/indentation_linter.R
+++ b/R/indentation_linter.R
@@ -214,7 +214,7 @@ indentation_linter <- function(indent = 2L, hanging_indent_style = c("tidy", "al
     bad_lines <- which(indent_levels != expected_indent_levels &
                          nzchar(trimws(source_expression$file_lines)) &
                          !in_str_const)
-    if (length(bad_lines)) {
+    if (length(bad_lines) > 0L) {
       # Suppress consecutive lints with the same indentation difference, to not generate an excessive number of lints
       is_consecutive_lint <- c(FALSE, diff(bad_lines) == 1L)
       indent_diff <- expected_indent_levels[bad_lines] - indent_levels[bad_lines]

--- a/R/methods.R
+++ b/R/methods.R
@@ -81,7 +81,7 @@ print.lints <- function(x, ...) {
 
   github_annotation_project_dir <- getOption("lintr.github_annotation_project_dir", "")
 
-  if (length(x)) {
+  if (length(x) > 0L) {
     inline_data <- x[[1L]][["filename"]] == "<text>"
     if (!inline_data && use_rstudio_source_markers) {
       rstudio_source_markers(x)


### PR DESCRIPTION
cf. https://style.tidyverse.org/syntax.html#implicit-type-coercion