### PR TITLE
Lint files in `exec` folder on lint_package

### DIFF
--- a/R/lint.R
+++ b/R/lint.R
@@ -3,7 +3,7 @@
 #' * `lint()` lints a single file.
 #' * `lint_dir()` lints all files in a directory.
 #' * `lint_package()` lints all likely locations for R files in a package, i.e.
-#'   `R/`, `tests/`, `inst/`, `vignettes/`, `data-raw/`, and `demo/`.
+#'   `R/`, `tests/`, `inst/`, `vignettes/`, `data-raw/`, `demo/` and `exec/`.
 #'
 #' Read `vignette("lintr")` to learn how to configure which linters are run
 #' by default.
@@ -262,7 +262,7 @@ lint_package <- function(path = ".", ...,
     root = pkg_path
   )
 
-  r_directories <- file.path(pkg_path, c("R", "tests", "inst", "vignettes", "data-raw", "demo"))
+  r_directories <- file.path(pkg_path, c("R", "tests", "inst", "vignettes", "data-raw", "demo", "exec"))
   # TODO: once relative_path= is fully deprecated as 2nd positional argument (see top of body), restore the cleaner:
   # > lints <- lint_dir(r_directories, relative_path = FALSE, exclusions = exclusions, parse_settings = FALSE, ...)
   lints <- do.call(

--- a/man/lint.Rd
+++ b/man/lint.Rd
@@ -74,7 +74,7 @@ An object of class \code{c("lints", "list")}, each element of which is a \code{"
 \item \code{lint()} lints a single file.
 \item \code{lint_dir()} lints all files in a directory.
 \item \code{lint_package()} lints all likely locations for R files in a package, i.e.
-\verb{R/}, \verb{tests/}, \verb{inst/}, \verb{vignettes/}, \verb{data-raw/}, and \verb{demo/}.
+\verb{R/}, \verb{tests/}, \verb{inst/}, \verb{vignettes/}, \verb{data-raw/}, \verb{demo/} and \verb{exec/}.
 }
 }
 \details{


### PR DESCRIPTION
FIX #1947

As per https://cran.r-project.org/doc/manuals/R-exts.html#Package-subdirectories:

Subdirectory exec could contain additional executable scripts the package needs, typically scripts for interpreters such as the shell, Perl, or Tcl.