### PR TITLE
Link to `read_settings()`

### DIFF
--- a/R/lint.R
+++ b/R/lint.R
@@ -19,8 +19,8 @@
 #'   - [lint()] (in case of `lint_dir()` and `lint_package()`; e.g. `linters` or `cache`)
 #' @param cache When logical, toggle caching of lint results. If passed a character string, store the cache in this
 #'   directory.
-#' @param parse_settings Logical, default `TRUE`. Whether to try and parse the settings;
-#'   otherwise, the [default_settings()] are used.
+#' @param parse_settings Logical, default `TRUE`. Whether to try and parse the [settings][read_settings]. Otherwise,
+#'   the [default_settings()] are used.
 #' @param text Optional argument for supplying a string or lines directly, e.g. if the file is already in memory or
 #'   linting is being done ad hoc.
 #'

--- a/R/settings.R
+++ b/R/settings.R
@@ -11,7 +11,7 @@
 #'   or the environment variable `R_LINTR_LINTER_FILE`
 #' This file is a DCF file, see [base::read.dcf()] for details.
 #' Experimentally, we also support keeping the config in a plain R file. By default we look for
-#'   a file named '.lintr.R' (in the same directories where we search for '.lintr').
+#'   a file named `.lintr.R` (in the same directories where we search for `.lintr`).
 #' We are still deciding the future of config support in lintr, so user feedback is welcome.
 #'   The advantage of R is that it maps more closely to how the configs are actually stored,
 #'   whereas the DCF approach requires somewhat awkward formatting of parseable R code within
@@ -20,7 +20,7 @@
 #"   otherwise "abusing" the ability to evaluate generic R code. Other recursive key-value stores
 #'   like YAML could work, but require new dependencies and are harder to parse
 #'   both programmatically and visually.
-#' @param filename source file to be linted
+#' @param filename Source file to be linted.
 read_settings <- function(filename) {
   reset_settings()
 

--- a/man/lint.Rd
+++ b/man/lint.Rd
@@ -51,8 +51,8 @@ linters.}
 \item{cache}{When logical, toggle caching of lint results. If passed a character string, store the cache in this
 directory.}
 
-\item{parse_settings}{Logical, default \code{TRUE}. Whether to try and parse the settings;
-otherwise, the \code{\link[=default_settings]{default_settings()}} are used.}
+\item{parse_settings}{Logical, default \code{TRUE}. Whether to try and parse the \link[=read_settings]{settings}. Otherwise,
+the \code{\link[=default_settings]{default_settings()}} are used.}
 
 \item{text}{Optional argument for supplying a string or lines directly, e.g. if the file is already in memory or
 linting is being done ad hoc.}

--- a/man/read_settings.Rd
+++ b/man/read_settings.Rd
@@ -7,7 +7,7 @@
 read_settings(filename)
 }
 \arguments{
-\item{filename}{source file to be linted}
+\item{filename}{Source file to be linted.}
 }
 \description{
 Lintr searches for settings for a given source file in the following order:
@@ -24,7 +24,7 @@ The default linter_file name is \code{.lintr} but it can be changed with option 
 or the environment variable \code{R_LINTR_LINTER_FILE}
 This file is a DCF file, see \code{\link[base:dcf]{base::read.dcf()}} for details.
 Experimentally, we also support keeping the config in a plain R file. By default we look for
-a file named '.lintr.R' (in the same directories where we search for '.lintr').
+a file named \code{.lintr.R} (in the same directories where we search for \code{.lintr}).
 We are still deciding the future of config support in lintr, so user feedback is welcome.
 The advantage of R is that it maps more closely to how the configs are actually stored,
 whereas the DCF approach requires somewhat awkward formatting of parseable R code within


### PR DESCRIPTION
Link to [`read_settings()`](https://lintr.r-lib.org/reference/read_settings.html) where settings search order is defined. Plus some cosmetic changes.