### PR TITLE
Speed up object_overwrite_linter

### DIFF
--- a/R/object_overwrite_linter.R
+++ b/R/object_overwrite_linter.R
@@ -104,8 +104,10 @@ object_overwrite_linter <- function(
     assigned_symbols <- get_r_string(assigned_exprs, "SYMBOL")
     is_bad <- assigned_symbols %in% pkg_exports$name
     source_pkg <- pkg_exports$package[match(assigned_symbols[is_bad], pkg_exports$name)]
-    lint_message <-
-      sprintf("'%s' is an exported object from package '%s'. Avoid re-using such symbols.", bad_symbol, source_pkg)
+    lint_message <- sprintf(
+      "'%s' is an exported object from package '%s'. Avoid re-using such symbols.",
+      assigned_symbols[is_bad], source_pkg
+    )
 
     xml_nodes_to_lints(
       assigned_exprs[is_bad],

--- a/R/object_overwrite_linter.R
+++ b/R/object_overwrite_linter.R
@@ -75,10 +75,9 @@ object_overwrite_linter <- function(
 
   # test that the symbol doesn't match an argument name in the function
   # NB: data.table := has parse token LEFT_ASSIGN as well
-  xpath <- glue("
+  xpath_assignments <- glue("
     //SYMBOL[
       not(text() = ancestor::expr/preceding-sibling::SYMBOL_FORMALS/text())
-      and ({ xp_text_in_table(pkg_exports$name) })
     ]/
       parent::expr[
         count(*) = 1
@@ -101,14 +100,15 @@ object_overwrite_linter <- function(
 
     xml <- source_expression$xml_parsed_content
 
-    bad_expr <- xml_find_all(xml, xpath)
-    bad_symbol <- xml_text(xml_find_first(bad_expr, "SYMBOL"))
-    source_pkg <- pkg_exports$package[match(bad_symbol, pkg_exports$name)]
+    assigned_exprs <- xml_find_all(xml, xpath_assignments)
+    assigned_symbols <- get_r_string(assigned_exprs, "SYMBOL")
+    is_bad <- assigned_symbols %in% pkg_exports$name
+    source_pkg <- pkg_exports$package[match(assigned_symbols[is_bad], pkg_exports$name)]
     lint_message <-
       sprintf("'%s' is an exported object from package '%s'. Avoid re-using such symbols.", bad_symbol, source_pkg)
 
     xml_nodes_to_lints(
-      bad_expr,
+      assigned_exprs[is_bad],
       source_expression = source_expression,
       lint_message = lint_message,
       type = "warning"


### PR DESCRIPTION
```r
system.time(lint_package(linters = object_overwrite_linter()))
# this
#   user  system elapsed 
#  5.744   0.010   5.752 

# main
#   user  system elapsed 
# 18.869   0.026  18.896 
```

While working on it, I wondered, if the lint message could be made more elegant.
WDYT about

`"'fun' overwrites 'pkg::fun'. Avoid overwriting symbols from other packages."`