### PR TITLE
Return early if there's nothing to lint

### DIFF
--- a/R/lint.R
+++ b/R/lint.R
@@ -170,6 +170,12 @@ lint_dir <- function(path = ".", ...,
   # Remove fully ignored files to avoid reading & parsing
   files <- drop_excluded(files, exclusions)
 
+  if (length(files) == 0L) {
+    lints <- list()
+    class(lints) <- "lints"
+    return(lints)
+  }
+
   pb <- if (isTRUE(show_progress)) {
     txtProgressBar(max = length(files), style = 3L)
   }

--- a/tests/testthat/test-lint_dir.R
+++ b/tests/testthat/test-lint_dir.R
@@ -112,3 +112,7 @@ test_that("lint_dir errors for relative_path= in 2nd positional argument", {
 test_that("typo in argument name gives helpful error", {
   expect_error(lint_dir(litners = identity), "Found unknown arguments in [.][.][.].*[?]lint_dir ")
 })
+
+test_that("linting empty directory passes", {
+  expect_length(withr::local_tempdir(), 0L)
+})

--- a/tests/testthat/test-lint_dir.R
+++ b/tests/testthat/test-lint_dir.R
@@ -114,5 +114,5 @@ test_that("typo in argument name gives helpful error", {
 })
 
 test_that("linting empty directory passes", {
-  expect_length(withr::local_tempdir(), 0L)
+  expect_length(lint_dir(withr::local_tempdir(), any_duplicated_linter()), 0L)
 })


### PR DESCRIPTION
Accidentally linted a directory where everything was excluded, leading to an error from `txtProgressBar()`:

```
Error in txtProgressBar(max = length(files), style = 3L) : 
  must have 'max' > 'min'
```

Better to just skip running anything if there's nothing to lint.