### PR TITLE
Add () missing from nonportable_path_linter() example

### DIFF
--- a/R/nonportable_path_linter.R
+++ b/R/nonportable_path_linter.R
@@ -6,7 +6,7 @@
 #' # will produce lints
 #' lint(
 #'   text = "'abcdefg/hijklmnop/qrst/uv/wxyz'",
-#'   linters = nonportable_path_linter
+#'   linters = nonportable_path_linter()
 #' )
 #'
 #' # okay

--- a/man/nonportable_path_linter.Rd
+++ b/man/nonportable_path_linter.Rd
@@ -21,7 +21,7 @@ Check that \code{\link[=file.path]{file.path()}} is used to construct safe and p
 # will produce lints
 lint(
   text = "'abcdefg/hijklmnop/qrst/uv/wxyz'",
-  linters = nonportable_path_linter
+  linters = nonportable_path_linter()
 )
 
 # okay


### PR DESCRIPTION
Uncaught error from #2288. Not being able to rely completely on GHA let this slip through.