### PR TITLE
Ensure examples in linter docs

### DIFF
--- a/R/comparison_negation_linter.R
+++ b/R/comparison_negation_linter.R
@@ -3,6 +3,34 @@
 #' `!(x == y)` is more readably expressed as `x != y`. The same is true of
 #'   other negations of simple comparisons like `!(x > y)` and `!(x <= y)`.
 #'
+#' @examples
+#' # will produce lints
+#' lint(
+#'   text = "!x == 2",
+#'   linters = comparison_negation_linter()
+#' )
+#'
+#' lint(
+#'   text = "!(x > 2)",
+#'   linters = comparison_negation_linter()
+#' )
+#'
+#' # okay
+#' lint(
+#'   text = "!(x == 2 & y > 2)",
+#'   linters = comparison_negation_linter()
+#' )
+#'
+#' lint(
+#'   text = "!(x & y)",
+#'   linters = comparison_negation_linter()
+#' )
+#'
+#' lint(
+#'   text = "x != 2",
+#'   linters = comparison_negation_linter()
+#' )
+#'
 #' @evalRd rd_tags("comparison_negation_linter")
 #' @seealso [linters] for a complete list of linters available in lintr.
 #' @export

--- a/R/nonportable_path_linter.R
+++ b/R/nonportable_path_linter.R
@@ -2,6 +2,19 @@
 #'
 #' Check that [file.path()] is used to construct safe and portable paths.
 #'
+#' @examples
+#' # will produce lints
+#' lint(
+#'   text = "'abcdefg/hijklmnop/qrst/uv/wxyz'",
+#'   linters = nonportable_path_linter
+#' )
+#'
+#' # okay
+#' lint(
+#'   text = "file.path('abcdefg', 'hijklmnop', 'qrst', 'uv', 'wxyz')",
+#'   linters = nonportable_path_linter()
+#' )
+#'
 #' @inheritParams absolute_path_linter
 #' @evalRd rd_tags("nonportable_path_linter")
 #' @seealso

--- a/R/sample_int_linter.R
+++ b/R/sample_int_linter.R
@@ -3,6 +3,34 @@
 #' [sample.int()] is preferable to `sample()` for the case of sampling numbers
 #'   between 1 and `n`. `sample` calls `sample.int()` "under the hood".
 #'
+#' @examples
+#' # will produce lints
+#' lint(
+#'   text = "sample(1:10, 2)",
+#'   linters = sample_int_linter()
+#' )
+#'
+#' lint(
+#'   text = "sample(seq(4), 2)",
+#'   linters = sample_int_linter()
+#' )
+#'
+#' lint(
+#'   text = "sample(seq_len(8), 2)",
+#'   linters = sample_int_linter()
+#' )
+#'
+#' # okay
+#' lint(
+#'   text = "sample(seq(1, 5, by = 2), 2)",
+#'   linters = sample_int_linter()
+#' )
+#'
+#' lint(
+#'   text = "sample(letters, 2)",
+#'   linters = sample_int_linter()
+#' )
+#'
 #' @evalRd rd_tags("sample_int_linter")
 #' @seealso [linters] for a complete list of linters available in lintr.
 #' @export

--- a/R/scalar_in_linter.R
+++ b/R/scalar_in_linter.R
@@ -7,6 +7,24 @@
 #' `scalar %in% vector` is OK, because the alternative (`any(vector == scalar)`)
 #'   is more circuitous & potentially less clear.
 #'
+#' @examples
+#' # will produce lints
+#' lint(
+#'   text = "x %in% 1L",
+#'   linters = scalar_in_linter()
+#' )
+#'
+#' lint(
+#'   text = "x %chin% 'a'",
+#'   linters = scalar_in_linter()
+#' )
+#'
+#' # okay
+#' lint(
+#'   text = "x %in% 1:10",
+#'   linters = scalar_in_linter()
+#' )
+#'
 #' @evalRd rd_tags("scalar_in_linter")
 #' @seealso [linters] for a complete list of linters available in lintr.
 #' @export

--- a/R/stopifnot_all_linter.R
+++ b/R/stopifnot_all_linter.R
@@ -3,6 +3,29 @@
 #' `stopifnot(A)` actually checks `all(A)` "under the hood" if `A` is a vector,
 #'   and produces a better error message than `stopifnot(all(A))` does.
 #'
+#' @examples
+#' # will produce lints
+#' lint(
+#'   text = "stopifnot(all(x > 0))",
+#'   linters = stopifnot_all_linter()
+#' )
+#'
+#' lint(
+#'   text = "stopifnot(y > 3, all(x < 0))",
+#'   linters = stopifnot_all_linter()
+#' )
+#'
+#' # okay
+#' lint(
+#'   text = "stopifnot(is.null(x) || all(x > 0))",
+#'   linters = stopifnot_all_linter()
+#' )
+#'
+#' lint(
+#'   text = "assert_that(all(x > 0))",
+#'   linters = stopifnot_all_linter()
+#' )
+#'
 #' @evalRd rd_tags("stopifnot_all_linter")
 #' @seealso [linters] for a complete list of linters available in lintr.
 #' @export

--- a/R/terminal_close_linter.R
+++ b/R/terminal_close_linter.R
@@ -3,6 +3,37 @@
 #' Functions that end in `close(x)` are almost always better written by using
 #'   `on.exit(close(x))` close to where `x` is defined and/or opened.
 #'
+#' @examples
+#' # will produce lints
+#' code <- paste(
+#'   "f <- function(fl) {",
+#'   "  conn <- file(fl, open = 'r')",
+#'   "  readLines(conn)",
+#'   "  close(conn)",
+#'   "}",
+#'   sep = "\n"
+#' )
+#' writeLines(code)
+#' lint(
+#'   text = code,
+#'   linters = terminal_close_linter()
+#' )
+#'
+#' # okay
+#' code <- paste(
+#'   "f <- function(fl) {",
+#'   "  conn <- file(fl, open = 'r')",
+#'   "  on.exit(close(conn))",
+#'   "  readLines(conn)",
+#'   "}",
+#'   sep = "\n"
+#' )
+#' writeLines(code)
+#' lint(
+#'   text = code,
+#'   linters = terminal_close_linter()
+#' )
+#'
 #' @evalRd rd_tags("terminal_close_linter")
 #' @seealso [linters] for a complete list of linters available in lintr.
 #' @export

--- a/man/comparison_negation_linter.Rd
+++ b/man/comparison_negation_linter.Rd
@@ -10,6 +10,35 @@ comparison_negation_linter()
 \code{!(x == y)} is more readably expressed as \code{x != y}. The same is true of
 other negations of simple comparisons like \code{!(x > y)} and \code{!(x <= y)}.
 }
+\examples{
+# will produce lints
+lint(
+  text = "!x == 2",
+  linters = comparison_negation_linter()
+)
+
+lint(
+  text = "!(x > 2)",
+  linters = comparison_negation_linter()
+)
+
+# okay
+lint(
+  text = "!(x == 2 & y > 2)",
+  linters = comparison_negation_linter()
+)
+
+lint(
+  text = "!(x & y)",
+  linters = comparison_negation_linter()
+)
+
+lint(
+  text = "x != 2",
+  linters = comparison_negation_linter()
+)
+
+}
 \seealso{
 \link{linters} for a complete list of linters available in lintr.
 }

--- a/man/nonportable_path_linter.Rd
+++ b/man/nonportable_path_linter.Rd
@@ -17,6 +17,20 @@ If \code{TRUE}, only lint path strings, which
 \description{
 Check that \code{\link[=file.path]{file.path()}} is used to construct safe and portable paths.
 }
+\examples{
+# will produce lints
+lint(
+  text = "'abcdefg/hijklmnop/qrst/uv/wxyz'",
+  linters = nonportable_path_linter
+)
+
+# okay
+lint(
+  text = "file.path('abcdefg', 'hijklmnop', 'qrst', 'uv', 'wxyz')",
+  linters = nonportable_path_linter()
+)
+
+}
 \seealso{
 \itemize{
 \item \link{linters} for a complete list of linters available in lintr.

--- a/man/sample_int_linter.Rd
+++ b/man/sample_int_linter.Rd
@@ -10,6 +10,35 @@ sample_int_linter()
 \code{\link[=sample.int]{sample.int()}} is preferable to \code{sample()} for the case of sampling numbers
 between 1 and \code{n}. \code{sample} calls \code{sample.int()} "under the hood".
 }
+\examples{
+# will produce lints
+lint(
+  text = "sample(1:10, 2)",
+  linters = sample_int_linter()
+)
+
+lint(
+  text = "sample(seq(4), 2)",
+  linters = sample_int_linter()
+)
+
+lint(
+  text = "sample(seq_len(8), 2)",
+  linters = sample_int_linter()
+)
+
+# okay
+lint(
+  text = "sample(seq(1, 5, by = 2), 2)",
+  linters = sample_int_linter()
+)
+
+lint(
+  text = "sample(letters, 2)",
+  linters = sample_int_linter()
+)
+
+}
 \seealso{
 \link{linters} for a complete list of linters available in lintr.
 }

--- a/man/scalar_in_linter.Rd
+++ b/man/scalar_in_linter.Rd
@@ -15,6 +15,25 @@ is matched as well.
 \code{scalar \%in\% vector} is OK, because the alternative (\code{any(vector == scalar)})
 is more circuitous & potentially less clear.
 }
+\examples{
+# will produce lints
+lint(
+  text = "x \%in\% 1L",
+  linters = scalar_in_linter()
+)
+
+lint(
+  text = "x \%chin\% 'a'",
+  linters = scalar_in_linter()
+)
+
+# okay
+lint(
+  text = "x \%in\% 1:10",
+  linters = scalar_in_linter()
+)
+
+}
 \seealso{
 \link{linters} for a complete list of linters available in lintr.
 }

--- a/man/stopifnot_all_linter.Rd
+++ b/man/stopifnot_all_linter.Rd
@@ -10,6 +10,30 @@ stopifnot_all_linter()
 \code{stopifnot(A)} actually checks \code{all(A)} "under the hood" if \code{A} is a vector,
 and produces a better error message than \code{stopifnot(all(A))} does.
 }
+\examples{
+# will produce lints
+lint(
+  text = "stopifnot(all(x > 0))",
+  linters = stopifnot_all_linter()
+)
+
+lint(
+  text = "stopifnot(y > 3, all(x < 0))",
+  linters = stopifnot_all_linter()
+)
+
+# okay
+lint(
+  text = "stopifnot(is.null(x) || all(x > 0))",
+  linters = stopifnot_all_linter()
+)
+
+lint(
+  text = "assert_that(all(x > 0))",
+  linters = stopifnot_all_linter()
+)
+
+}
 \seealso{
 \link{linters} for a complete list of linters available in lintr.
 }

--- a/man/terminal_close_linter.Rd
+++ b/man/terminal_close_linter.Rd
@@ -10,6 +10,38 @@ terminal_close_linter()
 Functions that end in \code{close(x)} are almost always better written by using
 \code{on.exit(close(x))} close to where \code{x} is defined and/or opened.
 }
+\examples{
+# will produce lints
+code <- paste(
+  "f <- function(fl) {",
+  "  conn <- file(fl, open = 'r')",
+  "  readLines(conn)",
+  "  close(conn)",
+  "}",
+  sep = "\n"
+)
+writeLines(code)
+lint(
+  text = code,
+  linters = terminal_close_linter()
+)
+
+# okay
+code <- paste(
+  "f <- function(fl) {",
+  "  conn <- file(fl, open = 'r')",
+  "  on.exit(close(conn))",
+  "  readLines(conn)",
+  "}",
+  sep = "\n"
+)
+writeLines(code)
+lint(
+  text = code,
+  linters = terminal_close_linter()
+)
+
+}
 \seealso{
 \link{linters} for a complete list of linters available in lintr.
 }

--- a/tests/testthat/test-lintr-package.R
+++ b/tests/testthat/test-lintr-package.R
@@ -1,0 +1,9 @@
+test_that("All linter help files have examples", {
+  help_db <- tools::Rd_db("lintr")
+  linter_db <- help_db[endsWith(names(help_db), "_linter.Rd")]
+  rd_has_examples <- function(rd) any(vapply(rd, attr, "Rd_tag", FUN.VALUE = character(1L)) == "\\examples")
+  linter_has_examples <- vapply(linter_db, rd_has_examples, logical(1L))
+  for (ii in seq_along(linter_has_examples)) {
+    expect_true(linter_has_examples[ii], label = paste("Linter", names(linter_db)[ii], "has examples"))
+  }
+})


### PR DESCRIPTION
Thanks @IndrajeetPatil for catching the mistake of `sample_int_linter()` lacking examples. I added those, and looked for other doc pages lacking `@examples` -- a few more slipped through as well.

Therefore I added a regression test to guard against this going forward.