### PR TITLE
also a method for as.data.table.lints

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -48,6 +48,8 @@ Suggests:
     tibble,
     tufte,
     withr (>= 2.5.0)
+Enhances:
+    data.table
 VignetteBuilder: 
     knitr
 Config/Needs/website: tidyverse/tidytemplate

--- a/R/methods.R
+++ b/R/methods.R
@@ -181,6 +181,11 @@ as_tibble.lints <- function(x, ..., # nolint: object_name_linter.
   tibble::as_tibble(as.data.frame(x), ..., .rows = .rows, .name_repair = .name_repair, rownames = rownames)
 }
 
+as.data.table.lints <- function(x, keep.rownames = FALSE, ...) { # nolint: object_name_linter.
+  stopifnot(requireNamespace("data.table", quietly = TRUE))
+  data.table::setDT(as.data.frame(x), keep.rownames = keep.rownames, ...)
+}
+
 #' @export
 `[.lints` <- function(x, ...) {
   attrs <- attributes(x)

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -330,5 +330,8 @@ settings <- NULL
   if (requireNamespace("tibble", quietly = TRUE)) {
     registerS3method("as_tibble", "lints", as_tibble.lints, asNamespace("tibble"))
   }
+  if (requireNamespace("data.table", quietly = TRUE)) {
+    registerS3method("as.data.table", "lints", as.data.table.lints, asNamespace("data.table"))
+  }
 }
 # nocov end

--- a/tests/testthat/test-methods.R
+++ b/tests/testthat/test-methods.R
@@ -156,3 +156,11 @@ test_that("as_tibble.list is _not_ dispatched directly", {
     1L
   )
 })
+
+test_that("as.data.table.list is _not_ dispatched directly", {
+  skip_if_not_installed("data.table")
+  expect_identical(
+    nrow(data.table::as.data.table(lint(text = "a = 1", linters = assignment_linter()))),
+    1L
+  )
+})


### PR DESCRIPTION
Follow-up to #1998 -- actually `as.data.table()` experiences a similar regression from v3.0.2 to HEAD, just that it's not breaking any tested downstreams. I have relied on this behavior in interactive cases, though.

I _think_ the enigmatic `Enhances` is the proper place for the new dependency, [per WRE](https://cran.r-project.org/doc/manuals/R-exts.html#Package-Dependencies):

> ‘Enhances’... lists packages “enhanced” by the package at hand, e.g., by providing methods for classes from these packages...

OTOH we might just "keep it simple" and put data.table in `Suggests`.

---

Currently `as.data.table()` works very poorly b/c of dispatch:

```r
data.table::as.data.table(lintr::lint(text="a=1", linters=lintr::assignment_linter()))
#                            <text>
# 1:                         <text>
# 2:                              1
# 3:                              2
# 4:                          style
# 5: Use <-, not =, for assignment.
# 6:                            a=1
# 7:                      <list[1]>
# 8:              assignment_linter
```