### PR TITLE
fail gracefully when missing Suggests in tests

### DIFF
--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -1,10 +1,10 @@
 library(testthat)
 library(lintr)
 
-# suppress printing environment name (noisy)
-invisible({
-  loadNamespace("patrick")
-  loadNamespace("withr")
-})
-
-test_check("lintr")
+# These packages are used heavily in the suite and are thus required
+if (
+  requireNamespace("patrick", quietly = TRUE) &&
+    requireNamespace("withr", quietly = TRUE)
+) {
+  test_check("lintr")
+}


### PR DESCRIPTION
Instigated by failures on R 3.4 (https://github.com/r-lib/lintr/pull/1873), but actually this is a better implementation of the rules around Suggests packages anyway which tell us to fail with more aplomb when Suggests are missing.