### PR TITLE
`implicit_assignment_linter()` doesn't produce false positives with walrus operator

### DIFF
--- a/R/implicit_assignment_linter.R
+++ b/R/implicit_assignment_linter.R
@@ -56,9 +56,11 @@ implicit_assignment_linter <- function(except = c(
     //SYMBOL_FUNCTION_CALL"
   }
 
+  # The walrus operator `:=` is also `LEFT_ASSIGN`, but is not a relevant operator
+  # to be considered for the present linter.
   assignments <- c(
-    "LEFT_ASSIGN", # e.g. mean(x <- 1:4)
-    "RIGHT_ASSIGN" # e.g. mean(1:4 -> x)
+    "LEFT_ASSIGN[text() = '<-']", # e.g. mean(x <- 1:4)
+    "RIGHT_ASSIGN[text() = '->']" # e.g. mean(1:4 -> x)
   )
 
   xpath_fun_call <- paste0(

--- a/R/implicit_assignment_linter.R
+++ b/R/implicit_assignment_linter.R
@@ -59,8 +59,8 @@ implicit_assignment_linter <- function(except = c(
   # The walrus operator `:=` is also `LEFT_ASSIGN`, but is not a relevant operator
   # to be considered for the present linter.
   assignments <- c(
-    "LEFT_ASSIGN[text() = '<-']", # e.g. mean(x <- 1:4)
-    "RIGHT_ASSIGN[text() = '->']" # e.g. mean(1:4 -> x)
+    "LEFT_ASSIGN[text() != ':=']", # e.g. mean(x <- 1:4)
+    "RIGHT_ASSIGN" # e.g. mean(1:4 -> x)
   )
 
   xpath_fun_call <- paste0(

--- a/tests/testthat/test-implicit_assignment_linter.R
+++ b/tests/testthat/test-implicit_assignment_linter.R
@@ -3,6 +3,8 @@ test_that("implicit_assignment_linter skips allowed usages", {
 
   expect_lint("x <- 1L", NULL, linter)
   expect_lint("1L -> x", NULL, linter)
+  expect_lint("x <<- 1L", NULL, linter)
+  expect_lint("1L ->> x", NULL, linter)
   expect_lint("y <- if (is.null(x)) z else x", NULL, linter)
   expect_lint("for (x in 1:10) x <- x + 1", NULL, linter)
 
@@ -208,9 +210,10 @@ test_that("implicit_assignment_linter blocks disallowed usages in simple conditi
   lint_message <- rex::rex("Avoid implicit assignments in function calls.")
   linter <- implicit_assignment_linter()
 
-  # conditional statements
   expect_lint("if (x <- 1L) TRUE", lint_message, linter)
   expect_lint("if (1L -> x) TRUE", lint_message, linter)
+  expect_lint("if (x <<- 1L) TRUE", lint_message, linter)
+  expect_lint("if (1L ->> x) TRUE", lint_message, linter)
   expect_lint("while (x <- 0L) FALSE", lint_message, linter)
   expect_lint("while (0L -> x) FALSE", lint_message, linter)
   expect_lint("for (x in y <- 1:10) print(x)", lint_message, linter)

--- a/tests/testthat/test-implicit_assignment_linter.R
+++ b/tests/testthat/test-implicit_assignment_linter.R
@@ -276,3 +276,17 @@ test_that("implicit_assignment_linter blocks disallowed usages in function calls
     linter
   )
 })
+
+test_that("implicit_assignment_linter works as expected with pipes and walrus operator", {
+  linter <- implicit_assignment_linter()
+
+  expect_lint("data %>% mutate(a := b)", NULL, linter)
+  expect_lint("dt %>% .[, z := x + y]", NULL, linter)
+  expect_lint("data %<>% mutate(a := b)", NULL, linter)
+
+  expect_lint("DT[i, x := i]", NULL, linter)
+
+  skip_if_not_r_version("4.1.0")
+
+  expect_lint("data |> mutate(a := b)", NULL, linter)
+})


### PR DESCRIPTION
Closes #1827