### PR TITLE
Add dependabot workflow

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,8 @@
+version: 2
+
+updates:
+  # Keep dependencies for GitHub Actions up-to-date
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,7 +1,14 @@
+# This Dependabot configuration is designed to keep GitHub Actions dependencies up-to-date
+# by running weekly checks and creating pull requests to update them as needed.
+#
+# This ensures that the GitHub Actions workflows remain compatible with the latest versions
+# of their dependencies, potentially improving the stability and security of automation processes.
+#
+# For more, see:
+# https://docs.github.com/en/code-security/dependabot/dependabot-alerts/about-dependabot-alerts
 version: 2
 
 updates:
-  # Keep dependencies for GitHub Actions up-to-date
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:


### PR DESCRIPTION
To avoid manually doing upkeep like in https://github.com/r-lib/lintr/pull/2119.

This Dependabot configuration is designed to keep GitHub Actions dependencies up-to-date
by running weekly checks and creating pull requests to update them as needed.

This ensures that the GitHub Actions workflows remain compatible with the latest versions
of their dependencies, potentially improving the stability and security of automation processes.

For more, see:
https://docs.github.com/en/code-security/dependabot/dependabot-alerts/about-dependabot-alerts