### PR TITLE
document "symbols" in object_name_linter (#1924)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -200,6 +200,9 @@
 
 * `object_usage_linter()` gives a more helpful warning when a `glue()` expression fails to evaluate (#1985, @MichaelChirico)
 
+* The documentation of `object_name_linter()` now describes how `"symbols"`
+works when passed to the `styles` parameter (#1924, @hedsnz).
+
 # lintr 3.0.2
 
 * Fix test to avoid leaving behind cache files in the global cache directory.

--- a/R/object_name_linter.R
+++ b/R/object_name_linter.R
@@ -45,7 +45,9 @@ object_name_xpath <- local({
 #'
 #' @param styles A subset of
 #'   \Sexpr[stage=render, results=rd]{lintr:::regexes_rd}. A name should
-#'   match at least one of these styles.
+#'   match at least one of these styles. The `"symbols"` style refers to
+#'   names containing only non-alphanumeric characters, e.g., `%+%` from
+#'   ggplot2 or `%>%` from magrittr.
 #' @param regexes A (possibly named) character vector specifying a custom naming convention.
 #'   If named, the names will be used in the lint message. Otherwise, the regexes enclosed by `/` will be used in the
 #'   lint message.

--- a/R/object_name_linter.R
+++ b/R/object_name_linter.R
@@ -46,8 +46,10 @@ object_name_xpath <- local({
 #' @param styles A subset of
 #'   \Sexpr[stage=render, results=rd]{lintr:::regexes_rd}. A name should
 #'   match at least one of these styles. The `"symbols"` style refers to
-#'   names containing only non-alphanumeric characters, e.g., `%+%` from
-#'   ggplot2 or `%>%` from magrittr.
+#'   names containing *only* non-alphanumeric characters; e.g., `%+%` from
+#'   ggplot2 or `%>%` from magrittr will not generate lint markers, whereas
+#'   `%in%` (containing both alphanumeric *and* non-alphanumeric characters)
+#'   will.
 #' @param regexes A (possibly named) character vector specifying a custom naming convention.
 #'   If named, the names will be used in the lint message. Otherwise, the regexes enclosed by `/` will be used in the
 #'   lint message.

--- a/R/object_name_linter.R
+++ b/R/object_name_linter.R
@@ -48,8 +48,9 @@ object_name_xpath <- local({
 #'   match at least one of these styles. The `"symbols"` style refers to
 #'   names containing *only* non-alphanumeric characters; e.g., `%+%` from
 #'   ggplot2 or `%>%` from magrittr will not generate lint markers, whereas
-#'   `%in%` (containing both alphanumeric *and* non-alphanumeric characters)
-#'   will.
+#'   `%m+%` from lubridate (containing both alphanumeric *and* non-alphanumeric
+#'   characters) will.
+#'
 #' @param regexes A (possibly named) character vector specifying a custom naming convention.
 #'   If named, the names will be used in the lint message. Otherwise, the regexes enclosed by `/` will be used in the
 #'   lint message.

--- a/R/object_name_linter.R
+++ b/R/object_name_linter.R
@@ -46,10 +46,10 @@ object_name_xpath <- local({
 #' @param styles A subset of
 #'   \Sexpr[stage=render, results=rd]{lintr:::regexes_rd}. A name should
 #'   match at least one of these styles. The `"symbols"` style refers to
-#'   names containing *only* non-alphanumeric characters; e.g., `%+%` from
-#'   ggplot2 or `%>%` from magrittr will not generate lint markers, whereas
-#'   `%m+%` from lubridate (containing both alphanumeric *and* non-alphanumeric
-#'   characters) will.
+#'   names containing *only* non-alphanumeric characters; e.g., defining `%+%`
+#'   from ggplot2 or `%>%` from magrittr would not generate lint markers,
+#'   whereas `%m+%` from lubridate (containing both alphanumeric *and*
+#'   non-alphanumeric characters) would.
 #'
 #' @param regexes A (possibly named) character vector specifying a custom naming convention.
 #'   If named, the names will be used in the lint message. Otherwise, the regexes enclosed by `/` will be used in the

--- a/man/object_name_linter.Rd
+++ b/man/object_name_linter.Rd
@@ -9,7 +9,9 @@ object_name_linter(styles = c("snake_case", "symbols"), regexes = character())
 \arguments{
 \item{styles}{A subset of
 \Sexpr[stage=render, results=rd]{lintr:::regexes_rd}. A name should
-match at least one of these styles.}
+match at least one of these styles. The \code{"symbols"} style refers to
+names containing only non-alphanumeric characters, e.g., \verb{\%+\%} from
+ggplot2 or \verb{\%>\%} from magrittr.}
 
 \item{regexes}{A (possibly named) character vector specifying a custom naming convention.
 If named, the names will be used in the lint message. Otherwise, the regexes enclosed by \code{/} will be used in the

--- a/man/object_name_linter.Rd
+++ b/man/object_name_linter.Rd
@@ -10,10 +10,10 @@ object_name_linter(styles = c("snake_case", "symbols"), regexes = character())
 \item{styles}{A subset of
 \Sexpr[stage=render, results=rd]{lintr:::regexes_rd}. A name should
 match at least one of these styles. The \code{"symbols"} style refers to
-names containing \emph{only} non-alphanumeric characters; e.g., \verb{\%+\%} from
-ggplot2 or \verb{\%>\%} from magrittr will not generate lint markers, whereas
-\verb{\%m+\%} from lubridate (containing both alphanumeric \emph{and} non-alphanumeric
-characters) will.}
+names containing \emph{only} non-alphanumeric characters; e.g., defining \verb{\%+\%}
+from ggplot2 or \verb{\%>\%} from magrittr would not generate lint markers,
+whereas \verb{\%m+\%} from lubridate (containing both alphanumeric \emph{and}
+non-alphanumeric characters) would.}
 
 \item{regexes}{A (possibly named) character vector specifying a custom naming convention.
 If named, the names will be used in the lint message. Otherwise, the regexes enclosed by \code{/} will be used in the

--- a/man/object_name_linter.Rd
+++ b/man/object_name_linter.Rd
@@ -12,8 +12,8 @@ object_name_linter(styles = c("snake_case", "symbols"), regexes = character())
 match at least one of these styles. The \code{"symbols"} style refers to
 names containing \emph{only} non-alphanumeric characters; e.g., \verb{\%+\%} from
 ggplot2 or \verb{\%>\%} from magrittr will not generate lint markers, whereas
-\code{\%in\%} (containing both alphanumeric \emph{and} non-alphanumeric characters)
-will.}
+\verb{\%m+\%} from lubridate (containing both alphanumeric \emph{and} non-alphanumeric
+characters) will.}
 
 \item{regexes}{A (possibly named) character vector specifying a custom naming convention.
 If named, the names will be used in the lint message. Otherwise, the regexes enclosed by \code{/} will be used in the

--- a/man/object_name_linter.Rd
+++ b/man/object_name_linter.Rd
@@ -10,8 +10,10 @@ object_name_linter(styles = c("snake_case", "symbols"), regexes = character())
 \item{styles}{A subset of
 \Sexpr[stage=render, results=rd]{lintr:::regexes_rd}. A name should
 match at least one of these styles. The \code{"symbols"} style refers to
-names containing only non-alphanumeric characters, e.g., \verb{\%+\%} from
-ggplot2 or \verb{\%>\%} from magrittr.}
+names containing \emph{only} non-alphanumeric characters; e.g., \verb{\%+\%} from
+ggplot2 or \verb{\%>\%} from magrittr will not generate lint markers, whereas
+\code{\%in\%} (containing both alphanumeric \emph{and} non-alphanumeric characters)
+will.}
 
 \item{regexes}{A (possibly named) character vector specifying a custom naming convention.
 If named, the names will be used in the lint message. Otherwise, the regexes enclosed by \code{/} will be used in the


### PR DESCRIPTION
Resolves https://github.com/r-lib/lintr/issues/1924 by adding a short description of the "symbols" style in the `object_name_linter` documentation.