### PR TITLE
handle when re_matches returns a data.frame from capture groups

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # lintr (development version)
 
+## Bug fixes
+
+* `object_name_linter()` no longer errors when user-supplied `regexes=` have capture groups (#2188, @MichaelChirico).
+
 ## New and improved features
 
 * More helpful errors for invalid configs (#2253, @MichaelChirico).

--- a/R/object_name_linter.R
+++ b/R/object_name_linter.R
@@ -152,8 +152,13 @@ object_name_linter <- function(styles = c("snake_case", "symbols"), regexes = ch
 check_style <- function(nms, style, generics = character()) {
   conforming <- re_matches(nms, style)
 
-  # mark empty names and NA names as conforming
-  conforming[!nzchar(nms) | is.na(conforming)] <- TRUE
+  # style has capture group(s)
+  if (is.data.frame(conforming)) {
+    # if any group is missing, all groups are missing, so just check the first column
+    conforming <- !is.na(conforming[[1L]])
+  }
+  # mark empty or NA names as conforming
+  conforming <- is.na(nms) | !nzchar(nms) | conforming
 
   if (!all(conforming)) {
     possible_s3 <- re_matches(

--- a/tests/testthat/test-object_name_linter.R
+++ b/tests/testthat/test-object_name_linter.R
@@ -273,3 +273,8 @@ test_that("function shorthand also lints", {
 
   expect_lint("aBc <- \\() NULL", "function name style", object_name_linter())
 })
+
+test_that("capture groups in style are fine", {
+  expect_lint("a <- 1\nab <- 2", NULL, object_name_linter(regexes = c(capture = "^(a)")))
+  expect_lint("ab <- 1\nabc <- 2", NULL, object_name_linter(regexes = c(capture = "^(a)(b)")))
+})


### PR DESCRIPTION
Closes #2188

NB: We don't have any tests touching the `is.na(nms)` case. I guess that's because our XPath is good at ensuring we always find a variable name. Should we just drop that instead? Harmless I guess.