### PR TITLE
Need relative, not global descendant in unnecessary_lambda_linter()

### DIFF
--- a/R/unnecessary_lambda_linter.R
+++ b/R/unnecessary_lambda_linter.R
@@ -72,7 +72,7 @@ unnecessary_lambda_linter <- function() {
       count(.//SYMBOL[self::* = preceding::SYMBOL_FORMALS[1]]) = 1
       and count(.//SYMBOL_FUNCTION_CALL[text() != 'return']) = 1
       and preceding-sibling::SYMBOL_FORMALS =
-        //expr[
+        .//expr[
           position() = 2
           and preceding-sibling::expr/SYMBOL_FUNCTION_CALL
           and not(preceding-sibling::*[1][self::EQ_SUB])

--- a/tests/testthat/test-unnecessary_lambda_linter.R
+++ b/tests/testthat/test-unnecessary_lambda_linter.R
@@ -55,6 +55,16 @@ test_that("unnecessary_lambda_linter skips allowed usages", {
   expect_lint("lapply(l, function(x) foo(x) * 2)", NULL, linter)
   expect_lint("lapply(l, function(x) foo(x) ^ 3)", NULL, linter)
   expect_lint("lapply(l, function(x) foo(x) %% 4)", NULL, linter)
+
+  # Don't include other lambdas, #2249
+  expect_lint(
+    trim_some('{
+      lapply(x, function(e) sprintf("%o", e))
+      lapply(y, function(e) paste(strlpad(e, "0", width)))
+    }'),
+    NULL,
+    linter
+  )
 })
 
 test_that("unnecessary_lambda_linter blocks simple disallowed usage", {


### PR DESCRIPTION
Closes #2249 

`//` starts from the top of the document, `.//` starts from within the current expression. Key difference in larger files!