### PR TITLE
Use node-level | for efficiency in infix_spaces_linter

### DIFF
--- a/R/infix_spaces_linter.R
+++ b/R/infix_spaces_linter.R
@@ -144,10 +144,11 @@ infix_spaces_linter <- function(exclude_operators = NULL, allow_multiple_spaces 
 
   # NB: preceding-sibling::* and not preceding-sibling::expr because
   #   of the foo(a=1) case, where the tree is <SYMBOL_SUB><EQ_SUB><expr>
-  # NB: position() > 1 for the unary case, e.g. x[-1]
+  # NB: parent::*[count(expr) + count(OP-LEFT-PAREN) > 1] for the unary case, e.g. x[-1]
+  #  OP-LEFT-PAREN for EQ_SUB case with missing argument like alist(a =)
   # NB: the last not() disables lints inside box::use() declarations
   xpath <- paste(collapse = "|", glue::glue("//{infix_tokens}[
-    position() > 1
+    parent::*[count(expr) + count(SYMBOL_SUB) > 1]
     and (
       (
         @line1 = preceding-sibling::*[1]/@line2

--- a/R/infix_spaces_linter.R
+++ b/R/infix_spaces_linter.R
@@ -146,9 +146,8 @@ infix_spaces_linter <- function(exclude_operators = NULL, allow_multiple_spaces 
   #   of the foo(a=1) case, where the tree is <SYMBOL_SUB><EQ_SUB><expr>
   # NB: position() > 1 for the unary case, e.g. x[-1]
   # NB: the last not() disables lints inside box::use() declarations
-  xpath <- glue::glue("//*[
-    ({xp_or(paste0('self::', infix_tokens))})
-    and position() > 1
+  xpath <- paste(collapse = "|", glue::glue("//{infix_tokens}[
+    position() > 1
     and (
       (
         @line1 = preceding-sibling::*[1]/@line2
@@ -166,7 +165,7 @@ infix_spaces_linter <- function(exclude_operators = NULL, allow_multiple_spaces 
         ]
       ]
     )
-  ]")
+  ]"))
 
   Linter(function(source_expression) {
     if (!is_lint_level(source_expression, "expression")) {

--- a/R/infix_spaces_linter.R
+++ b/R/infix_spaces_linter.R
@@ -144,7 +144,7 @@ infix_spaces_linter <- function(exclude_operators = NULL, allow_multiple_spaces 
 
   # NB: preceding-sibling::* and not preceding-sibling::expr because
   #   of the foo(a=1) case, where the tree is <SYMBOL_SUB><EQ_SUB><expr>
-  # NB: parent::*[count(expr) + count(OP-LEFT-PAREN) > 1] for the unary case, e.g. x[-1]
+  # NB: parent::*[count(expr | SYMBOL_SUB)) > 1] for the unary case, e.g. x[-1]
   #  SYMBOL_SUB for case with missing argument like alist(a =)
   # NB: the last not() disables lints inside box::use() declarations
   xpath <- paste(collapse = "|", glue::glue("//{infix_tokens}[

--- a/R/infix_spaces_linter.R
+++ b/R/infix_spaces_linter.R
@@ -145,7 +145,7 @@ infix_spaces_linter <- function(exclude_operators = NULL, allow_multiple_spaces 
   # NB: preceding-sibling::* and not preceding-sibling::expr because
   #   of the foo(a=1) case, where the tree is <SYMBOL_SUB><EQ_SUB><expr>
   # NB: parent::*[count(expr) + count(OP-LEFT-PAREN) > 1] for the unary case, e.g. x[-1]
-  #  OP-LEFT-PAREN for EQ_SUB case with missing argument like alist(a =)
+  #  SYMBOL_SUB for case with missing argument like alist(a =)
   # NB: the last not() disables lints inside box::use() declarations
   xpath <- paste(collapse = "|", glue::glue("//{infix_tokens}[
     parent::*[count(expr | SYMBOL_SUB) > 1]

--- a/R/infix_spaces_linter.R
+++ b/R/infix_spaces_linter.R
@@ -148,7 +148,7 @@ infix_spaces_linter <- function(exclude_operators = NULL, allow_multiple_spaces 
   #  OP-LEFT-PAREN for EQ_SUB case with missing argument like alist(a =)
   # NB: the last not() disables lints inside box::use() declarations
   xpath <- paste(collapse = "|", glue::glue("//{infix_tokens}[
-    parent::*[count(expr) + count(SYMBOL_SUB) > 1]
+    parent::*[count(expr | SYMBOL_SUB) > 1]
     and (
       (
         @line1 = preceding-sibling::*[1]/@line2

--- a/tests/testthat/test-infix_spaces_linter.R
+++ b/tests/testthat/test-infix_spaces_linter.R
@@ -185,3 +185,7 @@ test_that("native pipe is supported", {
   expect_lint("a |> foo()", NULL, linter)
   expect_lint("a|>foo()", rex::rex("Put spaces around all infix operators."), linter)
 })
+
+test_that("mixed unary & binary operators aren't mis-lint", {
+  expect_lint("-1-1", rex::rex("Put spaces around all infix operators."), infix_spaces_linter())
+})

--- a/tests/testthat/test-infix_spaces_linter.R
+++ b/tests/testthat/test-infix_spaces_linter.R
@@ -187,5 +187,12 @@ test_that("native pipe is supported", {
 })
 
 test_that("mixed unary & binary operators aren't mis-lint", {
-  expect_lint("-1-1", rex::rex("Put spaces around all infix operators."), infix_spaces_linter())
+  expect_lint(
+    "-1-1",
+    list(
+      message = rex::rex("Put spaces around all infix operators."),
+      column_number = 3L
+    ),
+    infix_spaces_linter()
+  )
 })


### PR DESCRIPTION
Similar to #2024, I found `infix_spaces_linter()` to be among the slowest, and apparently owing to the `//*` expression.

It's really slow! Even with 22 entries in `//NODE1[...] | //NODE2[...] | ... | //NODE22[...]`, I find this approach about 3x as fast in the core loop:

```r
exp <- get_source_expressions("QC.R")
ll <- lintr::infix_spaces_linter()
system.time(replicate(100, lapply(exp$expressions, ll)))

## BEFORE
#    user  system elapsed 
# 148.841   0.800 157.128

## AFTER
#    user  system elapsed 
#  48.209   0.286  51.664
```