### PR TITLE
Drop non-syntactic names from list in object_overwrite_linter()

### DIFF
--- a/R/object_overwrite_linter.R
+++ b/R/object_overwrite_linter.R
@@ -70,7 +70,7 @@ object_overwrite_linter <- function(
     # .__C__ etc.: drop 150+ "virtual" names since they are very unlikely to appear anyway
     !grepl("^[.]__[A-Z]__", pkg_exports$name) &
     # exclude non-syntactic names. this might be supported upon user request.
-    make.names(pkg_exports$name) == pkg_exports$name
+    make.names(pkg_exports$name) == pkg_exports$name,
   ]
 
   # test that the symbol doesn't match an argument name in the function

--- a/R/object_overwrite_linter.R
+++ b/R/object_overwrite_linter.R
@@ -59,7 +59,7 @@ object_overwrite_linter <- function(
       stop("Package '", package, "' is not available.")
     }
   }
-  pkg_exports <- lapply(packages, function(pkg) setdiff(getNamespaceExports(pkg), allow_names))
+  pkg_exports <- lapply(packages, getNamespaceExports)
   pkg_exports <- data.frame(
     package = rep(packages, lengths(pkg_exports)),
     name = unlist(pkg_exports),
@@ -69,8 +69,9 @@ object_overwrite_linter <- function(
   pkg_exports <- pkg_exports[
     # .__C__ etc.: drop 150+ "virtual" names since they are very unlikely to appear anyway
     !grepl("^[.]__[A-Z]__", pkg_exports$name) &
-    # exclude non-syntactic names. this might be supported upon user request.
-    make.names(pkg_exports$name) == pkg_exports$name,
+      # exclude non-syntactic names. this might be supported upon user request.
+      make.names(pkg_exports$name) == pkg_exports$name &
+      !pkg_exports$name %in% allow_names,
   ]
 
   # test that the symbol doesn't match an argument name in the function

--- a/R/object_overwrite_linter.R
+++ b/R/object_overwrite_linter.R
@@ -59,16 +59,19 @@ object_overwrite_linter <- function(
       stop("Package '", package, "' is not available.")
     }
   }
-  pkg_exports <- lapply(
-    packages,
-    # .__C__ etc.: drop 150+ "virtual" names since they are very unlikely to appear anyway
-    function(pkg) setdiff(grep("^[.]__[A-Z]__", getNamespaceExports(pkg), value = TRUE, invert = TRUE), allow_names)
-  )
+  pkg_exports <- lapply(packages, function(pkg) setdiff(getNamespaceExports(pkg), allow_names))
   pkg_exports <- data.frame(
     package = rep(packages, lengths(pkg_exports)),
     name = unlist(pkg_exports),
     stringsAsFactors = FALSE
   )
+
+  pkg_exports <- pkg_exports[
+    # .__C__ etc.: drop 150+ "virtual" names since they are very unlikely to appear anyway
+    !grepl("^[.]__[A-Z]__", pkg_exports$name) &
+    # exclude non-syntactic names. this might be supported upon user request.
+    make.names(pkg_exports$name) == pkg_exports$name
+  ]
 
   # test that the symbol doesn't match an argument name in the function
   # NB: data.table := has parse token LEFT_ASSIGN as well


### PR DESCRIPTION
Related to #2337 

Such names (e.g. `base::body<-`) need special handling anyway that's not yet covered.

We could toggle whether to include such names, but I think we can leave that for if it's actually requested.

About 7% of exports from default packages fit this filter, so there should be some improvement, though I don't expect anything dramatic.