### PR TITLE
Quit in-progress CI runs on new commit

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -12,6 +12,10 @@ on:
 
 name: R-CMD-check
 
+concurrency:
+  group: ${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   R-CMD-check:
     runs-on: ${{ matrix.config.os }}


### PR DESCRIPTION
We have a lot of .yml files where we could use this, I applied it to this one first since it's the costliest.

Is there an easy way to have a common config like this re-used across all of our jobs?