### PR TITLE
remove mentions of lintr-bot

### DIFF
--- a/vignettes/continuous-integration.Rmd
+++ b/vignettes/continuous-integration.Rmd
@@ -67,8 +67,7 @@ after_success:
 ```
 
 Live example of a package using this setup:
-[`hibpwned`](https://github.com/jumpingrivers/HIBPwned/blob/master/.travis.yml),
-[lintr-bot commenting on a PR](https://github.com/jumpingrivers/HIBPwned/pull/30).
+[`hibpwned`](https://github.com/jumpingrivers/HIBPwned/blob/master/.travis.yml).
 
 ## For projects
 

--- a/vignettes/continuous-integration.Rmd
+++ b/vignettes/continuous-integration.Rmd
@@ -59,12 +59,7 @@ r_github_packages:
   - r-lib/lintr
 ```
 
-We recommend running `lintr::lint_package()` as an [after_success step in your build process](#non-failing-lints)]
-
-If lints are found in the commit or pull request they will be printed on Travis-CI.
-The environment variable `LINTR_ERROR_ON_LINT` mentioned for GitHub actions also works with Travis CI builds.
-
-##### Non-failing Lints {#non-failing-lints}
+We recommend running `lintr::lint_package()` as an after_success step in your build process:
 
 ``` yaml
 after_success:
@@ -72,8 +67,8 @@ after_success:
   - Rscript -e 'lintr::lint_package()'
 ```
 
-Live example of a package using this setup:
-[`hibpwned`](https://github.com/jumpingrivers/HIBPwned/blob/master/.travis.yml).
+If lints are found in the commit or pull request they will be printed on Travis-CI.
+The environment variable `LINTR_ERROR_ON_LINT` mentioned for GitHub actions also works with Travis CI builds.
 
 ## For projects
 

--- a/vignettes/continuous-integration.Rmd
+++ b/vignettes/continuous-integration.Rmd
@@ -33,11 +33,17 @@ usethis::use_github_action("lint")
 This will create a workflow file called `lint.yaml` and place it in the correct location, namely in the `.github/workflows` directory of your repository.
 This file configures all the steps required to run `lintr::lint_package()` on your package.
 
+Alternatively you can use the eponymous [`lint-changed-files.yaml`](https://github.com/r-lib/actions/blob/v2-branch/examples/lint-changed-files.yaml) to only lint any changed files:
+
+```r
+usethis::use_github_action("lint-changed-files")
+```
+
 Comments to the commit or pull request will be printed as
 [annotations](https://docs.github.com/en/free-pro-team@latest/github/collaborating-with-issues-and-pull-requests/about-status-checks#types-of-status-checks-on-github)
 along side the status check on GitHub.
 If you want the builds to produce an error instead of just a warning, you can set the environment variable `LINTR_ERROR_ON_LINT=true`.
-This is set by default in [r-lib/actions](https://github.com/r-lib/actions/)'s `lint.yaml`.
+This is set by default for both [r-lib/actions](https://github.com/r-lib/actions/)'s `lint.yaml` and `lint-changed-files.yaml`. 
 Note that this will kill the R process in case of a lint.
 
 If your project is in a subdirectory and you would like to use GitHub Actions annotations, you can set

--- a/vignettes/continuous-integration.Rmd
+++ b/vignettes/continuous-integration.Rmd
@@ -33,11 +33,11 @@ usethis::use_github_action("lint")
 This will create a workflow file called `lint.yaml` and place it in the correct location, namely in the `.github/workflows` directory of your repository.
 This file configures all the steps required to run `lintr::lint_package()` on your package.
 
-[lintr-bot](https://github.com/lintr-bot) will then add comments to the commit or pull request with the lints found and they will also be printed as
+Comments to the commit or pull request will be printed as
 [annotations](https://docs.github.com/en/free-pro-team@latest/github/collaborating-with-issues-and-pull-requests/about-status-checks#types-of-status-checks-on-github)
 along side the status check on GitHub.
-If you want to disable the commenting you can set the environment variable `LINTR_COMMENT_BOT=false`.
-Additionally, if you want the builds to produce an error instead of just a warning, you can set the environment variable `LINTR_ERROR_ON_LINT=true`.
+If you want the builds to produce an error instead of just a warning, you can set the environment variable `LINTR_ERROR_ON_LINT=true`.
+This is set by default in [r-lib/actions](https://github.com/r-lib/actions/)'s `lint.yaml`.
 Note that this will kill the R process in case of a lint.
 
 If your project is in a subdirectory and you would like to use GitHub Actions annotations, you can set
@@ -55,9 +55,8 @@ r_github_packages:
 
 We recommend running `lintr::lint_package()` as an [after_success step in your build process](#non-failing-lints)]
 
-Just like with GitHub Actions, [lintr-bot](https://github.com/lintr-bot) will then add comments to the commit or pull request with the lints found and
-they will also be printed on Travis-CI.
-The environment variables `LINTR_COMMENT_BOT` and `LINTR_ERROR_ON_LINT` mentioned for GitHub actions also work with Travis CI builds.
+If lints are found in the commit or pull request they will be printed on Travis-CI.
+The environment variable `LINTR_ERROR_ON_LINT` mentioned for GitHub actions also works with Travis CI builds.
 
 ##### Non-failing Lints {#non-failing-lints}
 
@@ -73,7 +72,7 @@ Live example of a package using this setup:
 
 ## For projects
 
-You are not limited you using `lintr` for packages -- you can use it in combination with continuous integration for any other project.
+You are not limited to using `lintr` for packages -- you can use it in combination with continuous integration for any other project.
 
 ### GitHub Actions
 


### PR DESCRIPTION
I gather from #1558 that lintr-bot is retired, so its mentions should be removed.

Re the Travis section in the vignette. {[HIBPwnd](https://github.com/jumpingrivers/HIBPwned/)} has been archived, so that is not a good example anymore. Do you have another one? Or should we just remove the whole Travis section since it is probably not used much anymore anyway?