### PR TITLE
Remove error for deprecated functionality

### DIFF
--- a/R/lint.R
+++ b/R/lint.R
@@ -36,10 +36,6 @@
 #'
 #' @export
 lint <- function(filename, linters = NULL, ..., cache = FALSE, parse_settings = TRUE, text = NULL) {
-  if (has_positional_logical(list(...))) {
-    stop("'cache' is no longer available as a positional argument; please supply 'cache' as a named argument instead.")
-  }
-
   check_dots(...names(), c("exclude", "parse_exclusions"))
 
   needs_tempfile <- missing(filename) || re_matches(filename, rex(newline))
@@ -135,13 +131,6 @@ lint_dir <- function(path = ".", ...,
                      pattern = "(?i)[.](r|rmd|qmd|rnw|rhtml|rrst|rtex|rtxt)$",
                      parse_settings = TRUE,
                      show_progress = NULL) {
-  if (has_positional_logical(list(...))) {
-    stop(
-      "'relative_path' is no longer available as a positional argument; ",
-      "please supply 'relative_path' as a named argument instead. "
-    )
-  }
-
   check_dots(...names(), c("lint", "exclude", "parse_exclusions"))
 
   if (isTRUE(parse_settings)) {
@@ -235,15 +224,6 @@ lint_package <- function(path = ".", ...,
                          exclusions = list("R/RcppExports.R"),
                          parse_settings = TRUE,
                          show_progress = NULL) {
-  if (has_positional_logical(list(...))) {
-    # nocov start: dead code path
-    stop(
-      "'relative_path' is no longer available as a positional argument; ",
-      "please supply 'relative_path' as a named argument instead. "
-    )
-    # nocov end
-  }
-
   if (length(path) > 1L) {
     stop("Only linting one package at a time is supported.")
   }

--- a/tests/testthat/test-lint.R
+++ b/tests/testthat/test-lint.R
@@ -215,14 +215,6 @@ test_that("old compatibility usage errors", {
   )
 })
 
-test_that("Deprecated positional usage of cache= errors", {
-  expect_error(
-    lint("a = 2\n", FALSE, linters = assignment_linter()),
-    "'cache' is no longer available as a positional argument",
-    fixed = TRUE
-  )
-})
-
 test_that("Linters throwing an error give a helpful error", {
   tmp_file <- withr::local_tempfile(lines = "a <- 1")
   linter <- function() Linter(function(source_expression) stop("a broken linter"))

--- a/tests/testthat/test-lint_dir.R
+++ b/tests/testthat/test-lint_dir.R
@@ -99,16 +99,6 @@ test_that("lint_dir works with specific linters without specifying other argumen
   expect_length(lint_dir(the_dir, commented_code_linter(), parse_settings = FALSE), 0L)
 })
 
-test_that("lint_dir errors for relative_path= in 2nd positional argument", {
-  the_dir <- test_path("dummy_packages", "package", "vignettes")
-
-  expect_error(
-    lint_dir(the_dir, FALSE),
-    "'relative_path' is no longer available as a positional argument",
-    fixed = TRUE
-  )
-})
-
 test_that("typo in argument name gives helpful error", {
   expect_error(lint_dir(litners = identity), "Found unknown arguments in [.][.][.].*[?]lint_dir ")
 })


### PR DESCRIPTION
This became an error in 3.1.1, now we can remove it for the next release.