### PR TITLE
exit early from package_hooks_linter() if no hooks are found

### DIFF
--- a/R/backport_linter.R
+++ b/R/backport_linter.R
@@ -57,6 +57,7 @@ backport_linter <- function(r_version = getRversion(), except = character()) {
     # rbind makes sure we have a matrix with dimensions [n_versions x n_names]
     # so that colSums() works to tell us which names are in an unavailable version
     # rbind not cbind because R is column-major --> which() below will be in column order
+    if (length(all_names) > 100) browser()
     needs_backport <- do.call(rbind, lapply(backport_blacklist, function(nm) all_names %in% nm))
     bad_idx <- colSums(needs_backport) > 0L
 

--- a/R/backport_linter.R
+++ b/R/backport_linter.R
@@ -57,7 +57,6 @@ backport_linter <- function(r_version = getRversion(), except = character()) {
     # rbind makes sure we have a matrix with dimensions [n_versions x n_names]
     # so that colSums() works to tell us which names are in an unavailable version
     # rbind not cbind because R is column-major --> which() below will be in column order
-    if (length(all_names) > 100) browser()
     needs_backport <- do.call(rbind, lapply(backport_blacklist, function(nm) all_names %in% nm))
     bad_idx <- colSums(needs_backport) > 0L
 


### PR DESCRIPTION
Closes #2336

Also move to `"file"`-level linting, I think that makes more sense for this linter.

With this, `lint_package()` goes from taking 11s to 8s on my machine.

For reference, `make_linter_from_xpath("false", "xx")` also takes about 8s, i.e., most of that 11s is the overhead of loading the files.