### PR TITLE
Update link to design guide

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -245,7 +245,7 @@ works when passed to the `styles` parameter (#1924, @hedsnz).
 * `unreachable_code_linter()` ignores trailing comments if they match a closing nolint block (#1347, @AshesITR).
 
 * New `function_argument_linter()` to enforce that arguments with defaults appear last in function declarations,
-  see the [Tidyverse design guide](https://design.tidyverse.org/args-data-details.html) (#450, @AshesITR).
+  see the [Tidyverse design guide](https://design.tidyverse.org/required-no-defaults.html) (#450, @AshesITR).
 
 * New `allow_trailing` argument added to `assignment_linter()` to check when assignment operators are at the 
   end of a line, and the value is on the following line (#1491, @ashbaldry) 
@@ -326,7 +326,7 @@ works when passed to the `styles` parameter (#1924, @hedsnz).
    + `open_curly_linter()`
    + `paren_brace_linter()`
 * The `...` argument for `lint()`, `lint_dir()`, and `lint_package()` has been promoted to an earlier position to
-  better match the [Tidyverse design principle](https://design.tidyverse.org/args-data-details.html) of
+  better match the [Tidyverse design principle](https://design.tidyverse.org/required-no-defaults.html) of
   data->descriptor->details. This change enables passing objects to `...` without needing to specify non-required
   arguments, e.g. `lint_dir("/path/to/dir", linter())` now works without the need to specify `relative_path`.
   This affects some code that uses positional arguments (#935, @MichaelChirico).

--- a/R/function_argument_linter.R
+++ b/R/function_argument_linter.R
@@ -43,7 +43,7 @@
 #' @evalRd rd_tags("function_argument_linter")
 #' @seealso
 #' - [linters] for a complete list of linters available in lintr.
-#' - <https://design.tidyverse.org/args-data-details.html>
+#' - <https://design.tidyverse.org/required-no-defaults.html>
 #' @export
 function_argument_linter <- function() {
   xpath <- paste(collapse = " | ", glue::glue("

--- a/man/function_argument_linter.Rd
+++ b/man/function_argument_linter.Rd
@@ -50,7 +50,7 @@ lint(
 \seealso{
 \itemize{
 \item \link{linters} for a complete list of linters available in lintr.
-\item \url{https://design.tidyverse.org/args-data-details.html}
+\item \url{https://design.tidyverse.org/required-no-defaults.html}
 }
 }
 \section{Tags}{


### PR DESCRIPTION
Seems there was a refactor in the last few days:

https://design.tidyverse.org/required-no-defaults.html

It looks like there's some clarification/exceptions added to the body, it might make sense to revisit when lints apply in light of that. But for now we just fix the links.