### PR TITLE
Add `colsums_rowsums_linter()`

### DIFF
--- a/R/colsums_rowsums_linter.R
+++ b/R/colsums_rowsums_linter.R
@@ -1,0 +1,78 @@
+#' Require usage of `colSums(x)` or `rowSums(x)` over `apply(x, ., sum)`
+#'
+#' [colSums()] and [rowSums()] are clearer and more performant alternatives to
+#' `apply(x, 2, sum)` and `apply(x, 1, sum)` respectively in the case of 2D
+#' arrays, or matrices
+#'
+#' @examples
+#' # will produce lints
+#' lint(
+#'   text = "apply(x, 1, sum)",
+#'   linters = colsums_rowsums_linter()
+#' )
+#'
+#' lint(
+#'   text = "apply(x, 2, sum)",
+#'   linters = colsums_rowsums_linter()
+#' )
+#'
+#' lint(
+#'   text = "apply(x, 2, sum, na.rm = TRUE)",
+#'   linters = colsums_rowsums_linter()
+#' )
+#'
+#' @evalRd rd_tags("expect_named_linter")
+#' @seealso [linters] for a complete list of linters available in lintr.
+#' @export
+colsums_rowsums_linter <- function() {
+
+  # mean() and sum() have very different signatures so we treat them separately.
+  # sum() takes values to sum over via ..., has just one extra argument and is not a generic
+  # mean() is a generic, takes values to average via a single argument, and can have extra arguments
+  sums_xpath <- "
+  //SYMBOL_FUNCTION_CALL[text() = 'apply']
+    /parent::expr
+    /following-sibling::expr[
+      SYMBOL[text() = 'sum']
+      and (position() = 3)
+    ]
+  "
+
+  means_xpath <- "
+  //SYMBOL_FUNCTION_CALL[text() = 'apply']
+    /parent::expr
+    /following-sibling::expr[
+      SYMBOL[text() = 'mean']
+      and (position() = 3)
+    ]
+  "
+
+  Linter(function(source_expression) {
+    if (!is_lint_level(source_expression, "expression")) {
+      return(list())
+    }
+
+    xml <- source_expression$xml_parsed_content
+
+    bad_sums_expr <- xml2::xml_find_all(xml, sums_xpath)
+    sums_lint_message <- sprintf("colSums()")
+    sums_lint <- xml_nodes_to_lints(
+      bad_sums_expr,
+      source_expression = source_expression,
+      sums_lint_message,
+      type = "warning"
+    )
+
+    bad_means_expr <- xml2::xml_find_all(xml, means_xpath)
+    means_lint_message <- sprintf("colMeans()")
+    means_lint <- xml_nodes_to_lints(
+      bad_means_expr,
+      source_expression = source_expression,
+      means_lint_message,
+      type = "warning"
+    )
+
+    c(sums_lint, means_lint)
+
+  })
+}

--- a/R/colsums_rowsums_linter.R
+++ b/R/colsums_rowsums_linter.R
@@ -54,6 +54,13 @@ colsums_rowsums_linter <- function() {
     ]
   "
 
+  xpath <- glue::glue("{sums_xpath} | {means_xpath}")
+
+  # This doesn't handle the case when MARGIN and FUN are named and in a different position
+  # but this should be relatively rate
+  margin_xpath <- "expr[position() = 3]"
+  fun_xpath <- "expr[position() = 4]"
+
   Linter(function(source_expression) {
     if (!is_lint_level(source_expression, "expression")) {
       return(list())
@@ -61,25 +68,17 @@ colsums_rowsums_linter <- function() {
 
     xml <- source_expression$xml_parsed_content
 
-    bad_sums_expr <- xml2::xml_find_all(xml, sums_xpath)
-    sums_lint_message <- sprintf("colSums()")
-    sums_lint <- xml_nodes_to_lints(
-      bad_sums_expr,
+    bad_expr <- xml2::xml_find_all(xml, xpath)
+    fun <- xml2::xml_text(xml2::xml_find_all(bad_expr, fun_xpath))
+    lint_message <- sprintf("col%ss()", tools::toTitleCase(fun))
+
+    xml_nodes_to_lints(
+      bad_expr,
       source_expression = source_expression,
-      sums_lint_message,
+      lint_message,
       type = "warning"
     )
 
-    bad_means_expr <- xml2::xml_find_all(xml, means_xpath)
-    means_lint_message <- sprintf("colMeans()")
-    means_lint <- xml_nodes_to_lints(
-      bad_means_expr,
-      source_expression = source_expression,
-      means_lint_message,
-      type = "warning"
-    )
-
-    c(sums_lint, means_lint)
 
   })
 }

--- a/R/colsums_rowsums_linter.R
+++ b/R/colsums_rowsums_linter.R
@@ -36,14 +36,21 @@ colsums_rowsums_linter <- function() {
       SYMBOL[text() = 'sum']
       and (position() = 3)
     ]
+    /parent::expr
   "
 
+  # Since mean() is a generic, we make sure that we only lint cases with arguments
+  # supported by colMeans() and rowMeans(), i.e., na.rm
   means_xpath <- "
   //SYMBOL_FUNCTION_CALL[text() = 'apply']
     /parent::expr
     /following-sibling::expr[
       SYMBOL[text() = 'mean']
       and (position() = 3)
+    ]
+    /parent::expr[
+      count(expr) = 4
+      or (count(expr) = 5 and SYMBOL_SUB[text() = 'na.rm'])
     ]
   "
 

--- a/tests/testthat/test-colsums_rowsums_linter.R
+++ b/tests/testthat/test-colsums_rowsums_linter.R
@@ -16,31 +16,35 @@ test_that("colsums_rowsums_linter skips allowed usages", {
 
 test_that("colsums_rowsums_linter simple disallowed usages", {
   linter <- colsums_rowsums_linter()
-  lint_message <- rex::rex("colSums")
+  lint_message <- rex::rex("rowSums")
 
   expect_lint("apply(x, 1, sum)", lint_message, linter)
 
   expect_lint("apply(x, MARGIN = 1, FUN = sum)", lint_message, linter)
 
+  # Works with extra args in sum()
+  expect_lint("apply(x, 1, sum, na.rm = TRUE)", lint_message, linter)
+
+  lint_message <- rex::rex("colSums")
+
   expect_lint("apply(x, 2, sum)", lint_message, linter)
 
   expect_lint("apply(x, 2:4, sum)", lint_message, linter)
 
-  # Works with extra args in sum()
-  expect_lint("apply(x, 1, sum, na.rm = TRUE)", lint_message, linter)
-
-  lint_message <- rex::rex("colMeans")
+  lint_message <- rex::rex("rowMeans")
 
   expect_lint("apply(x, 1, mean)", lint_message, linter)
 
   expect_lint("apply(x, MARGIN = 1, FUN = mean)", lint_message, linter)
 
+  # Works with extra args in mean()
+  expect_lint("apply(x, 1, mean, na.rm = TRUE)", lint_message, linter)
+
+  lint_message <- rex::rex("colMeans")
+
   expect_lint("apply(x, 2, mean)", lint_message, linter)
 
   expect_lint("apply(x, 2:4, mean)", lint_message, linter)
-
-  # Works with extra args in mean()
-  expect_lint("apply(x, 1, mean, na.rm = TRUE)", lint_message, linter)
 
 })
 
@@ -50,10 +54,10 @@ test_that("colsums_rowsums_linter works with multiple lints in a single expressi
   expect_lint(
     "rbind(
       apply(x, 1, sum),
-      apply(y, 1, mean)
+      apply(y, 2:4, mean)
     )",
     list(
-      rex::rex("colSums"),
+      rex::rex("rowSums"),
       rex::rex("colMeans")
     ),
     linter

--- a/tests/testthat/test-colsums_rowsums_linter.R
+++ b/tests/testthat/test-colsums_rowsums_linter.R
@@ -44,17 +44,17 @@ test_that("colsums_rowsums_linter simple disallowed usages", {
 
 })
 
-test_that("colsums_rowsums_linterr works with multiple lints in a single expression", {
+test_that("colsums_rowsums_linter works with multiple lints in a single expression", {
   linter <- colsums_rowsums_linter()
 
   expect_lint(
     "rbind(
       apply(x, 1, sum),
-      apply(y, 1, sum)
+      apply(y, 1, mean)
     )",
     list(
       rex::rex("colSums"),
-      rex::rex("colSums")
+      rex::rex("colMeans")
     ),
     linter
   )

--- a/tests/testthat/test-colsums_rowsums_linter.R
+++ b/tests/testthat/test-colsums_rowsums_linter.R
@@ -1,0 +1,62 @@
+test_that("colsums_rowsums_linter skips allowed usages", {
+  linter <- colsums_rowsums_linter()
+
+  expect_lint("apply(x, 1, prod)", NULL, linter)
+
+  expect_lint("apply(x, 1, function(i) sum(i[i > 0]))", NULL, linter)
+
+  # sum as FUN argument
+  expect_lint("apply(x, 1, f, sum)", NULL, linter)
+
+  # mean() with named arguments other than na.rm is skipped because they are not
+  # implemented in colMeans() or rowMeans()
+  expect_lint("apply(x, 1, mean, trim = 0.2)", NULL, linter)
+})
+
+
+test_that("colsums_rowsums_linter simple disallowed usages", {
+  linter <- colsums_rowsums_linter()
+  lint_message <- rex::rex("colSums")
+
+  expect_lint("apply(x, 1, sum)", lint_message, linter)
+
+  expect_lint("apply(x, MARGIN = 1, FUN = sum)", lint_message, linter)
+
+  expect_lint("apply(x, 2, sum)", lint_message, linter)
+
+  expect_lint("apply(x, 2:4, sum)", lint_message, linter)
+
+  # Works with extra args in sum()
+  expect_lint("apply(x, 1, sum, na.rm = TRUE)", lint_message, linter)
+
+  lint_message <- rex::rex("colMeans")
+
+  expect_lint("apply(x, 1, mean)", lint_message, linter)
+
+  expect_lint("apply(x, MARGIN = 1, FUN = mean)", lint_message, linter)
+
+  expect_lint("apply(x, 2, mean)", lint_message, linter)
+
+  expect_lint("apply(x, 2:4, mean)", lint_message, linter)
+
+  # Works with extra args in mean()
+  expect_lint("apply(x, 1, mean, na.rm = TRUE)", lint_message, linter)
+
+})
+
+test_that("colsums_rowsums_linterr works with multiple lints in a single expression", {
+  linter <- colsums_rowsums_linter()
+
+  expect_lint(
+    "rbind(
+      apply(x, 1, sum),
+      apply(y, 1, sum)
+    )",
+    list(
+      rex::rex("colSums"),
+      rex::rex("colSums")
+    ),
+    linter
+  )
+
+})


### PR DESCRIPTION
Fix #1764 

This is still a work of progress but it can already receive a first round of review if you wish while I'm addressing the remaining TODO items:

To do:
- [ ] Test lint messages more strictly
- [ ] Add messages for simple cases when we have a matrix, or when `l2 = length(dim(x))`
- [ ] Add NEWS item
- [ ] Add linter tags

Open questions for input:
- [ ] I ended up implemented a linter for both `colSums()`/`rowSums()` and `colMeans()`/`rowMeans()`. The function should maybe have a more generic name but I'm not sure what
- [ ] The case when `MARGIN` is passed as an integer is not covered but I believe this is not correct syntax anyways (should there be a linter for this?)
  ```r
  apply(x, 1L, mean)
  ```
- [ ] Detection of `x`, `MARGIN` and `FUN` is purely based on position. I don't believe it should be common to see deviation from this but I'm open to counterpoints