### PR TITLE
`missing_argument_linter()` allows missing arguments in `quote()` calls

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -96,6 +96,8 @@
 
 * `all_linters()` function provides an easy way to access all available linters (#1843, @IndrajeetPatil)
 
+* `missing_argument_linter()` allows missing arguments in `quote()` calls (#1889, @IndrajeetPatil). 
+
 ### New linters
 
 * `unnecessary_lambda_linter()`: detect unnecessary lambdas (anonymous functions), e.g.

--- a/R/missing_argument_linter.R
+++ b/R/missing_argument_linter.R
@@ -31,7 +31,7 @@
 #' @evalRd rd_tags("missing_argument_linter")
 #' @seealso [linters] for a complete list of linters available in lintr.
 #' @export
-missing_argument_linter <- function(except = c("switch", "alist"), allow_trailing = FALSE) {
+missing_argument_linter <- function(except = c("alist", "quote", "switch"), allow_trailing = FALSE) {
   conds <- c(
     "self::OP-COMMA[preceding-sibling::*[not(self::COMMENT)][1][self::OP-LEFT-PAREN or self::OP-COMMA]]",
     "self::EQ_SUB[following-sibling::*[not(self::COMMENT)][1][self::OP-RIGHT-PAREN or self::OP-COMMA]]"

--- a/man/missing_argument_linter.Rd
+++ b/man/missing_argument_linter.Rd
@@ -4,7 +4,10 @@
 \alias{missing_argument_linter}
 \title{Missing argument linter}
 \usage{
-missing_argument_linter(except = c("switch", "alist"), allow_trailing = FALSE)
+missing_argument_linter(
+  except = c("alist", "quote", "switch"),
+  allow_trailing = FALSE
+)
 }
 \arguments{
 \item{except}{a character vector of function names as exceptions.}

--- a/tests/testthat/test-missing_argument_linter.R
+++ b/tests/testthat/test-missing_argument_linter.R
@@ -8,6 +8,7 @@ test_that("missing_argument_linter skips allowed usages", {
   expect_lint("array[, , 1]", NULL, linter)
   expect_lint("switch(a =, b =, c = 1, 0)", NULL, linter)
   expect_lint("alist(a =, b =, c = 1, 0)", NULL, linter)
+  expect_lint("pairlist(path = quote(expr = ))", NULL, linter) #1889
 
   expect_lint("test(a =, b =, c = 1, 0)", NULL, missing_argument_linter("test"))
 })


### PR DESCRIPTION
Closes #1889