### PR TITLE
Make sure examples don't produce additional lints

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -54,7 +54,7 @@ Config/Needs/website: tidyverse/tidytemplate
 Config/testthat/edition: 3
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.2.3
+RoxygenNote: 7.2.3.9000
 Collate:
     'T_and_F_symbol_linter.R'
     'utils.R'

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -54,7 +54,7 @@ Config/Needs/website: tidyverse/tidytemplate
 Config/testthat/edition: 3
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.2.3.9000
+RoxygenNote: 7.2.3
 Collate:
     'T_and_F_symbol_linter.R'
     'utils.R'

--- a/R/T_and_F_symbol_linter.R
+++ b/R/T_and_F_symbol_linter.R
@@ -5,12 +5,12 @@
 #' @examples
 #' # will produce lints
 #' lint(
-#'   text = "x <- T; y <- F",
+#'   text = "x <- c(T, F)",
 #'   linters = T_and_F_symbol_linter()
 #' )
 #'
 #' lint(
-#'   text = "T = 1.2; F = 2.4",
+#'   text = "F <- 2.4",
 #'   linters = T_and_F_symbol_linter()
 #' )
 #'
@@ -21,7 +21,7 @@
 #' )
 #'
 #' lint(
-#'   text = "t = 1.2; f = 2.4",
+#'   text = "f <- 2.4",
 #'   linters = T_and_F_symbol_linter()
 #' )
 #'

--- a/R/any_duplicated_linter.R
+++ b/R/any_duplicated_linter.R
@@ -1,4 +1,4 @@
-#' Require usage of `anyDuplicated(x) > 0` over `any(duplicated(x))`
+#' Require usage of `anyDuplicated(x) > 0L` over `any(duplicated(x))`
 #'
 #' [anyDuplicated()] exists as a replacement for `any(duplicated(.))`, which is
 #'   more efficient for simple objects, and is at worst equally efficient.

--- a/R/assignment_linter.R
+++ b/R/assignment_linter.R
@@ -14,7 +14,7 @@
 #'   linters = assignment_linter()
 #' )
 #'
-#' code_lines <- "1 -> x\n2 ->> y"
+#' code_lines <- "1L -> x\n2L ->> y"
 #' writeLines(code_lines)
 #' lint(
 #'   text = code_lines,
@@ -27,7 +27,7 @@
 #'   linters = assignment_linter()
 #' )
 #'
-#' code_lines <- "x <- 1\ny <<- 2"
+#' code_lines <- "x <- 1L\ny <<- 2L"
 #' writeLines(code_lines)
 #' lint(
 #'   text = code_lines,
@@ -35,7 +35,7 @@
 #' )
 #'
 #' # customizing using arguments
-#' code_lines <- "1 -> x\n2 ->> y"
+#' code_lines <- "1L -> x\n2L ->> y"
 #' writeLines(code_lines)
 #' lint(
 #'   text = code_lines,
@@ -43,13 +43,13 @@
 #' )
 #'
 #' lint(
-#'   text = "x <<- 1",
+#'   text = "x <<- 1L",
 #'   linters = assignment_linter(allow_cascading_assign = FALSE)
 #' )
 #'
-#' writeLines("foo(bar = \n 1)")
+#' writeLines("foo(bar = \n 1L)")
 #' lint(
-#'   text = "foo(bar = \n 1)",
+#'   text = "foo(bar = \n 1L)",
 #'   linters = assignment_linter(allow_trailing = FALSE)
 #' )
 #'

--- a/R/boolean_arithmetic_linter.R
+++ b/R/boolean_arithmetic_linter.R
@@ -11,7 +11,7 @@
 #' )
 #'
 #' lint(
-#'   text = "sum(grepl(pattern, x)) == 0",
+#'   text = "sum(grepl(pattern, x)) == 0L",
 #'   linters = boolean_arithmetic_linter()
 #' )
 #'

--- a/R/brace_linter.R
+++ b/R/brace_linter.R
@@ -15,33 +15,33 @@
 #' @examples
 #' # will produce lints
 #' lint(
-#'   text = "f <- function() { 1 }",
+#'   text = "f <- function() { 1L }",
 #'   linters = brace_linter()
 #' )
 #'
-#' writeLines("if (TRUE) {\n return(1) }")
+#' writeLines("if (TRUE) {\n return(1L) }")
 #' lint(
-#'   text = "if (TRUE) {\n return(1) }",
+#'   text = "if (TRUE) {\n return(1L) }",
 #'   linters = brace_linter()
 #' )
 #'
 #' # okay
-#' writeLines("f <- function() {\n  1\n}")
+#' writeLines("f <- function() {\n  1L\n}")
 #' lint(
-#'   text = "f <- function() {\n  1\n}",
+#'   text = "f <- function() {\n  1L\n}",
 #'   linters = brace_linter()
 #' )
 #'
-#' writeLines("if (TRUE) { \n return(1) \n}")
+#' writeLines("if (TRUE) { \n return(1L) \n}")
 #' lint(
-#'   text = "if (TRUE) { \n return(1) \n}",
+#'   text = "if (TRUE) { \n return(1L) \n}",
 #'   linters = brace_linter()
 #' )
 #'
 #' # customizing using arguments
-#' writeLines("if (TRUE) { return(1) }")
+#' writeLines("if (TRUE) { return(1L) }")
 #' lint(
-#'   text = "if (TRUE) { return(1) }",
+#'   text = "if (TRUE) { return(1L) }",
 #'   linters = brace_linter(allow_single_line = TRUE)
 #' )
 #' @evalRd rd_tags("brace_linter")

--- a/R/conjunct_test_linter.R
+++ b/R/conjunct_test_linter.R
@@ -23,7 +23,7 @@
 #' )
 #'
 #' lint(
-#'   text = "stopifnot('x must be a logical scalar' = length(x) == 1 && is.logical(x) && !is.na(x))",
+#'   text = "stopifnot('x must be a logical scalar' = length(x) == 1L && is.logical(x) && !is.na(x))",
 #'   linters = conjunct_test_linter(allow_named_stopifnot = FALSE)
 #' )
 #'
@@ -34,7 +34,7 @@
 #' )
 #'
 #' lint(
-#'   text = 'stopifnot("x must be a logical scalar" = length(x) == 1 && is.logical(x) && !is.na(x))',
+#'   text = 'stopifnot("x must be a logical scalar" = length(x) == 1L && is.logical(x) && !is.na(x))',
 #'   linters = conjunct_test_linter(allow_named_stopifnot = TRUE)
 #' )
 #'

--- a/R/empty_assignment_linter.R
+++ b/R/empty_assignment_linter.R
@@ -5,20 +5,18 @@
 #'
 #' @examples
 #' # will produce lints
+#' code_lines <- "x <- {\n}"
+#' writeLines(code_lines)
 #' lint(
-#'   text = "x <- {}",
-#'   linters = empty_assignment_linter()
-#' )
-#'
-#' writeLines("x = {\n}")
-#' lint(
-#'   text = "x = {\n}",
+#'   text = code_lines,
 #'   linters = empty_assignment_linter()
 #' )
 #'
 #' # okay
+#' code_lines <- "x <- {\n3L + 4L\n}"
+#' writeLines(code_lines)
 #' lint(
-#'   text = "x <- { 3 + 4 }",
+#'   text = code_lines,
 #'   linters = empty_assignment_linter()
 #' )
 #'

--- a/R/expect_comparison_linter.R
+++ b/R/expect_comparison_linter.R
@@ -19,7 +19,7 @@
 #' )
 #'
 #' lint(
-#'   text = "expect_true(x == (y == 2))",
+#'   text = "expect_true(x == (y == 2L))",
 #'   linters = expect_comparison_linter()
 #' )
 #'
@@ -35,12 +35,12 @@
 #' )
 #'
 #' lint(
-#'   text = "expect_identical(x, y == 2)",
+#'   text = "expect_identical(x, y == 2L)",
 #'   linters = expect_comparison_linter()
 #' )
 #'
 #' lint(
-#'   text = "expect_true(x < y | x > y^2)",
+#'   text = "expect_true(x < y | x > y^2L)",
 #'   linters = expect_comparison_linter()
 #' )
 #'

--- a/R/function_argument_linter.R
+++ b/R/function_argument_linter.R
@@ -10,33 +10,33 @@
 #' @examples
 #' # will produce lints
 #' lint(
-#'   text = "function(y = 1, z = 2, x) {}",
+#'   text = "function(y = 1L, z = 2L, x) {}",
 #'   linters = function_argument_linter()
 #' )
 #'
 #' lint(
-#'   text = "function(x, y, z = 1, ..., w) {}",
+#'   text = "function(x, y, z = 1L, ..., w) {}",
 #'   linters = function_argument_linter()
 #' )
 #'
 #' # okay
 #' lint(
-#'   text = "function(x, y = 1, z = 2) {}",
+#'   text = "function(x, y = 1L, z = 2L) {}",
 #'   linters = function_argument_linter()
 #' )
 #'
 #' lint(
-#'   text = "function(x, y, w, z = 1, ...) {}",
+#'   text = "function(x, y, w, z = 1L, ...) {}",
 #'   linters = function_argument_linter()
 #' )
 #'
 #' lint(
-#'   text = "function(y = 1, z = 2, x = NULL) {}",
+#'   text = "function(y = 1L, z = 2L, x = NULL) {}",
 #'   linters = function_argument_linter()
 #' )
 #'
 #' lint(
-#'   text = "function(x, y, z = 1, ..., w = NULL) {}",
+#'   text = "function(x, y, z = 1L, ..., w = NULL) {}",
 #'   linters = function_argument_linter()
 #' )
 #'

--- a/R/function_left_parentheses_linter.R
+++ b/R/function_left_parentheses_linter.R
@@ -30,7 +30,7 @@
 #' )
 #'
 #' lint(
-#'   text = "foo <- function(x) (x + 1)",
+#'   text = "foo <- function(x) (x + 1L)",
 #'   linters = function_left_parentheses_linter()
 #' )
 #'

--- a/R/function_return_linter.R
+++ b/R/function_return_linter.R
@@ -7,30 +7,30 @@
 #' @examples
 #' # will produce lints
 #' lint(
-#'   text = "foo <- function(x) return(y <- x + 1)",
+#'   text = "foo <- function(x) return(y <- x + 1L)",
 #'   linters = function_return_linter()
 #' )
 #'
 #' lint(
-#'   text = "foo <- function(x) return(x <<- x + 1)",
+#'   text = "foo <- function(x) return(x <<- x + 1L)",
 #'   linters = function_return_linter()
 #' )
 #'
-#' writeLines("e <- new.env() \nfoo <- function(x) return(e$val <- x + 1)")
+#' writeLines("e <- new.env() \nfoo <- function(x) return(e$val <- x + 1L)")
 #' lint(
-#'   text = "e <- new.env() \nfoo <- function(x) return(e$val <- x + 1)",
+#'   text = "e <- new.env() \nfoo <- function(x) return(e$val <- x + 1L)",
 #'   linters = function_return_linter()
 #' )
 #'
 #' # okay
 #' lint(
-#'   text = "foo <- function(x) return(x + 1)",
+#'   text = "foo <- function(x) return(x + 1L)",
 #'   linters = function_return_linter()
 #' )
 #'
 #' code_lines <- "
 #' foo <- function(x) {
-#'   x <<- x + 1
+#'   x <<- x + 1L
 #'   return(x)
 #' }
 #' "
@@ -42,7 +42,7 @@
 #' code_lines <- "
 #' e <- new.env()
 #' foo <- function(x) {
-#'   e$val <- x + 1
+#'   e$val <- x + 1L
 #'   return(e$val)
 #' }
 #' "

--- a/R/ifelse_censor_linter.R
+++ b/R/ifelse_censor_linter.R
@@ -16,7 +16,7 @@
 #' )
 #'
 #' lint(
-#'   text = "ifelse(x > 0, x, 0)",
+#'   text = "ifelse(x > 0L, x, 0L)",
 #'   linters = ifelse_censor_linter()
 #' )
 #'
@@ -27,7 +27,7 @@
 #' )
 #'
 #' lint(
-#'   text = "pmax(x, 0)",
+#'   text = "pmax(x, 0L)",
 #'   linters = ifelse_censor_linter()
 #' )
 #'

--- a/R/indentation_linter.R
+++ b/R/indentation_linter.R
@@ -16,26 +16,26 @@
 #'   map(
 #'     x,
 #'     f,
-#'     additional_arg = 42
+#'     additional_arg = 42L
 #'   )
 #'
 #'   # complies to "tidy" and "never"
 #'   map(x, f,
-#'     additional_arg = 42
+#'     additional_arg = 42L
 #'   )
 #'
 #'   # complies to "always"
 #'   map(x, f,
-#'       additional_arg = 42
+#'       additional_arg = 42L
 #'   )
 #'
 #'   # complies to "tidy" and "always"
 #'   map(x, f,
-#'       additional_arg = 42)
+#'       additional_arg = 42L)
 #'
 #'   # complies to "never"
 #'   map(x, f,
-#'     additional_arg = 42)
+#'     additional_arg = 42L)
 #'
 #'   # complies to "tidy"
 #'   function(
@@ -75,21 +75,21 @@
 #'   linters = indentation_linter()
 #' )
 #'
-#' code_lines <- "if (TRUE) {\n    1 + 1\n}"
+#' code_lines <- "if (TRUE) {\n    1L + 1L\n}"
 #' writeLines(code_lines)
 #' lint(
 #'   text = code_lines,
 #'   linters = indentation_linter()
 #' )
 #'
-#' code_lines <- "map(x, f,\n  additional_arg = 42\n)"
+#' code_lines <- "map(x, f,\n  additional_arg = 42L\n)"
 #' writeLines(code_lines)
 #' lint(
 #'   text = code_lines,
 #'   linters = indentation_linter(hanging_indent_style = "always")
 #' )
 #'
-#' code_lines <- "map(x, f,\n    additional_arg = 42)"
+#' code_lines <- "map(x, f,\n    additional_arg = 42L)"
 #' writeLines(code_lines)
 #' lint(
 #'   text = code_lines,
@@ -97,18 +97,18 @@
 #' )
 #'
 #' # okay
-#' code_lines <- "map(x, f,\n  additional_arg = 42\n)"
+#' code_lines <- "map(x, f,\n  additional_arg = 42L\n)"
 #' writeLines(code_lines)
 #' lint(
 #'   text = code_lines,
 #'   linters = indentation_linter()
 #' )
 #'
-#' code_lines <- "if (TRUE) {\n    1 + 1\n}"
+#' code_lines <- "if (TRUE) {\n    1L + 1L\n}"
 #' writeLines(code_lines)
 #' lint(
 #'   text = code_lines,
-#'   linters = indentation_linter(indent = 4)
+#'   linters = indentation_linter(indent = 4L)
 #' )
 #'
 #' @evalRd rd_tags("indentation_linter")

--- a/R/inner_combine_linter.R
+++ b/R/inner_combine_linter.R
@@ -20,7 +20,7 @@
 #' )
 #'
 #' lint(
-#'   text = "c(log(x, base = 10), log10(x, base = 2))",
+#'   text = "c(log(x, base = 10L), log10(x, base = 2L))",
 #'   linters = inner_combine_linter()
 #' )
 #'

--- a/R/namespace_linter.R
+++ b/R/namespace_linter.R
@@ -10,28 +10,28 @@
 #' @examples
 #' # will produce lints
 #' lint(
-#'   text = "xyzxyz::sd(c(1, 2, 3))",
+#'   text = "xyzxyz::sd(c(1.1, 2.3, 3.4))",
 #'   linters = namespace_linter()
 #' )
 #'
 #' lint(
-#'   text = "stats::ssd(c(1, 2, 3))",
+#'   text = "stats::ssd(c(1.1, 2.3, 3.4))",
 #'   linters = namespace_linter()
 #' )
 #'
 #' # okay
 #' lint(
-#'   text = "stats::sd(c(1, 2, 3))",
+#'   text = "stats::sd(c(1.1, 2.3, 3.4))",
 #'   linters = namespace_linter()
 #' )
 #'
 #' lint(
-#'   text = "stats::ssd(c(1, 2, 3))",
+#'   text = "stats::ssd(c(1.1, 2.3, 3.4))",
 #'   linters = namespace_linter(check_exports = FALSE)
 #' )
 #'
 #' lint(
-#'   text = "stats:::ssd(c(1, 2, 3))",
+#'   text = "stats:::ssd(c(1.1, 2.3, 3.4))",
 #'   linters = namespace_linter(check_nonexports = FALSE)
 #' )
 #'

--- a/R/object_name_linter.R
+++ b/R/object_name_linter.R
@@ -85,13 +85,17 @@ object_name_xpath <- local({
 #'   linters = object_name_linter(styles = "lowercase")
 #' )
 #'
+#' code_lines <- "my.var <- 1L\nmyvar <- 2L"
+#' writeLines(code_lines)
 #' lint(
-#'   text = "my.var <- 1L; myvar <- 2L",
+#'   text = code_lines,
 #'   linters = object_name_linter(styles = c("dotted.case", "lowercase"))
 #' )
 #'
+#' code_lines <- "asdf <- 1L\nasdF <- 1L"
+#' writeLines(code_lines)
 #' lint(
-#'   text = "asdf <- 1L; asdF <- 1L",
+#'   text = code_lines,
 #'   linters = object_name_linter(regexes = c(my_style = "F$", "f$"))
 #' )
 #'

--- a/R/object_usage_linter.R
+++ b/R/object_usage_linter.R
@@ -12,18 +12,20 @@
 #' @examples
 #' # will produce lints
 #' lint(
-#'   text = "foo <- function() { x <- 1 }",
+#'   text = "foo <- function() { x <- 1L }",
 #'   linters = object_usage_linter()
 #' )
 #'
 #' # okay
 #' lint(
-#'   text = "foo <- function(x) { x <- 1 }",
+#'   text = "foo <- function(x) { x <- 1L }",
 #'   linters = object_usage_linter()
 #' )
 #'
+#' code_lines <- "foo <- function() {\n  x <- 1L\n  return(x)\n}"
+#' writeLines(code_lines)
 #' lint(
-#'   text = "foo <- function() { x <- 1; return(x) }",
+#'   text = code_lines,
 #'   linters = object_usage_linter()
 #' )
 #' @evalRd rd_linters("package_development")

--- a/R/paren_body_linter.R
+++ b/R/paren_body_linter.R
@@ -7,13 +7,13 @@
 #' @examples
 #' # will produce lints
 #' lint(
-#'   text = "function(x)x + 1",
+#'   text = "function(x)x + 1L",
 #'   linters = paren_body_linter()
 #' )
 #'
 #' # okay
 #' lint(
-#'   text = "function(x) x + 1",
+#'   text = "function(x) x + 1L",
 #'   linters = paren_body_linter()
 #' )
 #'

--- a/R/redundant_equals_linter.R
+++ b/R/redundant_equals_linter.R
@@ -10,23 +10,23 @@
 #' @examples
 #' # will produce lints
 #' lint(
-#'   text = "if (any(x == TRUE)) 1",
+#'   text = "if (any(x == TRUE)) 1L",
 #'   linters = redundant_equals_linter()
 #' )
 #'
 #' lint(
-#'   text = "if (any(x != FALSE)) 0",
+#'   text = "if (any(x != FALSE)) 0L",
 #'   linters = redundant_equals_linter()
 #' )
 #'
 #' # okay
 #' lint(
-#'   text = "if (any(x)) 1",
+#'   text = "if (any(x)) 1L",
 #'   linters = redundant_equals_linter()
 #' )
 #'
 #' lint(
-#'   text = "if (!all(x)) 0",
+#'   text = "if (!all(x)) 0L",
 #'   linters = redundant_equals_linter()
 #' )
 #'

--- a/R/semicolon_linter.R
+++ b/R/semicolon_linter.R
@@ -10,32 +10,32 @@
 #' @examples
 #' # will produce lints
 #' lint(
-#'   text = "a <- 1;",
+#'   text = "a <- 1L;",
 #'   linters = semicolon_linter()
 #' )
 #'
 #' lint(
-#'   text = "a <- 1; b <- 1",
+#'   text = "a <- 1L; b <- 1L",
 #'   linters = semicolon_linter()
 #' )
 #'
 #' lint(
-#'   text = "function() { a <- 1; b <- 1 }",
+#'   text = "function() { a <- 1L; b <- 1L }",
 #'   linters = semicolon_linter()
 #' )
 #'
 #' # okay
 #' lint(
-#'   text = "a <- 1",
+#'   text = "a <- 1L",
 #'   linters = semicolon_linter()
 #' )
 #'
 #' lint(
-#'   text = "a <- 1;",
+#'   text = "a <- 1L;",
 #'   linters = semicolon_linter(allow_trailing = TRUE)
 #' )
 #'
-#' code_lines <- "a <- 1\nb <- 1"
+#' code_lines <- "a <- 1L\nb <- 1L"
 #' writeLines(code_lines)
 #' lint(
 #'   text = code_lines,
@@ -43,11 +43,11 @@
 #' )
 #'
 #' lint(
-#'   text = "a <- 1; b <- 1",
+#'   text = "a <- 1L; b <- 1L",
 #'   linters = semicolon_linter(allow_compound = TRUE)
 #' )
 #'
-#' code_lines <- "function() { \n  a <- 1\n  b <- 1\n}"
+#' code_lines <- "function() { \n  a <- 1L\n  b <- 1L\n}"
 #' writeLines(code_lines)
 #' lint(
 #'   text = code_lines,

--- a/R/trailing_blank_lines_linter.R
+++ b/R/trailing_blank_lines_linter.R
@@ -4,7 +4,7 @@
 #'
 #' @examplesIf requireNamespace("withr", quietly = TRUE)
 #' # will produce lints
-#' f <- withr::local_tempfile(lines = "x <- 1\n")
+#' f <- withr::local_tempfile(lines = "x <- 1L\n")
 #' readLines(f)
 #' lint(
 #'   filename = f,
@@ -12,7 +12,7 @@
 #' )
 #'
 #' # okay
-#' f <- withr::local_tempfile(lines = "x <- 1")
+#' f <- withr::local_tempfile(lines = "x <- 1L")
 #' readLines(f)
 #' lint(
 #'   filename = f,

--- a/R/undesirable_function_linter.R
+++ b/R/undesirable_function_linter.R
@@ -43,7 +43,7 @@
 #' )
 #'
 #' lint(
-#'   text = "log(x, base = 10)",
+#'   text = "log(x, base = 10L)",
 #'   linters = undesirable_function_linter(fun = c("log10" = "use log()"))
 #' )
 #'

--- a/R/undesirable_operator_linter.R
+++ b/R/undesirable_operator_linter.R
@@ -15,7 +15,7 @@
 #'
 #' # will produce lints
 #' lint(
-#'   text = "a <<- log(10)",
+#'   text = "a <<- log(10.0)",
 #'   linters = undesirable_operator_linter()
 #' )
 #'

--- a/R/unreachable_code_linter.R
+++ b/R/unreachable_code_linter.R
@@ -7,7 +7,7 @@
 #'
 #' @examples
 #' # will produce lints
-#' code_lines <- "f <- function() {\n  return(1 + 1)\n  2 + 2\n}"
+#' code_lines <- "f <- function() {\n  return(1L + 1L)\n  2L + 2L\n}"
 #' writeLines(code_lines)
 #' lint(
 #'   text = code_lines,
@@ -15,7 +15,7 @@
 #' )
 #'
 #' # okay
-#' code_lines <- "f <- function() {\n  return(1 + 1)\n}"
+#' code_lines <- "f <- function() {\n  return(1L + 1L)\n}"
 #' writeLines(code_lines)
 #' lint(
 #'   text = code_lines,

--- a/R/unused_import_linter.R
+++ b/R/unused_import_linter.R
@@ -9,14 +9,14 @@
 #'
 #' @examples
 #' # will produce lints
-#' code_lines <- "library(dplyr)\n1 + 1"
+#' code_lines <- "library(dplyr)\n1L + 1L"
 #' writeLines(code_lines)
 #' lint(
 #'   text = code_lines,
 #'   linters = unused_import_linter()
 #' )
 #'
-#' code_lines <- "library(dplyr)\ndplyr::tibble(a = 1)"
+#' code_lines <- "library(dplyr)\ndplyr::tibble(a = 1L)"
 #' writeLines(code_lines)
 #' lint(
 #'   text = code_lines,
@@ -24,14 +24,14 @@
 #' )
 #'
 #' # okay
-#' code_lines <- "library(dplyr)\ntibble(a = 1)"
+#' code_lines <- "library(dplyr)\ntibble(a = 1L)"
 #' writeLines(code_lines)
 #' lint(
 #'   text = code_lines,
 #'   linters = unused_import_linter()
 #' )
 #'
-#' code_lines <- "library(dplyr)\ndplyr::tibble(a = 1)"
+#' code_lines <- "library(dplyr)\ndplyr::tibble(a = 1L)"
 #' writeLines(code_lines)
 #' lint(
 #'   text = code_lines,

--- a/R/vector_logic_linter.R
+++ b/R/vector_logic_linter.R
@@ -22,23 +22,23 @@
 #' @examples
 #' # will produce lints
 #' lint(
-#'   text = "if (TRUE & FALSE) 1",
+#'   text = "if (TRUE & FALSE) 1.0",
 #'   linters = vector_logic_linter()
 #' )
 #'
 #' lint(
-#'   text = "if (TRUE && (TRUE | FALSE)) 4",
+#'   text = "if (TRUE && (TRUE | FALSE)) 4.2",
 #'   linters = vector_logic_linter()
 #' )
 #'
 #' # okay
 #' lint(
-#'   text = "if (TRUE && FALSE) 1",
+#'   text = "if (TRUE && FALSE) 1.0",
 #'   linters = vector_logic_linter()
 #' )
 #'
 #' lint(
-#'   text = "if (TRUE && (TRUE || FALSE)) 4",
+#'   text = "if (TRUE && (TRUE || FALSE)) 4.2",
 #'   linters = vector_logic_linter()
 #' )
 #'

--- a/R/yoda_test_linter.R
+++ b/R/yoda_test_linter.R
@@ -8,7 +8,7 @@
 #' @examples
 #' # will produce lints
 #' lint(
-#'   text = "expect_equal(2, x)",
+#'   text = "expect_equal(2L, x)",
 #'   linters = yoda_test_linter()
 #' )
 #'
@@ -19,7 +19,7 @@
 #'
 #' # okay
 #' lint(
-#'   text = "expect_equal(x, 2)",
+#'   text = "expect_equal(x, 2L)",
 #'   linters = yoda_test_linter()
 #' )
 #'

--- a/man/T_and_F_symbol_linter.Rd
+++ b/man/T_and_F_symbol_linter.Rd
@@ -12,12 +12,12 @@ Avoid the symbols \code{T} and \code{F}, and use \code{TRUE} and \code{FALSE} in
 \examples{
 # will produce lints
 lint(
-  text = "x <- T; y <- F",
+  text = "x <- c(T, F)",
   linters = T_and_F_symbol_linter()
 )
 
 lint(
-  text = "T = 1.2; F = 2.4",
+  text = "F <- 2.4",
   linters = T_and_F_symbol_linter()
 )
 
@@ -28,7 +28,7 @@ lint(
 )
 
 lint(
-  text = "t = 1.2; f = 2.4",
+  text = "f <- 2.4",
   linters = T_and_F_symbol_linter()
 )
 

--- a/man/any_duplicated_linter.Rd
+++ b/man/any_duplicated_linter.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/any_duplicated_linter.R
 \name{any_duplicated_linter}
 \alias{any_duplicated_linter}
-\title{Require usage of \code{anyDuplicated(x) > 0} over \code{any(duplicated(x))}}
+\title{Require usage of \code{anyDuplicated(x) > 0L} over \code{any(duplicated(x))}}
 \usage{
 any_duplicated_linter()
 }

--- a/man/assignment_linter.Rd
+++ b/man/assignment_linter.Rd
@@ -28,7 +28,7 @@ lint(
   linters = assignment_linter()
 )
 
-code_lines <- "1 -> x\n2 ->> y"
+code_lines <- "1L -> x\n2L ->> y"
 writeLines(code_lines)
 lint(
   text = code_lines,
@@ -41,7 +41,7 @@ lint(
   linters = assignment_linter()
 )
 
-code_lines <- "x <- 1\ny <<- 2"
+code_lines <- "x <- 1L\ny <<- 2L"
 writeLines(code_lines)
 lint(
   text = code_lines,
@@ -49,7 +49,7 @@ lint(
 )
 
 # customizing using arguments
-code_lines <- "1 -> x\n2 ->> y"
+code_lines <- "1L -> x\n2L ->> y"
 writeLines(code_lines)
 lint(
   text = code_lines,
@@ -57,13 +57,13 @@ lint(
 )
 
 lint(
-  text = "x <<- 1",
+  text = "x <<- 1L",
   linters = assignment_linter(allow_cascading_assign = FALSE)
 )
 
-writeLines("foo(bar = \n 1)")
+writeLines("foo(bar = \n 1L)")
 lint(
-  text = "foo(bar = \n 1)",
+  text = "foo(bar = \n 1L)",
   linters = assignment_linter(allow_trailing = FALSE)
 )
 

--- a/man/boolean_arithmetic_linter.Rd
+++ b/man/boolean_arithmetic_linter.Rd
@@ -18,7 +18,7 @@ lint(
 )
 
 lint(
-  text = "sum(grepl(pattern, x)) == 0",
+  text = "sum(grepl(pattern, x)) == 0L",
   linters = boolean_arithmetic_linter()
 )
 

--- a/man/brace_linter.Rd
+++ b/man/brace_linter.Rd
@@ -26,33 +26,33 @@ does.
 \examples{
 # will produce lints
 lint(
-  text = "f <- function() { 1 }",
+  text = "f <- function() { 1L }",
   linters = brace_linter()
 )
 
-writeLines("if (TRUE) {\n return(1) }")
+writeLines("if (TRUE) {\n return(1L) }")
 lint(
-  text = "if (TRUE) {\n return(1) }",
+  text = "if (TRUE) {\n return(1L) }",
   linters = brace_linter()
 )
 
 # okay
-writeLines("f <- function() {\n  1\n}")
+writeLines("f <- function() {\n  1L\n}")
 lint(
-  text = "f <- function() {\n  1\n}",
+  text = "f <- function() {\n  1L\n}",
   linters = brace_linter()
 )
 
-writeLines("if (TRUE) { \n return(1) \n}")
+writeLines("if (TRUE) { \n return(1L) \n}")
 lint(
-  text = "if (TRUE) { \n return(1) \n}",
+  text = "if (TRUE) { \n return(1L) \n}",
   linters = brace_linter()
 )
 
 # customizing using arguments
-writeLines("if (TRUE) { return(1) }")
+writeLines("if (TRUE) { return(1L) }")
 lint(
-  text = "if (TRUE) { return(1) }",
+  text = "if (TRUE) { return(1L) }",
   linters = brace_linter(allow_single_line = TRUE)
 )
 }

--- a/man/conjunct_test_linter.Rd
+++ b/man/conjunct_test_linter.Rd
@@ -32,7 +32,7 @@ lint(
 )
 
 lint(
-  text = "stopifnot('x must be a logical scalar' = length(x) == 1 && is.logical(x) && !is.na(x))",
+  text = "stopifnot('x must be a logical scalar' = length(x) == 1L && is.logical(x) && !is.na(x))",
   linters = conjunct_test_linter(allow_named_stopifnot = FALSE)
 )
 
@@ -43,7 +43,7 @@ lint(
 )
 
 lint(
-  text = 'stopifnot("x must be a logical scalar" = length(x) == 1 && is.logical(x) && !is.na(x))',
+  text = 'stopifnot("x must be a logical scalar" = length(x) == 1L && is.logical(x) && !is.na(x))',
   linters = conjunct_test_linter(allow_named_stopifnot = TRUE)
 )
 

--- a/man/empty_assignment_linter.Rd
+++ b/man/empty_assignment_linter.Rd
@@ -12,20 +12,18 @@ for clarity. Closely related: \code{\link[=unnecessary_concatenation_linter]{unn
 }
 \examples{
 # will produce lints
+code_lines <- "x <- {\n}"
+writeLines(code_lines)
 lint(
-  text = "x <- {}",
-  linters = empty_assignment_linter()
-)
-
-writeLines("x = {\n}")
-lint(
-  text = "x = {\n}",
+  text = code_lines,
   linters = empty_assignment_linter()
 )
 
 # okay
+code_lines <- "x <- {\n3L + 4L\n}"
+writeLines(code_lines)
 lint(
-  text = "x <- { 3 + 4 }",
+  text = code_lines,
   linters = empty_assignment_linter()
 )
 

--- a/man/expect_comparison_linter.Rd
+++ b/man/expect_comparison_linter.Rd
@@ -26,7 +26,7 @@ lint(
 )
 
 lint(
-  text = "expect_true(x == (y == 2))",
+  text = "expect_true(x == (y == 2L))",
   linters = expect_comparison_linter()
 )
 
@@ -42,12 +42,12 @@ lint(
 )
 
 lint(
-  text = "expect_identical(x, y == 2)",
+  text = "expect_identical(x, y == 2L)",
   linters = expect_comparison_linter()
 )
 
 lint(
-  text = "expect_true(x < y | x > y^2)",
+  text = "expect_true(x < y | x > y^2L)",
   linters = expect_comparison_linter()
 )
 

--- a/man/function_argument_linter.Rd
+++ b/man/function_argument_linter.Rd
@@ -16,33 +16,33 @@ is to instead set the default for such arguments to \code{NULL}.
 \examples{
 # will produce lints
 lint(
-  text = "function(y = 1, z = 2, x) {}",
+  text = "function(y = 1L, z = 2L, x) {}",
   linters = function_argument_linter()
 )
 
 lint(
-  text = "function(x, y, z = 1, ..., w) {}",
+  text = "function(x, y, z = 1L, ..., w) {}",
   linters = function_argument_linter()
 )
 
 # okay
 lint(
-  text = "function(x, y = 1, z = 2) {}",
+  text = "function(x, y = 1L, z = 2L) {}",
   linters = function_argument_linter()
 )
 
 lint(
-  text = "function(x, y, w, z = 1, ...) {}",
+  text = "function(x, y, w, z = 1L, ...) {}",
   linters = function_argument_linter()
 )
 
 lint(
-  text = "function(y = 1, z = 2, x = NULL) {}",
+  text = "function(y = 1L, z = 2L, x = NULL) {}",
   linters = function_argument_linter()
 )
 
 lint(
-  text = "function(x, y, z = 1, ..., w = NULL) {}",
+  text = "function(x, y, z = 1L, ..., w = NULL) {}",
   linters = function_argument_linter()
 )
 

--- a/man/function_left_parentheses_linter.Rd
+++ b/man/function_left_parentheses_linter.Rd
@@ -38,7 +38,7 @@ lint(
 )
 
 lint(
-  text = "foo <- function(x) (x + 1)",
+  text = "foo <- function(x) (x + 1L)",
   linters = function_left_parentheses_linter()
 )
 

--- a/man/function_return_linter.Rd
+++ b/man/function_return_linter.Rd
@@ -14,30 +14,30 @@ by the dual-purpose expression).
 \examples{
 # will produce lints
 lint(
-  text = "foo <- function(x) return(y <- x + 1)",
+  text = "foo <- function(x) return(y <- x + 1L)",
   linters = function_return_linter()
 )
 
 lint(
-  text = "foo <- function(x) return(x <<- x + 1)",
+  text = "foo <- function(x) return(x <<- x + 1L)",
   linters = function_return_linter()
 )
 
-writeLines("e <- new.env() \nfoo <- function(x) return(e$val <- x + 1)")
+writeLines("e <- new.env() \nfoo <- function(x) return(e$val <- x + 1L)")
 lint(
-  text = "e <- new.env() \nfoo <- function(x) return(e$val <- x + 1)",
+  text = "e <- new.env() \nfoo <- function(x) return(e$val <- x + 1L)",
   linters = function_return_linter()
 )
 
 # okay
 lint(
-  text = "foo <- function(x) return(x + 1)",
+  text = "foo <- function(x) return(x + 1L)",
   linters = function_return_linter()
 )
 
 code_lines <- "
 foo <- function(x) {
-  x <<- x + 1
+  x <<- x + 1L
   return(x)
 }
 "
@@ -49,7 +49,7 @@ lint(
 code_lines <- "
 e <- new.env()
 foo <- function(x) {
-  e$val <- x + 1
+  e$val <- x + 1L
   return(e$val)
 }
 "

--- a/man/ifelse_censor_linter.Rd
+++ b/man/ifelse_censor_linter.Rd
@@ -24,7 +24,7 @@ lint(
 )
 
 lint(
-  text = "ifelse(x > 0, x, 0)",
+  text = "ifelse(x > 0L, x, 0L)",
   linters = ifelse_censor_linter()
 )
 
@@ -35,7 +35,7 @@ lint(
 )
 
 lint(
-  text = "pmax(x, 0)",
+  text = "pmax(x, 0L)",
   linters = ifelse_censor_linter()
 )
 

--- a/man/indentation_linter.Rd
+++ b/man/indentation_linter.Rd
@@ -27,26 +27,26 @@ first line of the function definition contains no arguments and the closing pare
 map(
   x,
   f,
-  additional_arg = 42
+  additional_arg = 42L
 )
 
 # complies to "tidy" and "never"
 map(x, f,
-  additional_arg = 42
+  additional_arg = 42L
 )
 
 # complies to "always"
 map(x, f,
-    additional_arg = 42
+    additional_arg = 42L
 )
 
 # complies to "tidy" and "always"
 map(x, f,
-    additional_arg = 42)
+    additional_arg = 42L)
 
 # complies to "never"
 map(x, f,
-  additional_arg = 42)
+  additional_arg = 42L)
 
 # complies to "tidy"
 function(
@@ -90,21 +90,21 @@ lint(
   linters = indentation_linter()
 )
 
-code_lines <- "if (TRUE) {\n    1 + 1\n}"
+code_lines <- "if (TRUE) {\n    1L + 1L\n}"
 writeLines(code_lines)
 lint(
   text = code_lines,
   linters = indentation_linter()
 )
 
-code_lines <- "map(x, f,\n  additional_arg = 42\n)"
+code_lines <- "map(x, f,\n  additional_arg = 42L\n)"
 writeLines(code_lines)
 lint(
   text = code_lines,
   linters = indentation_linter(hanging_indent_style = "always")
 )
 
-code_lines <- "map(x, f,\n    additional_arg = 42)"
+code_lines <- "map(x, f,\n    additional_arg = 42L)"
 writeLines(code_lines)
 lint(
   text = code_lines,
@@ -112,18 +112,18 @@ lint(
 )
 
 # okay
-code_lines <- "map(x, f,\n  additional_arg = 42\n)"
+code_lines <- "map(x, f,\n  additional_arg = 42L\n)"
 writeLines(code_lines)
 lint(
   text = code_lines,
   linters = indentation_linter()
 )
 
-code_lines <- "if (TRUE) {\n    1 + 1\n}"
+code_lines <- "if (TRUE) {\n    1L + 1L\n}"
 writeLines(code_lines)
 lint(
   text = code_lines,
-  linters = indentation_linter(indent = 4)
+  linters = indentation_linter(indent = 4L)
 )
 
 }

--- a/man/inner_combine_linter.Rd
+++ b/man/inner_combine_linter.Rd
@@ -27,7 +27,7 @@ lint(
 )
 
 lint(
-  text = "c(log(x, base = 10), log10(x, base = 2))",
+  text = "c(log(x, base = 10L), log10(x, base = 2L))",
   linters = inner_combine_linter()
 )
 

--- a/man/namespace_linter.Rd
+++ b/man/namespace_linter.Rd
@@ -19,28 +19,28 @@ potentially change the global state.
 \examples{
 # will produce lints
 lint(
-  text = "xyzxyz::sd(c(1, 2, 3))",
+  text = "xyzxyz::sd(c(1.1, 2.3, 3.4))",
   linters = namespace_linter()
 )
 
 lint(
-  text = "stats::ssd(c(1, 2, 3))",
+  text = "stats::ssd(c(1.1, 2.3, 3.4))",
   linters = namespace_linter()
 )
 
 # okay
 lint(
-  text = "stats::sd(c(1, 2, 3))",
+  text = "stats::sd(c(1.1, 2.3, 3.4))",
   linters = namespace_linter()
 )
 
 lint(
-  text = "stats::ssd(c(1, 2, 3))",
+  text = "stats::ssd(c(1.1, 2.3, 3.4))",
   linters = namespace_linter(check_exports = FALSE)
 )
 
 lint(
-  text = "stats:::ssd(c(1, 2, 3))",
+  text = "stats:::ssd(c(1.1, 2.3, 3.4))",
   linters = namespace_linter(check_nonexports = FALSE)
 )
 

--- a/man/object_name_linter.Rd
+++ b/man/object_name_linter.Rd
@@ -74,13 +74,17 @@ lint(
   linters = object_name_linter(styles = "lowercase")
 )
 
+code_lines <- "my.var <- 1L\nmyvar <- 2L"
+writeLines(code_lines)
 lint(
-  text = "my.var <- 1L; myvar <- 2L",
+  text = code_lines,
   linters = object_name_linter(styles = c("dotted.case", "lowercase"))
 )
 
+code_lines <- "asdf <- 1L\nasdF <- 1L"
+writeLines(code_lines)
 lint(
-  text = "asdf <- 1L; asdF <- 1L",
+  text = code_lines,
   linters = object_name_linter(regexes = c(my_style = "F$", "f$"))
 )
 

--- a/man/object_usage_linter.Rd
+++ b/man/object_usage_linter.Rd
@@ -21,18 +21,20 @@ Note that this runs \code{\link[base:eval]{base::eval()}} on the code, so \stron
 \examples{
 # will produce lints
 lint(
-  text = "foo <- function() { x <- 1 }",
+  text = "foo <- function() { x <- 1L }",
   linters = object_usage_linter()
 )
 
 # okay
 lint(
-  text = "foo <- function(x) { x <- 1 }",
+  text = "foo <- function(x) { x <- 1L }",
   linters = object_usage_linter()
 )
 
+code_lines <- "foo <- function() {\n  x <- 1L\n  return(x)\n}"
+writeLines(code_lines)
 lint(
-  text = "foo <- function() { x <- 1; return(x) }",
+  text = code_lines,
   linters = object_usage_linter()
 )
 }

--- a/man/paren_body_linter.Rd
+++ b/man/paren_body_linter.Rd
@@ -12,13 +12,13 @@ Check that there is a space between right parenthesis and a body expression.
 \examples{
 # will produce lints
 lint(
-  text = "function(x)x + 1",
+  text = "function(x)x + 1L",
   linters = paren_body_linter()
 )
 
 # okay
 lint(
-  text = "function(x) x + 1",
+  text = "function(x) x + 1L",
   linters = paren_body_linter()
 )
 

--- a/man/redundant_equals_linter.Rd
+++ b/man/redundant_equals_linter.Rd
@@ -17,23 +17,23 @@ nature, while \code{child}, \code{parent_supervision}, \code{watch_horror_movie}
 \examples{
 # will produce lints
 lint(
-  text = "if (any(x == TRUE)) 1",
+  text = "if (any(x == TRUE)) 1L",
   linters = redundant_equals_linter()
 )
 
 lint(
-  text = "if (any(x != FALSE)) 0",
+  text = "if (any(x != FALSE)) 0L",
   linters = redundant_equals_linter()
 )
 
 # okay
 lint(
-  text = "if (any(x)) 1",
+  text = "if (any(x)) 1L",
   linters = redundant_equals_linter()
 )
 
 lint(
-  text = "if (!all(x)) 0",
+  text = "if (!all(x)) 0L",
   linters = redundant_equals_linter()
 )
 

--- a/man/semicolon_linter.Rd
+++ b/man/semicolon_linter.Rd
@@ -19,32 +19,32 @@ Check that no semicolons terminate expressions.
 \examples{
 # will produce lints
 lint(
-  text = "a <- 1;",
+  text = "a <- 1L;",
   linters = semicolon_linter()
 )
 
 lint(
-  text = "a <- 1; b <- 1",
+  text = "a <- 1L; b <- 1L",
   linters = semicolon_linter()
 )
 
 lint(
-  text = "function() { a <- 1; b <- 1 }",
+  text = "function() { a <- 1L; b <- 1L }",
   linters = semicolon_linter()
 )
 
 # okay
 lint(
-  text = "a <- 1",
+  text = "a <- 1L",
   linters = semicolon_linter()
 )
 
 lint(
-  text = "a <- 1;",
+  text = "a <- 1L;",
   linters = semicolon_linter(allow_trailing = TRUE)
 )
 
-code_lines <- "a <- 1\nb <- 1"
+code_lines <- "a <- 1L\nb <- 1L"
 writeLines(code_lines)
 lint(
   text = code_lines,
@@ -52,11 +52,11 @@ lint(
 )
 
 lint(
-  text = "a <- 1; b <- 1",
+  text = "a <- 1L; b <- 1L",
   linters = semicolon_linter(allow_compound = TRUE)
 )
 
-code_lines <- "function() { \n  a <- 1\n  b <- 1\n}"
+code_lines <- "function() { \n  a <- 1L\n  b <- 1L\n}"
 writeLines(code_lines)
 lint(
   text = code_lines,

--- a/man/trailing_blank_lines_linter.Rd
+++ b/man/trailing_blank_lines_linter.Rd
@@ -12,7 +12,7 @@ Check that there are no trailing blank lines in source code.
 \examples{
 \dontshow{if (requireNamespace("withr", quietly = TRUE)) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
 # will produce lints
-f <- withr::local_tempfile(lines = "x <- 1\n")
+f <- withr::local_tempfile(lines = "x <- 1L\n")
 readLines(f)
 lint(
   filename = f,
@@ -20,7 +20,7 @@ lint(
 )
 
 # okay
-f <- withr::local_tempfile(lines = "x <- 1")
+f <- withr::local_tempfile(lines = "x <- 1L")
 readLines(f)
 lint(
   filename = f,

--- a/man/undesirable_function_linter.Rd
+++ b/man/undesirable_function_linter.Rd
@@ -55,7 +55,7 @@ lint(
 )
 
 lint(
-  text = "log(x, base = 10)",
+  text = "log(x, base = 10L)",
   linters = undesirable_function_linter(fun = c("log10" = "use log()"))
 )
 

--- a/man/undesirable_operator_linter.Rd
+++ b/man/undesirable_operator_linter.Rd
@@ -23,7 +23,7 @@ names(default_undesirable_operators)
 
 # will produce lints
 lint(
-  text = "a <<- log(10)",
+  text = "a <<- log(10.0)",
   linters = undesirable_operator_linter()
 )
 

--- a/man/unreachable_code_linter.Rd
+++ b/man/unreachable_code_linter.Rd
@@ -14,7 +14,7 @@ meant for posterity should be placed \emph{before} the final \code{return()}.
 }
 \examples{
 # will produce lints
-code_lines <- "f <- function() {\n  return(1 + 1)\n  2 + 2\n}"
+code_lines <- "f <- function() {\n  return(1L + 1L)\n  2L + 2L\n}"
 writeLines(code_lines)
 lint(
   text = code_lines,
@@ -22,7 +22,7 @@ lint(
 )
 
 # okay
-code_lines <- "f <- function() {\n  return(1 + 1)\n}"
+code_lines <- "f <- function() {\n  return(1L + 1L)\n}"
 writeLines(code_lines)
 lint(
   text = code_lines,

--- a/man/unused_import_linter.Rd
+++ b/man/unused_import_linter.Rd
@@ -23,14 +23,14 @@ Check that imported packages are actually used
 }
 \examples{
 # will produce lints
-code_lines <- "library(dplyr)\n1 + 1"
+code_lines <- "library(dplyr)\n1L + 1L"
 writeLines(code_lines)
 lint(
   text = code_lines,
   linters = unused_import_linter()
 )
 
-code_lines <- "library(dplyr)\ndplyr::tibble(a = 1)"
+code_lines <- "library(dplyr)\ndplyr::tibble(a = 1L)"
 writeLines(code_lines)
 lint(
   text = code_lines,
@@ -38,14 +38,14 @@ lint(
 )
 
 # okay
-code_lines <- "library(dplyr)\ntibble(a = 1)"
+code_lines <- "library(dplyr)\ntibble(a = 1L)"
 writeLines(code_lines)
 lint(
   text = code_lines,
   linters = unused_import_linter()
 )
 
-code_lines <- "library(dplyr)\ndplyr::tibble(a = 1)"
+code_lines <- "library(dplyr)\ndplyr::tibble(a = 1L)"
 writeLines(code_lines)
 lint(
   text = code_lines,

--- a/man/vector_logic_linter.Rd
+++ b/man/vector_logic_linter.Rd
@@ -30,23 +30,23 @@ assignment outside the condition, so using \code{||} is still preferable.
 \examples{
 # will produce lints
 lint(
-  text = "if (TRUE & FALSE) 1",
+  text = "if (TRUE & FALSE) 1.0",
   linters = vector_logic_linter()
 )
 
 lint(
-  text = "if (TRUE && (TRUE | FALSE)) 4",
+  text = "if (TRUE && (TRUE | FALSE)) 4.2",
   linters = vector_logic_linter()
 )
 
 # okay
 lint(
-  text = "if (TRUE && FALSE) 1",
+  text = "if (TRUE && FALSE) 1.0",
   linters = vector_logic_linter()
 )
 
 lint(
-  text = "if (TRUE && (TRUE || FALSE)) 4",
+  text = "if (TRUE && (TRUE || FALSE)) 4.2",
   linters = vector_logic_linter()
 )
 

--- a/man/yoda_test_linter.Rd
+++ b/man/yoda_test_linter.Rd
@@ -15,7 +15,7 @@ the simple case of testing an expression against a literal value, e.g.
 \examples{
 # will produce lints
 lint(
-  text = "expect_equal(2, x)",
+  text = "expect_equal(2L, x)",
   linters = yoda_test_linter()
 )
 
@@ -26,7 +26,7 @@ lint(
 
 # okay
 lint(
-  text = "expect_equal(x, 2)",
+  text = "expect_equal(x, 2L)",
   linters = yoda_test_linter()
 )
 


### PR DESCRIPTION
Make sure that examples produce only the lint they are designed to showcase, and no other lints.

Follow-up on https://github.com/r-lib/lintr/issues/1492

## Progress tracker

 - [x] absolute_path_linter
 - [x] any_duplicated_linter
 - [x] any_is_na_linter
 - [x] assignment_linter
 - [x] backport_linter
 - [x] boolean_arithmetic_linter
 - [x] brace_linter
 - [x] class_equals_linter
 - [x] commas_linter
 - [x] commented_code_linter
 - [x] condition_message_linter
 - [x] conjunct_test_linter
 - [x] consecutive_stopifnot_linter
 - [x] cyclocomp_linter
 - [x] duplicate_argument_linter
 - [x] equals_na_linter
 - [x] expect_comparison_linter
 - [x] expect_identical_linter
 - [x] expect_length_linter
 - [x] expect_named_linter
 - [x] expect_not_linter
 - [x] expect_null_linter
 - [x] expect_s3_class_linter
 - [x] expect_s4_class_linter
 - [x] expect_true_false_linter
 - [x] expect_type_linter
 - [x] extraction_operator_linter
 - [x] fixed_regex_linter
 - [x] function_argument_linter
 - [x] function_left_parentheses_linter
 - [x] function_return_linter
 - [x] ifelse_censor_linter
 - [x] implicit_integer_linter
 - [x] infix_spaces_linter
 - [x] inner_combine_linter
 - [x] lengths_linter
 - [x] line_length_linter
 - [x] literal_coercion_linter
 - [x] missing_argument_linter
 - [x] missing_package_linter
 - [x] namespace_linter
 - [x] nested_ifelse_linter
 - [x] no_tab_linter
 - ~~[ ] nonportable_path_linter~~
 - [x] numeric_leading_zero_linter
 - [x] object_length_linter
- [x] object_name_linter
- [x] object_usage_linter
- [x] outer_negation_linter
- [x] package_hooks_linter
- [x] paren_body_linter
- [x] paste_linter
- [x] pipe_call_linter
- [x] pipe_continuation_linter
- [x] redundant_equals_linter
- [x] redundant_ifelse_linter
- [x] regex_subset_linter
- [x] semicolon_linter
- [x] seq_linter
- [x] single_quotes_linter
- [x] spaces_inside_linter
- [x] spaces_left_parentheses_linter
- [x] sprintf_linter
- [x] string_boundary_linter
- [x] strings_as_factors_linter
- [x] system_file_linter
- [x] T_and_F_symbol_linter
- [x] todo_comment_linter
- [x] trailing_blank_lines_linter
- [x] trailing_whitespace_linter
- [x] undesirable_function_linter
- [x] undesirable_operator_linter
- [x] unnecessary_lambda_linter
- [x] unneeded_concatenation_linter
- [x] unreachable_code_linter
- [x] unused_import_linter
- [x] vector_logic_linter
- [x] yoda_test_linter