### PR TITLE
Add examples for `unnecessary_lambda_linter()`

### DIFF
--- a/R/unnecessary_lambda_linter.R
+++ b/R/unnecessary_lambda_linter.R
@@ -7,7 +7,7 @@
 #' @examples
 #' # will produce lints
 #' lint(
-#'   text = "lapply(list(1:3, 2:4), function(xi) { sum(xi) })",
+#'   text = "lapply(list(1:3, 2:4), function(xi) sum(xi))",
 #'   linters = unnecessary_lambda_linter()
 #' )
 #'

--- a/R/unnecessary_lambda_linter.R
+++ b/R/unnecessary_lambda_linter.R
@@ -17,6 +17,16 @@
 #'   linters = unnecessary_lambda_linter()
 #' )
 #'
+#' lint(
+#'   text = 'lapply(x, function(xi) grep("ptn", xi))',
+#'   linters = unnecessary_lambda_linter()
+#' )
+#'
+#' lint(
+#'   text = "lapply(x, function(xi) data.frame(col = xi))",
+#'   linters = unnecessary_lambda_linter()
+#' )
+#'
 #' @evalRd rd_tags("unnecessary_lambda_linter")
 #' @seealso [linters] for a complete list of linters available in lintr.
 #' @export

--- a/R/unnecessary_lambda_linter.R
+++ b/R/unnecessary_lambda_linter.R
@@ -4,6 +4,19 @@
 #'   e.g. `lapply(DF, sum)` is the same as `lapply(DF, function(x) sum(x))` and
 #'   the former is more readable.
 #'
+#' @examples
+#' # will produce lints
+#' lint(
+#'   text = "lapply(list(1:3, 2:4), function(xi) { sum(xi) })",
+#'   linters = unnecessary_lambda_linter()
+#' )
+#'
+#' # okay
+#' lint(
+#'   text = "lapply(list(1:3, 2:4), sum)",
+#'   linters = unnecessary_lambda_linter()
+#' )
+#'
 #' @evalRd rd_tags("unnecessary_lambda_linter")
 #' @seealso [linters] for a complete list of linters available in lintr.
 #' @export

--- a/man/unnecessary_lambda_linter.Rd
+++ b/man/unnecessary_lambda_linter.Rd
@@ -14,7 +14,7 @@ the former is more readable.
 \examples{
 # will produce lints
 lint(
-  text = "lapply(list(1:3, 2:4), function(xi) { sum(xi) })",
+  text = "lapply(list(1:3, 2:4), function(xi) sum(xi))",
   linters = unnecessary_lambda_linter()
 )
 

--- a/man/unnecessary_lambda_linter.Rd
+++ b/man/unnecessary_lambda_linter.Rd
@@ -24,6 +24,16 @@ lint(
   linters = unnecessary_lambda_linter()
 )
 
+lint(
+  text = 'lapply(x, function(xi) grep("ptn", xi))',
+  linters = unnecessary_lambda_linter()
+)
+
+lint(
+  text = "lapply(x, function(xi) data.frame(col = xi))",
+  linters = unnecessary_lambda_linter()
+)
+
 }
 \seealso{
 \link{linters} for a complete list of linters available in lintr.

--- a/man/unnecessary_lambda_linter.Rd
+++ b/man/unnecessary_lambda_linter.Rd
@@ -11,6 +11,20 @@ Using an anonymous function in, e.g., \code{\link[=lapply]{lapply()}} is not alw
 e.g. \code{lapply(DF, sum)} is the same as \code{lapply(DF, function(x) sum(x))} and
 the former is more readable.
 }
+\examples{
+# will produce lints
+lint(
+  text = "lapply(list(1:3, 2:4), function(xi) { sum(xi) })",
+  linters = unnecessary_lambda_linter()
+)
+
+# okay
+lint(
+  text = "lapply(list(1:3, 2:4), sum)",
+  linters = unnecessary_lambda_linter()
+)
+
+}
 \seealso{
 \link{linters} for a complete list of linters available in lintr.
 }

--- a/tests/testthat/test-unnecessary_lambda_linter.R
+++ b/tests/testthat/test-unnecessary_lambda_linter.R
@@ -64,36 +64,38 @@ test_that("unnecessary_lambda_linter doesn't apply to keyword args", {
 })
 
 test_that("purrr-style anonymous functions are also caught", {
+  linter <- unnecessary_lambda_linter()
+
   # TODO(michaelchirico): this is just purrr::flatten(x). We should write another
   #   linter to encourage that usage.
-  expect_lint("purrr::map(x, ~.x)", NULL, unnecessary_lambda_linter())
-  expect_lint("purrr::map_df(x, ~lm(y, .x))", NULL, unnecessary_lambda_linter())
-  expect_lint("map_dbl(x, ~foo(bar = .x))", NULL, unnecessary_lambda_linter())
+  expect_lint("purrr::map(x, ~.x)", NULL, linter)
+  expect_lint("purrr::map_df(x, ~lm(y, .x))", NULL, linter)
+  expect_lint("map_dbl(x, ~foo(bar = .x))", NULL, linter)
 
   expect_lint(
     "purrr::map(x, ~foo(.x))",
     rex::rex("Pass foo directly as a symbol to map()"),
-    unnecessary_lambda_linter()
+    linter
   )
   expect_lint(
     "purrr::map_int(x, ~foo(.x, y))",
     rex::rex("Pass foo directly as a symbol to map_int()"),
-    unnecessary_lambda_linter()
+    linter
   )
   expect_lint(
     "purrr::map_vec(x, ~foo(.x, y))",
     rex::rex("Pass foo directly as a symbol to map_vec()"),
-    unnecessary_lambda_linter()
+    linter
   )
 })
 
 test_that("cases with braces are caught", {
   linter <- unnecessary_lambda_linter()
-  print_msg <- rex::rex("Pass print directly as a symbol to lapply()")
+  lint_msg <- rex::rex("Pass print directly as a symbol to lapply()")
 
   expect_lint(
     "lapply(x, function(xi) { print(xi) })",
-    print_msg,
+    lint_msg,
     linter
   )
 
@@ -103,7 +105,7 @@ test_that("cases with braces are caught", {
         print(xi)
       })
     "),
-    print_msg,
+    lint_msg,
     linter
   )
 


### PR DESCRIPTION
Haven't added examples for `map` family on account of #1871. 