### PR TITLE
Require backports >= 1.1.7

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -23,7 +23,7 @@ BugReports: https://github.com/r-lib/lintr/issues
 Depends:
     R (>= 3.5)
 Imports:
-    backports,
+    backports (>= 1.1.7),
     codetools,
     cyclocomp,
     digest,


### PR DESCRIPTION
Fixes #2097 