### PR TITLE
Bump R dependency to R3.5

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -39,7 +39,7 @@ jobs:
           - {os: ubuntu-latest,  r: 'oldrel-2'}
           - {os: ubuntu-latest,  r: 'oldrel-3'}
           - {os: ubuntu-latest,  r: 'oldrel-4'}
-          - {os: ubuntu-latest,  r: '3.4'}
+          - {os: ubuntu-latest,  r: '3.5'}
 
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
@@ -73,9 +73,6 @@ jobs:
         with:
           extra-packages: |
             any::rcmdcheck
-            bookdown=?ignore-before-r=3.5.0
-            patrick=?ignore-before-r=3.5.0
-            purrr=?ignore-before-r=3.5.0
           needs: check
 
       - uses: r-lib/actions/check-r-package@v2

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -21,7 +21,7 @@ License: MIT + file LICENSE
 URL: https://github.com/r-lib/lintr, https://lintr.r-lib.org
 BugReports: https://github.com/r-lib/lintr/issues
 Depends:
-    R (>= 3.2)
+    R (>= 3.5)
 Imports:
     backports,
     codetools,

--- a/NEWS.md
+++ b/NEWS.md
@@ -133,6 +133,8 @@
 
 ## Notes
 
+* {lintr} now depends on R version 3.5.0, in line with the tidyverse policy for R version compatibility.
+
 * `lint()` continues to support Rmarkdown documents. For users of custom .Rmd engines, e.g.
   `marginformat` from {tufte} or `theorem` from {bookdown}, note that those engines must be registered
   in {knitr} prior to running `lint()` in order for {lintr} to behave as expected, i.e., they should be


### PR DESCRIPTION
Supersedes https://github.com/r-lib/lintr/pull/1921.

The version bump is bigger than I thought, but we've only been testing on R3.4, so that feels to me like our implicit dependency is really R3.4 -- we don't know for sure that the package works on R3.2/R3.3 right? Which makes this a more gradual bump R3.4->R3.5.