### PR TITLE
require & library both linted in library_call_linter()

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -31,7 +31,7 @@
 
 ### New linters
 
-* `library_call_linter()` can detect if all library calls are not at the top of your script (#2027, @nicholas-masel).
+* `library_call_linter()` can detect if all library/require calls are not at the top of your script (#2027 and #2043, @nicholas-masel and @MichaelChirico).
 * `keyword_quote_linter()` for finding unnecessary or discouraged quoting of symbols in assignment, function arguments, or extraction (part of #884, @MichaelChirico). Quoting is unnecessary when the target is a valid R name, e.g. `c("a" = 1)` can be `c(a = 1)`. The same goes to assignment (`"a" <- 1`) and extraction (`x$"a"`). Where quoting is necessary, the linter encourages doing so with backticks (e.g. `` x$`a b` `` instead of `x$"a b"`).
 * `length_levels_linter()` for using the specific function `nlevels()` instead of checking `length(levels(x))` (part of #884, @MichaelChirico).
 

--- a/R/library_call_linter.R
+++ b/R/library_call_linter.R
@@ -44,13 +44,14 @@
 #' @seealso [linters] for a complete list of linters available in lintr.
 #' @export
 library_call_linter <- function() {
-
-  xpath <- "
-    (//SYMBOL_FUNCTION_CALL[text() = 'library'])[last()]
+  attach_call <- "text() = 'library' or text() = 'require'"
+  xpath <- glue("
+    //SYMBOL_FUNCTION_CALL[{ attach_call }][last()]
       /preceding::expr
-      /SYMBOL_FUNCTION_CALL[text() != 'library'][last()]
-      /following::expr[SYMBOL_FUNCTION_CALL[text() = 'library']]
-  "
+      /SYMBOL_FUNCTION_CALL[not({ attach_call })][last()]
+      /following::expr[SYMBOL_FUNCTION_CALL[{ attach_call }]]
+      /parent::expr
+  ")
 
   Linter(function(source_expression) {
     if (!is_lint_level(source_expression, "file")) {
@@ -61,14 +62,12 @@ library_call_linter <- function() {
 
     bad_expr <- xml_find_all(xml, xpath)
 
-    if (length(bad_expr) == 0L) {
-      return(list())
-    }
+    call_name <- xp_call_name(bad_expr)
 
     xml_nodes_to_lints(
       bad_expr,
       source_expression = source_expression,
-      lint_message = "Move all library calls to the top of the script.",
+      lint_message = sprintf("Move all %s calls to the top of the script.", call_name),
       type = "warning"
     )
   })

--- a/tests/testthat/test-library_call_linter.R
+++ b/tests/testthat/test-library_call_linter.R
@@ -1,4 +1,5 @@
 test_that("library_call_linter skips allowed usages", {
+  linter <- library_call_linter()
 
   expect_lint(
     trim_some("
@@ -6,12 +7,12 @@ test_that("library_call_linter skips allowed usages", {
       print('test')
     "),
     NULL,
-    library_call_linter()
+    linter
   )
 
   expect_lint("print('test')",
     NULL,
-    library_call_linter()
+    linter
   )
 
   expect_lint(
@@ -20,7 +21,7 @@ test_that("library_call_linter skips allowed usages", {
       library(dplyr)
     "),
     NULL,
-    library_call_linter()
+    linter
   )
 
   expect_lint(
@@ -29,11 +30,12 @@ test_that("library_call_linter skips allowed usages", {
       # library(dplyr)
     "),
     NULL,
-    library_call_linter()
+    linter
   )
 })
 
 test_that("library_call_linter warns on disallowed usages", {
+  linter <- library_call_linter()
   lint_message <- rex::rex("Move all library calls to the top of the script.")
 
   expect_lint(
@@ -43,7 +45,7 @@ test_that("library_call_linter warns on disallowed usages", {
       library(tidyr)
     "),
     lint_message,
-    library_call_linter()
+    linter
   )
 
   expect_lint(
@@ -57,7 +59,7 @@ test_that("library_call_linter warns on disallowed usages", {
       list(lint_message, line_number = 3L, column_number = 1L),
       list(lint_message, line_number = 4L, column_number = 1L)
     ),
-    library_call_linter()
+    linter
   )
 
   expect_lint(
@@ -68,7 +70,7 @@ test_that("library_call_linter warns on disallowed usages", {
       library(tidyr)
     "),
     lint_message,
-    library_call_linter()
+    linter
   )
 
   expect_lint(
@@ -79,7 +81,7 @@ test_that("library_call_linter warns on disallowed usages", {
       print('test')
     "),
     lint_message,
-    library_call_linter()
+    linter
   )
 
   expect_lint(
@@ -94,6 +96,45 @@ test_that("library_call_linter warns on disallowed usages", {
       list(lint_message, line_number = 3L, column_number = 1L),
       list(lint_message, line_number = 5L, column_number = 1L)
     ),
-    library_call_linter()
+    linter
+  )
+})
+
+test_that("require() treated the same as library()", {
+  linter <- library_call_linter()
+  lint_message_library <- rex::rex("Move all library calls to the top of the script.")
+  lint_message_require <- rex::rex("Move all require calls to the top of the script.")
+
+  expect_lint(
+    trim_some('
+      library(dplyr)
+      require("tidyr")
+    '),
+    NULL,
+    linter
+  )
+
+  expect_lint(
+    trim_some('
+      library(dplyr)
+      print(letters)
+      require("tidyr")
+    '),
+    list(lint_message_require, line_number = 3L),
+    linter
+  )
+
+  expect_lint(
+    trim_some('
+      library(dplyr)
+      print(letters)
+      library(dbplyr)
+      require("tidyr")
+    '),
+    list(
+      list(lint_message_library, line_number = 3L),
+      list(lint_message_require, line_number = 4L)
+    ),
+    linter
   )
 })


### PR DESCRIPTION
Closes #2045 

Maybe a renaming is in order? `attach_up_front_linter()`? `preamble_attach_linter()`? `package_preamble_linter()`?