### PR TITLE
Bump oldest test suite to R 3.6.0

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -43,7 +43,7 @@ jobs:
           - {os: ubuntu-latest,  r: 'oldrel-2'}
           - {os: ubuntu-latest,  r: 'oldrel-3'}
           - {os: ubuntu-latest,  r: 'oldrel-4'}
-          - {os: ubuntu-latest,  r: '3.5'}
+          - {os: ubuntu-latest,  r: '3.6'}
 
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
I think we can get away with keeping R3.5.0 for this release since it's imminent, then bump our requirement to R>=3.6.0 immediately after release. Through today all of our tests have been passing on 3.5.0 so it's only CI that stopped for now.

Otherwise, we can make the next release 3.2.0 and bump our R dependency already.