### PR TITLE
ignore symbols in formula when pinpointing undefined variable lints

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -26,6 +26,8 @@
 
 * `object_name_linter()` allows all S3 group Generics (see `?base::groupGeneric`) and S3 generics defined in a different file in the same package (#1808, #1841, @AshesITR)
 
+* `object_usage_linter()` improves identification of the exact source of a lint for undefined variables in expresssions with formulas (#1914, @MichaelChirico).
+
 ## Changes to defaults
 
 * Set the default for the `except` argument in `duplicate_argument_linter()` to `c("mutate", "transmute")`.

--- a/R/object_usage_linter.R
+++ b/R/object_usage_linter.R
@@ -101,7 +101,7 @@ object_usage_linter <- function(interpret_glue = TRUE, skip_with = TRUE) {
         fun_assignment,
         "
         descendant::SYMBOL[not(ancestor::expr[OP-TILDE])]
-        | descendant::SYMBOL_FUNCTION_CALL
+        | descendant::SYMBOL_FUNCTION_CALL[not(ancestor::expr[OP-TILDE])]
         | descendant::SPECIAL
         | descendant::LEFT_ASSIGN[text() = ':=']
         "

--- a/R/object_usage_linter.R
+++ b/R/object_usage_linter.R
@@ -100,7 +100,7 @@ object_usage_linter <- function(interpret_glue = TRUE, skip_with = TRUE) {
       lintable_symbols <- xml2::xml_find_all(
         fun_assignment,
         "
-        descendant::SYMBOL
+        descendant::SYMBOL[not(ancestor::expr[OP-TILDE])]
         | descendant::SYMBOL_FUNCTION_CALL
         | descendant::SPECIAL
         | descendant::LEFT_ASSIGN[text() = ':=']

--- a/tests/testthat/test-object_usage_linter.R
+++ b/tests/testthat/test-object_usage_linter.R
@@ -626,12 +626,48 @@ test_that("messages without a quoted name are caught", {
 })
 
 # See #1914
-test_that("symbol on LHS of formula isn't treated as 'undefined global'", {
+test_that("symbols in formulas aren't treated as 'undefined global'", {
   expect_lint(
     trim_some("
       foo <- function(x) {
         lm(
           y ~ z,
+          data = x[!is.na(y)]
+        )
+      }
+    "),
+    list(
+      message = "no visible binding for global variable 'y'",
+      line_number = 4L,
+      column_number = 21L
+    ),
+    object_usage_linter()
+  )
+
+  # neither on the RHS
+  expect_lint(
+    trim_some("
+      foo <- function(x) {
+        lm(
+          z ~ y,
+          data = x[!is.na(y)]
+        )
+      }
+    "),
+    list(
+      message = "no visible binding for global variable 'y'",
+      line_number = 4L,
+      column_number = 21L
+    ),
+    object_usage_linter()
+  )
+
+  # nor in nested expressions
+  expect_lint(
+    trim_some("
+      foo <- function(x) {
+        lm(
+          log(log(y)) ~ z,
           data = x[!is.na(y)]
         )
       }

--- a/tests/testthat/test-object_usage_linter.R
+++ b/tests/testthat/test-object_usage_linter.R
@@ -679,4 +679,25 @@ test_that("symbols in formulas aren't treated as 'undefined global'", {
     ),
     object_usage_linter()
   )
+
+  # nor as a call
+  # NB: I wanted this to be s(), as in mgcv::s(), but that
+  #   doesn't work in this test suite because it resolves to
+  #   rex::s() since we attach that in testthat.R
+  expect_lint(
+    trim_some("
+      foo <- function(x) {
+        lm(
+          y(w) ~ z,
+          data = x[!is.na(y)]
+        )
+      }
+    "),
+    list(
+      message = "no visible binding for global variable 'y'",
+      line_number = 4L,
+      column_number = 21L
+    ),
+    object_usage_linter()
+  )
 })

--- a/tests/testthat/test-object_usage_linter.R
+++ b/tests/testthat/test-object_usage_linter.R
@@ -624,3 +624,23 @@ test_that("messages without a quoted name are caught", {
     object_usage_linter()
   )
 })
+
+# See #1914
+test_that("symbol on LHS of formula isn't treated as 'undefined global'", {
+  expect_lint(
+    trim_some("
+      foo <- function(x) {
+        lm(
+          y ~ z,
+          data = x[!is.na(y)]
+        )
+      }
+    "),
+    list(
+      message = "no visible binding for global variable 'y'",
+      line_number = 4L,
+      column_number = 21L
+    ),
+    object_usage_linter()
+  )
+})


### PR DESCRIPTION
Closes #1914 

I'm not a fan of the `descendant::*[ancestor::*]` XPath, but I'm not sure it can be avoided.