### PR TITLE
avoid structure()

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -15,10 +15,9 @@
 }
 
 flatten_lints <- function(x) {
-  structure(
-    flatten_list(x, class = "lint"),
-    class = "lints"
-  )
+  x <- flatten_list(x, class = "lint")
+  class(x) <- "lints"
+  x
 }
 
 # any function using unlist or c was dropping the classnames,
@@ -169,7 +168,9 @@ Linter <- function(fun, name = linter_auto_name()) { # nolint: object_name.
     stop("`fun` must be a function taking exactly one argument.", call. = FALSE)
   }
   force(name)
-  structure(fun, class = c("linter", "function"), name = name)
+  class(fun) <- c("linter", "function")
+  attr(fun, "name") <- name
+  fun
 }
 
 read_lines <- function(file, encoding = settings$encoding, ...) {


### PR DESCRIPTION
`structure()` is IME always slower (admittedly on very small absolute scale) than the alternatives, with little tradeoff of readability (if anything I think using setters is more canonical -> more readable). E.g.

```r
library(microbenchmark)

l <- list()

f1 <- function(l) structure(l, class = c("a", "b"), name = "nm")
f2 <- function(l) {
  class(l) <- c("a", "b")
  attr(l, "name") <- "nm"
  l
}

microbenchmark(times = 1e6, f1(l), f2(l))
# Unit: microseconds
#   expr   min    lq     mean median    uq      max neval cld
#  f1(l) 5.432 5.746 7.478789  5.895 6.280 74773.89 1e+06   b
#  f2(l) 1.469 1.616 2.235726  1.681 1.795 69402.46 1e+06  a 

identical(f1(l), f2(l))
# [1] TRUE
```