### PR TITLE
Drop duplicates from list of names in object_overwrite_linter()

### DIFF
--- a/R/object_overwrite_linter.R
+++ b/R/object_overwrite_linter.R
@@ -70,6 +70,9 @@ object_overwrite_linter <- function(
     stringsAsFactors = FALSE
   )
 
+  # Take the first among duplicate names, e.g. 'plot' resolves to base::plot, not graphics::plot
+  pkg_exports <- pkg_exports[!duplicated(pkg_exports$name), ]
+
   # test that the symbol doesn't match an argument name in the function
   # NB: data.table := has parse token LEFT_ASSIGN as well
   xpath <- glue("

--- a/tests/testthat/test-object_overwrite_linter.R
+++ b/tests/testthat/test-object_overwrite_linter.R
@@ -29,6 +29,13 @@ test_that("object_overwrite_linter blocks simple disallowed usages", {
     linter
   )
 
+  # base and graphics both export 'plot'; ensure this is no issue
+  expect_lint(
+    "function() plot <- 1",
+    rex::rex("'plot' is an exported object from package 'base'."),
+    linter
+  )
+
   # not just the top level of the function
   expect_lint(
     trim_some("

--- a/tests/testthat/test-object_overwrite_linter.R
+++ b/tests/testthat/test-object_overwrite_linter.R
@@ -29,10 +29,11 @@ test_that("object_overwrite_linter blocks simple disallowed usages", {
     linter
   )
 
-  # base and graphics both export 'plot'; ensure this is no issue
+  # base and graphics both export 'plot' (in recent R); ensure this is no issue
+  plot_pkg <- environmentName(environment(plot))
   expect_lint(
     "function() plot <- 1",
-    rex::rex("'plot' is an exported object from package 'base'."),
+    rex::rex("'plot' is an exported object from package '", plot_pkg, "'."),
     linter
   )
 


### PR DESCRIPTION
Related to #2337

This does not have much impact (there's only 3 overwrites in the default packages), but should be done anyway.