### PR TITLE
Fix test causing a warning in the lint GHA

### DIFF
--- a/tests/testthat/test-unreachable_code_linter.R
+++ b/tests/testthat/test-unreachable_code_linter.R
@@ -394,10 +394,10 @@ test_that("unreachable_code_linter ignores terminal nolint end comments", {
     trim_some("
       foo <- function() {
         do_something
-        # nolint start: one_linter.
+        # TestNoLintStart: one_linter.
         a = 42
         next
-        # nolint end
+        # TestNoLintEnd
       }
     "),
     NULL,


### PR DESCRIPTION
Look at any recent run e.g. https://github.com/r-lib/lintr/actions/runs/6886554472