### PR TITLE
skip c() unless >1 argument is used

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # lintr (development version)
 
+## Bug fixes
+
+* `inner_combine_linter()` no longer throws on length-1 calls to `c()` like `c(exp(2))` or `c(log(3))` (#2017, @MichaelChirico). Such usage is discouraged by `unnecessary_concatenation_linter()`, but `inner_combine_linter()` _per se_ does not apply.
+
 # lintr 3.1.0
 
 ## Deprecations & Breaking Changes

--- a/R/inner_combine_linter.R
+++ b/R/inner_combine_linter.R
@@ -78,7 +78,7 @@ inner_combine_linter <- function() {
   )
   xpath <- glue::glue("
   //SYMBOL_FUNCTION_CALL[text() = 'c']
-    /parent::expr
+    /parent::expr[count(following-sibling::expr) > 1]
     /following-sibling::expr[1][ {c_expr_cond} ]
     /parent::expr
   ")

--- a/tests/testthat/test-inner_combine_linter.R
+++ b/tests/testthat/test-inner_combine_linter.R
@@ -67,6 +67,10 @@ test_that("inner_combine_linter is order-agnostic for matching arguments", {
   )
 })
 
+test_that("c() with ...length()=1 is OK", {
+  expect_lint("c(exp())", NULL, inner_combine_linter())
+})
+
 skip_if_not_installed("tibble")
 patrick::with_parameters_test_that(
   "inner_combine_linter skips allowed usages:",


### PR DESCRIPTION
Closes #2017 

Confirming this is a regression introduced by 680715fc5411fcbefed55bff1dc7757d86ae061b:

```shell
git checkout 680715fc5411fcbefed55bff1dc7757d86ae061b~1
Rscript -e 'lintr::lint("\nc(exp())", lintr::inner_combine_linter())'

git checkout 680715fc5411fcbefed55bff1dc7757d86ae061b
Rscript -e 'lintr::lint("\nc(exp())", lintr::inner_combine_linter())'
# <text>:2:1: warning: [inner_combine_linter] Combine inputs to vectorized functions first to take full advantage of vectorization, e.g., exp(c(x, y)) only runs the more expensive exp() once as compared to c(exp(x), exp(y)).
# c(exp())
# ^~~~~~~~
```