### PR TITLE
Add missing spaces around "and" in glue_collapse()

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -8,7 +8,7 @@
 ## Bug fixes
 
 * `linters_with_tags()` now includes the previously missing spaces around "and" when listing missing linters advertised by `available_linters()`. 
-  This error message typically appears when you update lintr to a version with new linters but don't restart your R session (#1946, @Bisaloo)
+  This error message may appear e.g. when you update lintr to a version with new linters but don't restart your R session (#1946, @Bisaloo)
 
 * `fixed_regex_linter()` is more robust to errors stemming from unrecognized escapes (#1545, #1845, @IndrajeetPatil).
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -7,6 +7,9 @@
 
 ## Bug fixes
 
+* `linters_with_tags()` now includes the previously missing spaces around "and" when listing missing linters advertised by `available_linters()`. 
+  This error message typically appears when you update lintr to a version with new linters but don't restart your R session (#1946, @Bisaloo)
+
 * `fixed_regex_linter()` is more robust to errors stemming from unrecognized escapes (#1545, #1845, @IndrajeetPatil).
 
 * `get_source_expressions()` can handle Sweave/Rmarkdown documents with reference chunks like `<<ref_file>>` (#779, @MichaelChirico).

--- a/R/with.R
+++ b/R/with.R
@@ -104,7 +104,7 @@ linters_with_tags <- function(tags, ..., packages = "lintr", exclude_tags = "dep
       if (!all(available$linter %in% ns_exports)) {
         missing_linters <- setdiff(available$linter, ns_exports)
         stop(
-          "Linters ", glue::glue_collapse(sQuote(missing_linters), sep = ", ", last = "and"),
+          "Linters ", glue::glue_collapse(sQuote(missing_linters), sep = ", ", last = " and "),
           " advertised by `available_linters()` but not exported by package ", package, "."
         )
       }

--- a/tests/testthat/test-with.R
+++ b/tests/testthat/test-with.R
@@ -21,6 +21,19 @@ test_that("linters_with_defaults warns on unused NULLs", {
   )
 })
 
+test_that("linters_with_tags() verifies the output of available_linters()", {
+  skip_if_not_installed("mockery")
+  mockery::stub(
+    linters_with_tags,
+    "available_linters",
+    data.frame(linter = c("fake_linter", "super_fake_linter"), package = "lintr", tags = "test")
+  )
+  expect_error(
+    linters_with_tags(NULL),
+    "'fake_linter' and 'super_fake_linter'"
+  )
+})
+
 test_that("all default linters are tagged default", {
   expect_named(linters_with_defaults(), available_linters(tags = "default")$linter)
 

--- a/tests/testthat/test-with.R
+++ b/tests/testthat/test-with.R
@@ -26,11 +26,11 @@ test_that("linters_with_tags() verifies the output of available_linters()", {
   mockery::stub(
     linters_with_tags,
     "available_linters",
-    data.frame(linter = c("fake_linter", "super_fake_linter"), package = "lintr", tags = "test", stringsAsFactors = FALSE)
+    data.frame(linter = c("fake_linter", "very_fake_linter"), package = "lintr", tags = "", stringsAsFactors = FALSE)
   )
   expect_error(
     linters_with_tags(NULL),
-    "'fake_linter' and 'super_fake_linter'"
+    "'fake_linter' and 'very_fake_linter'"
   )
 })
 

--- a/tests/testthat/test-with.R
+++ b/tests/testthat/test-with.R
@@ -26,7 +26,7 @@ test_that("linters_with_tags() verifies the output of available_linters()", {
   mockery::stub(
     linters_with_tags,
     "available_linters",
-    data.frame(linter = c("fake_linter", "super_fake_linter"), package = "lintr", tags = "test")
+    data.frame(linter = c("fake_linter", "super_fake_linter"), package = "lintr", tags = "test", stringsAsFactors = FALSE)
   )
   expect_error(
     linters_with_tags(NULL),


### PR DESCRIPTION
Example error message at the moment:

> Error in linters_with_tags(tags = NULL) :
Linters ‘implicit_assignment_linter’, ‘matrix_apply_linter’, ‘quotes_linter’and‘unnecessary_concatenation_linter’ advertised by `available_linters()` but not exported by package lintr.