### PR TITLE
Remove excess nesting

### DIFF
--- a/tests/testthat/test-pipe_continuation_linter.R
+++ b/tests/testthat/test-pipe_continuation_linter.R
@@ -181,9 +181,7 @@ local({
   )
   patrick::with_parameters_test_that(
     "valid nesting is handled",
-    {
-      expect_lint(code_string, NULL, linter)
-    },
+    expect_lint(code_string, NULL, linter),
     .test_name = valid_code,
     code_string = valid_code
   )


### PR DESCRIPTION
Caught by #2302. Follow-up to #2303. Missed before as it got mixed in with `allow_assignment = TRUE` false positives.