### PR TITLE
Change linter_level= arg order for readability

### DIFF
--- a/R/T_and_F_symbol_linter.R
+++ b/R/T_and_F_symbol_linter.R
@@ -43,7 +43,7 @@ T_and_F_symbol_linter <- function() { # nolint: object_name.
 
   replacement_map <- c(T = "TRUE", F = "FALSE")
 
-  Linter(function(source_expression) {
+  Linter(linter_level = "expression", function(source_expression) {
     xml <- source_expression$xml_parsed_content
     if (is.null(xml)) return(list())
     bad_usage <- xml_find_all(xml, usage_xpath)
@@ -66,5 +66,5 @@ T_and_F_symbol_linter <- function() { # nolint: object_name.
       make_lints(bad_usage, "Use %s instead of the symbol %s."),
       make_lints(bad_assignment, "Don't use %2$s as a variable name, as it can break code relying on %2$s being %1$s.")
     )
-  }, linter_level = "expression")
+  })
 }

--- a/R/any_duplicated_linter.R
+++ b/R/any_duplicated_linter.R
@@ -85,7 +85,7 @@ any_duplicated_linter <- function() {
 
   uses_nrow_xpath <- "./parent::expr/expr/expr[1]/SYMBOL_FUNCTION_CALL[text() = 'nrow']"
 
-  Linter(function(source_expression) {
+  Linter(linter_level = "expression", function(source_expression) {
     xml <- source_expression$xml_parsed_content
     if (is.null(xml)) return(list())
 
@@ -111,5 +111,5 @@ any_duplicated_linter <- function() {
     )
 
     c(any_duplicated_lints, length_unique_lints)
-  }, linter_level = "expression")
+  })
 }

--- a/R/any_is_na_linter.R
+++ b/R/any_is_na_linter.R
@@ -46,7 +46,7 @@ any_is_na_linter <- function() {
     ]
   "
 
-  Linter(function(source_expression) {
+  Linter(linter_level = "expression", function(source_expression) {
     xml <- source_expression$xml_parsed_content
     if (is.null(xml)) return(list())
 
@@ -58,5 +58,5 @@ any_is_na_linter <- function() {
       lint_message = "anyNA(x) is better than any(is.na(x)).",
       type = "warning"
     )
-  }, linter_level = "expression")
+  })
 }

--- a/R/assignment_linter.R
+++ b/R/assignment_linter.R
@@ -99,7 +99,7 @@ assignment_linter <- function(allow_cascading_assign = TRUE,
     if (!allow_pipe_assign) "//SPECIAL[text() = '%<>%']"
   ))
 
-  Linter(function(source_expression) {
+  Linter(linter_level = "expression", function(source_expression) {
     xml <- source_expression$xml_parsed_content
     if (is.null(xml)) return(list())
 
@@ -123,5 +123,5 @@ assignment_linter <- function(allow_cascading_assign = TRUE,
 
     lint_message <- sprintf(lint_message_fmt, operator)
     xml_nodes_to_lints(bad_expr, source_expression, lint_message, type = "style")
-  }, linter_level = "expression")
+  })
 }

--- a/R/backport_linter.R
+++ b/R/backport_linter.R
@@ -47,7 +47,7 @@ backport_linter <- function(r_version = getRversion(), except = character()) {
 
   names_xpath <- "//SYMBOL | //SYMBOL_FUNCTION_CALL"
 
-  Linter(function(source_expression) {
+  Linter(linter_level = "expression", function(source_expression) {
     xml <- source_expression$xml_parsed_content
     if (is.null(xml)) return(list())
 
@@ -72,7 +72,7 @@ backport_linter <- function(r_version = getRversion(), except = character()) {
       lint_message = lint_message,
       type = "warning"
     )
-  }, linter_level = "expression")
+  })
 }
 
 normalize_r_version <- function(r_version) {

--- a/R/boolean_arithmetic_linter.R
+++ b/R/boolean_arithmetic_linter.R
@@ -55,7 +55,7 @@ boolean_arithmetic_linter <- function() {
   ")
   any_xpath <- paste(length_xpath, "|", sum_xpath)
 
-  Linter(function(source_expression) {
+  Linter(linter_level = "expression", function(source_expression) {
     xml <- source_expression$xml_parsed_content
     if (is.null(xml)) return(list())
 
@@ -71,5 +71,5 @@ boolean_arithmetic_linter <- function() {
       ),
       type = "warning"
     )
-  }, linter_level = "expression")
+  })
 }

--- a/R/brace_linter.R
+++ b/R/brace_linter.R
@@ -146,7 +146,7 @@ brace_linter <- function(allow_single_line = FALSE) {
   ]
   "
 
-  Linter(function(source_expression) {
+  Linter(linter_level = "expression", function(source_expression) {
     xml <- source_expression$xml_parsed_content
     if (is.null(xml)) return(list())
     lints <- list()
@@ -208,5 +208,5 @@ brace_linter <- function(allow_single_line = FALSE) {
     )
 
     lints
-  }, linter_level = "expression")
+  })
 }

--- a/R/class_equals_linter.R
+++ b/R/class_equals_linter.R
@@ -44,7 +44,7 @@ class_equals_linter <- function() {
     ]
   "
 
-  Linter(function(source_expression) {
+  Linter(linter_level = "expression", function(source_expression) {
     xml <- source_expression$xml_parsed_content
     if (is.null(xml)) return(list())
 
@@ -61,5 +61,5 @@ class_equals_linter <- function() {
       lint_message = lint_message,
       type = "warning"
     )
-  }, linter_level = "expression")
+  })
 }

--- a/R/commas_linter.R
+++ b/R/commas_linter.R
@@ -77,7 +77,7 @@ commas_linter <- function(allow_trailing = FALSE) {
     "]"
   )
 
-  Linter(function(source_expression) {
+  Linter(linter_level = "expression", function(source_expression) {
     xml <- source_expression$xml_parsed_content
     if (is.null(xml)) return(list())
 
@@ -98,5 +98,5 @@ commas_linter <- function(allow_trailing = FALSE) {
     )
 
     c(before_lints, after_lints)
-  }, linter_level = "expression")
+  })
 }

--- a/R/comment_linters.R
+++ b/R/comment_linters.R
@@ -75,7 +75,8 @@ commented_code_linter <- function() {
       anything
     )
   )
-  Linter(function(source_expression) {
+
+  Linter(linter_level = "file", function(source_expression) {
     xml <- source_expression$full_xml_parsed_content
     if (is.null(xml)) return(list())
     all_comment_nodes <- xml_find_all(xml, "//COMMENT")
@@ -105,7 +106,7 @@ commented_code_linter <- function() {
     }
 
     lint_list
-  }, linter_level = "file")
+  })
 }
 
 # is given text parsable

--- a/R/comparison_negation_linter.R
+++ b/R/comparison_negation_linter.R
@@ -60,12 +60,11 @@ comparison_negation_linter <- function() {
     ]
   ")
 
-  Linter(function(source_expression) {
+  Linter(linter_level = "expression", function(source_expression) {
     xml <- source_expression$xml_parsed_content
     if (is.null(xml)) return(list())
 
     bad_expr <- xml_find_all(xml, xpath)
-
 
     comparator_node <- xml_find_first(bad_expr, "expr/expr/*[2]")
     comparator_name <- xml_name(comparator_node)
@@ -85,5 +84,5 @@ comparison_negation_linter <- function() {
       lint_message = glue("Use x {inverse} y, not !(x {comparator_text} y)."),
       type = "warning"
     )
-  }, linter_level = "expression")
+  })
 }

--- a/R/condition_message_linter.R
+++ b/R/condition_message_linter.R
@@ -56,7 +56,7 @@ condition_message_linter <- function() {
     /parent::expr
   ")
 
-  Linter(function(source_expression) {
+  Linter(linter_level = "expression", function(source_expression) {
     xml <- source_expression$xml_parsed_content
     if (is.null(xml)) return(list())
 
@@ -72,5 +72,5 @@ condition_message_linter <- function() {
       '(using "" as a separator). For translatable strings, prefer using gettextf().'
     )
     xml_nodes_to_lints(bad_expr, source_expression = source_expression, lint_message = lint_message, type = "warning")
-  }, linter_level = "expression")
+  })
 }

--- a/R/conjunct_test_linter.R
+++ b/R/conjunct_test_linter.R
@@ -116,7 +116,7 @@ conjunct_test_linter <- function(allow_named_stopifnot = TRUE,
     /expr[AND]
   ")
 
-  Linter(function(source_expression) {
+  Linter(linter_level = "file", function(source_expression) {
     # need the full file to also catch usages at the top level
     xml <- source_expression$full_xml_parsed_content
     if (is.null(xml)) return(list())
@@ -157,5 +157,5 @@ conjunct_test_linter <- function(allow_named_stopifnot = TRUE,
     }
 
     lints
-  }, linter_level = "file")
+  })
 }

--- a/R/consecutive_assertion_linter.R
+++ b/R/consecutive_assertion_linter.R
@@ -47,7 +47,7 @@ consecutive_assertion_linter <- function() {
     ]
   "
 
-  Linter(function(source_expression) {
+  Linter(linter_level = "file", function(source_expression) {
     # need the full file to also catch usages at the top level
     xml <- source_expression$full_xml_parsed_content
     if (is.null(xml)) return(list())
@@ -61,5 +61,5 @@ consecutive_assertion_linter <- function() {
       lint_message = sprintf("Unify consecutive calls to %s().", matched_function),
       type = "warning"
     )
-  }, linter_level = "file")
+  })
 }

--- a/R/consecutive_mutate_linter.R
+++ b/R/consecutive_mutate_linter.R
@@ -71,7 +71,7 @@ consecutive_mutate_linter <- function(invalid_backends = "dbplyr") {
     /following-sibling::expr[{ mutate_cond }]
   ")
 
-  Linter(function(source_expression) {
+  Linter(linter_level = "file", function(source_expression) {
     # need the full file to also catch usages at the top level
     xml <- source_expression$full_xml_parsed_content
     if (is.null(xml)) return(list())
@@ -94,5 +94,5 @@ consecutive_mutate_linter <- function(invalid_backends = "dbplyr") {
       lint_message = "Unify consecutive calls to mutate().",
       type = "warning"
     )
-  }, linter_level = "file")
+  })
 }

--- a/R/cyclocomp_linter.R
+++ b/R/cyclocomp_linter.R
@@ -22,7 +22,7 @@
 #' @seealso [linters] for a complete list of linters available in lintr.
 #' @export
 cyclocomp_linter <- function(complexity_limit = 15L) {
-  Linter(function(source_expression) {
+  Linter(linter_level = "expression", function(source_expression) {
     complexity <- try_silently(
       cyclocomp::cyclocomp(parse(text = source_expression$content))
     )
@@ -42,5 +42,5 @@ cyclocomp_linter <- function(complexity_limit = 15L) {
       ranges = list(rep(col1, 2L)),
       line = source_expression$lines[1L]
     )
-  }, linter_level = "expression")
+  })
 }

--- a/R/duplicate_argument_linter.R
+++ b/R/duplicate_argument_linter.R
@@ -40,7 +40,7 @@ duplicate_argument_linter <- function(except = c("mutate", "transmute")) {
   xpath_call_with_args <- "//EQ_SUB/parent::expr"
   xpath_arg_name <- "./EQ_SUB/preceding-sibling::*[1]"
 
-  Linter(function(source_expression) {
+  Linter(linter_level = "file", function(source_expression) {
     xml <- source_expression$full_xml_parsed_content
     if (is.null(xml)) return(list())
 
@@ -61,5 +61,5 @@ duplicate_argument_linter <- function(except = c("mutate", "transmute")) {
       lint_message = "Duplicate arguments in function call.",
       type = "warning"
     )
-  }, linter_level = "file")
+  })
 }

--- a/R/equals_na_linter.R
+++ b/R/equals_na_linter.R
@@ -46,7 +46,7 @@ equals_na_linter <- function() {
     /parent::expr
   ")
 
-  Linter(function(source_expression) {
+  Linter(linter_level = "expression", function(source_expression) {
     xml <- source_expression$xml_parsed_content
     if (is.null(xml)) return(list())
 
@@ -58,5 +58,5 @@ equals_na_linter <- function() {
       lint_message = "Use is.na for comparisons to NA (not == or != or %in%)",
       type = "warning"
     )
-  }, linter_level = "expression")
+  })
 }

--- a/R/expect_comparison_linter.R
+++ b/R/expect_comparison_linter.R
@@ -63,7 +63,7 @@ expect_comparison_linter <- function() {
     `==` = "expect_identical"
   )
 
-  Linter(function(source_expression) {
+  Linter(linter_level = "expression", function(source_expression) {
     xml <- source_expression$xml_parsed_content
     if (is.null(xml)) return(list())
 
@@ -73,5 +73,5 @@ expect_comparison_linter <- function() {
     expectation <- comparator_expectation_map[comparator]
     lint_message <- sprintf("%s(x, y) is better than expect_true(x %s y).", expectation, comparator)
     xml_nodes_to_lints(bad_expr, source_expression, lint_message = lint_message, type = "warning")
-  }, linter_level = "expression")
+  })
 }

--- a/R/expect_identical_linter.R
+++ b/R/expect_identical_linter.R
@@ -81,7 +81,7 @@ expect_identical_linter <- function() {
   "
   xpath <- paste(expect_equal_xpath, "|", expect_true_xpath)
 
-  Linter(function(source_expression) {
+  Linter(linter_level = "expression", function(source_expression) {
     xml <- source_expression$xml_parsed_content
     if (is.null(xml)) return(list())
 
@@ -95,5 +95,5 @@ expect_identical_linter <- function() {
       ),
       type = "warning"
     )
-  }, linter_level = "expression")
+  })
 }

--- a/R/expect_length_linter.R
+++ b/R/expect_length_linter.R
@@ -32,7 +32,7 @@ expect_length_linter <- function() {
     /parent::expr[not(SYMBOL_SUB[text() = 'info' or contains(text(), 'label')])]
   ")
 
-  Linter(function(source_expression) {
+  Linter(linter_level = "expression", function(source_expression) {
     xml <- source_expression$xml_parsed_content
     if (is.null(xml)) return(list())
 
@@ -40,5 +40,5 @@ expect_length_linter <- function() {
     matched_function <- xp_call_name(bad_expr)
     lint_message <- sprintf("expect_length(x, n) is better than %s(length(x), n)", matched_function)
     xml_nodes_to_lints(bad_expr, source_expression, lint_message, type = "warning")
-  }, linter_level = "expression")
+  })
 }

--- a/R/expect_named_linter.R
+++ b/R/expect_named_linter.R
@@ -41,7 +41,7 @@ expect_named_linter <- function() {
     /parent::expr
   "
 
-  Linter(function(source_expression) {
+  Linter(linter_level = "expression", function(source_expression) {
     xml <- source_expression$xml_parsed_content
     if (is.null(xml)) return(list())
 
@@ -50,5 +50,5 @@ expect_named_linter <- function() {
     lint_message <- sprintf("expect_named(x, n) is better than %s(names(x), n)", matched_function)
 
     xml_nodes_to_lints(bad_expr, source_expression = source_expression, lint_message, type = "warning")
-  }, linter_level = "expression")
+  })
 }

--- a/R/expect_null_linter.R
+++ b/R/expect_null_linter.R
@@ -53,7 +53,7 @@ expect_null_linter <- function() {
   "
   xpath <- paste(expect_equal_identical_xpath, "|", expect_true_xpath)
 
-  Linter(function(source_expression) {
+  Linter(linter_level = "expression", function(source_expression) {
     xml <- source_expression$xml_parsed_content
     if (is.null(xml)) return(list())
 
@@ -71,5 +71,5 @@ expect_null_linter <- function() {
       lint_message = msg,
       type = "warning"
     )
-  }, linter_level = "expression")
+  })
 }

--- a/R/expect_s3_class_linter.R
+++ b/R/expect_s3_class_linter.R
@@ -69,7 +69,7 @@ expect_s3_class_linter <- function() {
   ")
   xpath <- paste(expect_equal_identical_xpath, "|", expect_true_xpath)
 
-  Linter(function(source_expression) {
+  Linter(linter_level = "expression", function(source_expression) {
     xml <- source_expression$xml_parsed_content
     if (is.null(xml)) return(list())
 
@@ -86,5 +86,5 @@ expect_s3_class_linter <- function() {
       lint_message = paste(msg, "Note also expect_s4_class() available for testing S4 objects."),
       type = "warning"
     )
-  }, linter_level = "expression")
+  })
 }

--- a/R/expect_s4_class_linter.R
+++ b/R/expect_s4_class_linter.R
@@ -32,7 +32,7 @@ expect_s4_class_linter <- function() {
     /parent::expr[not(SYMBOL_SUB[text() = 'info' or text() = 'label'])]
   "
 
-  Linter(function(source_expression) {
+  Linter(linter_level = "expression", function(source_expression) {
     xml <- source_expression$xml_parsed_content
     if (is.null(xml)) return(list())
 
@@ -49,5 +49,5 @@ expect_s4_class_linter <- function() {
       ),
       type = "warning"
     )
-  }, linter_level = "expression")
+  })
 }

--- a/R/expect_true_false_linter.R
+++ b/R/expect_true_false_linter.R
@@ -39,7 +39,7 @@ expect_true_false_linter <- function() {
     /parent::expr
   "
 
-  Linter(function(source_expression) {
+  Linter(linter_level = "expression", function(source_expression) {
     xml <- source_expression$xml_parsed_content
     if (is.null(xml)) return(list())
 
@@ -54,5 +54,5 @@ expect_true_false_linter <- function() {
     )
 
     xml_nodes_to_lints(bad_expr, source_expression, lint_message, type = "warning")
-  }, linter_level = "expression")
+  })
 }

--- a/R/expect_type_linter.R
+++ b/R/expect_type_linter.R
@@ -59,7 +59,7 @@ expect_type_linter <- function() {
   ")
   xpath <- paste(expect_equal_identical_xpath, "|", expect_true_xpath)
 
-  Linter(function(source_expression) {
+  Linter(linter_level = "expression", function(source_expression) {
     xml <- source_expression$xml_parsed_content
     if (is.null(xml)) return(list())
 
@@ -76,5 +76,5 @@ expect_type_linter <- function() {
       lint_message = msg,
       type = "warning"
     )
-  }, linter_level = "expression")
+  })
 }

--- a/R/extraction_operator_linter.R
+++ b/R/extraction_operator_linter.R
@@ -61,7 +61,7 @@ extraction_operator_linter <- function() {
   ]
   ")
 
-  Linter(function(source_expression) {
+  Linter(linter_level = "expression", function(source_expression) {
     xml <- source_expression$xml_parsed_content
     if (is.null(xml)) return(list())
     bad_exprs <- xml_find_all(xml, xpath)
@@ -73,5 +73,5 @@ extraction_operator_linter <- function() {
       lint_message = msgs,
       type = "warning"
     )
-  }, linter_level = "expression")
+  })
 }

--- a/R/fixed_regex_linter.R
+++ b/R/fixed_regex_linter.R
@@ -139,7 +139,7 @@ fixed_regex_linter <- function(allow_unescaped = FALSE) {
     ]
   ")
 
-  Linter(function(source_expression) {
+  Linter(linter_level = "expression", function(source_expression) {
     xml <- source_expression$xml_parsed_content
     if (is.null(xml)) return(list())
 
@@ -168,5 +168,5 @@ fixed_regex_linter <- function(allow_unescaped = FALSE) {
       lint_message = msg,
       type = "warning"
     )
-  }, linter_level = "expression")
+  })
 }

--- a/R/function_argument_linter.R
+++ b/R/function_argument_linter.R
@@ -59,7 +59,7 @@ function_argument_linter <- function() {
     text() = following-sibling::expr[last()]//expr[expr/SYMBOL_FUNCTION_CALL[text() = 'missing']]/expr[2]/SYMBOL/text()
   "
 
-  Linter(function(source_expression) {
+  Linter(linter_level = "expression", function(source_expression) {
     xml <- source_expression$xml_parsed_content
     if (is.null(xml)) return(list())
 
@@ -76,5 +76,5 @@ function_argument_linter <- function() {
       lint_message = paste0("Arguments without defaults should come before arguments with defaults.", missing_note),
       type = "style"
     )
-  }, linter_level = "expression")
+  })
 }

--- a/R/function_left_parentheses_linter.R
+++ b/R/function_left_parentheses_linter.R
@@ -57,7 +57,7 @@ function_left_parentheses_linter <- function() { # nolint: object_length.
     and @col2 != parent::expr/following-sibling::OP-LEFT-PAREN/@col1 - 1
   ]"
 
-  Linter(function(source_expression) {
+  Linter(linter_level = "expression", function(source_expression) {
     xml <- source_expression$xml_parsed_content
     if (is.null(xml)) return(list())
 
@@ -94,5 +94,5 @@ function_left_parentheses_linter <- function() { # nolint: object_length.
     )
 
     c(bad_line_fun_lints, bad_line_call_lints, bad_col_fun_lints, bad_col_call_lints)
-  }, linter_level = "expression")
+  })
 }

--- a/R/if_not_else_linter.R
+++ b/R/if_not_else_linter.R
@@ -83,7 +83,7 @@ if_not_else_linter <- function(exceptions = c("is.null", "is.na", "missing")) {
     ]]
   ")
 
-  Linter(function(source_expression) {
+  Linter(linter_level = "expression", function(source_expression) {
     xml <- source_expression$xml_parsed_content
     if (is.null(xml)) return(list())
 
@@ -111,5 +111,5 @@ if_not_else_linter <- function(exceptions = c("is.null", "is.na", "missing")) {
     )
 
     c(if_lints, ifelse_lints)
-  }, linter_level = "expression")
+  })
 }

--- a/R/if_switch_linter.R
+++ b/R/if_switch_linter.R
@@ -61,7 +61,7 @@ if_switch_linter <- function() {
     ]
   ")
 
-  Linter(function(source_expression) {
+  Linter(linter_level = "expression", function(source_expression) {
     xml <- source_expression$xml_parsed_content
     if (is.null(xml)) return(list())
 
@@ -77,5 +77,5 @@ if_switch_linter <- function() {
       ),
       type = "warning"
     )
-  }, linter_level = "expression")
+  })
 }

--- a/R/ifelse_censor_linter.R
+++ b/R/ifelse_censor_linter.R
@@ -46,7 +46,7 @@ ifelse_censor_linter <- function() {
     /parent::expr
   ")
 
-  Linter(function(source_expression) {
+  Linter(linter_level = "expression", function(source_expression) {
     xml <- source_expression$xml_parsed_content
     if (is.null(xml)) return(list())
 
@@ -70,5 +70,5 @@ ifelse_censor_linter <- function() {
       ),
       type = "warning"
     )
-  }, linter_level = "expression")
+  })
 }

--- a/R/implicit_assignment_linter.R
+++ b/R/implicit_assignment_linter.R
@@ -102,7 +102,7 @@ implicit_assignment_linter <- function(except = c("bquote", "expression", "expr"
     )
   }
 
-  Linter(function(source_expression) {
+  Linter(linter_level = "file", function(source_expression) {
     # need the full file to also catch usages at the top level
     xml <- source_expression$full_xml_parsed_content
     if (is.null(xml)) return(list())
@@ -120,5 +120,5 @@ implicit_assignment_linter <- function(except = c("bquote", "expression", "expr"
       lint_message = lint_message,
       type = "warning"
     )
-  }, linter_level = "file")
+  })
 }

--- a/R/implicit_integer_linter.R
+++ b/R/implicit_integer_linter.R
@@ -51,7 +51,7 @@ implicit_integer_linter <- function(allow_colon = FALSE) {
   } else {
     xpath <- "//NUM_CONST"
   }
-  Linter(function(source_expression) {
+  Linter(linter_level = "file", function(source_expression) {
     xml <- source_expression$full_xml_parsed_content
     if (is.null(xml)) return(list())
 
@@ -65,7 +65,7 @@ implicit_integer_linter <- function(allow_colon = FALSE) {
       column_number_xpath = "number(./@col2 + 1)", # mark at end
       range_end_xpath = "number(./@col2 + 1)" # end after number for easy fixing (enter "L" or ".0")
     )
-  }, linter_level = "file")
+  })
 }
 
 is_implicit_integer <- function(s) {

--- a/R/indentation_linter.R
+++ b/R/indentation_linter.R
@@ -204,7 +204,7 @@ indentation_linter <- function(indent = 2L, hanging_indent_style = c("tidy", "al
 
   xp_multiline_string <- "//STR_CONST[@line1 < @line2]"
 
-  Linter(function(source_expression) {
+  Linter(linter_level = "file", function(source_expression) {
     # must run on file level because a line can contain multiple expressions, losing indentation information, e.g.
     #
     #> fun(
@@ -304,7 +304,7 @@ indentation_linter <- function(indent = 2L, hanging_indent_style = c("tidy", "al
     } else {
       list()
     }
-  }, linter_level = "file")
+  })
 }
 
 find_new_indent <- function(current_indent, change_type, indent, hanging_indent) {

--- a/R/infix_spaces_linter.R
+++ b/R/infix_spaces_linter.R
@@ -105,7 +105,7 @@ infix_spaces_linter <- function(exclude_operators = NULL, allow_multiple_spaces 
     )
   ]")
 
-  Linter(function(source_expression) {
+  Linter(linter_level = "expression", function(source_expression) {
     xml <- source_expression$xml_parsed_content
     if (is.null(xml)) return(list())
     bad_expr <- xml_find_all(xml, xpath)
@@ -116,5 +116,5 @@ infix_spaces_linter <- function(exclude_operators = NULL, allow_multiple_spaces 
       lint_message = lint_message,
       type = "style"
     )
-  }, linter_level = "expression")
+  })
 }

--- a/R/inner_combine_linter.R
+++ b/R/inner_combine_linter.R
@@ -83,7 +83,7 @@ inner_combine_linter <- function() {
     /parent::expr
   ")
 
-  Linter(function(source_expression) {
+  Linter(linter_level = "expression", function(source_expression) {
     xml <- source_expression$xml_parsed_content
     if (is.null(xml)) return(list())
 
@@ -98,7 +98,7 @@ inner_combine_linter <- function() {
       )
     )
     xml_nodes_to_lints(bad_expr, source_expression = source_expression, lint_message, type = "warning")
-  }, linter_level = "expression")
+  })
 }
 
 #' Make the XPath condition ensuring an argument matches across calls

--- a/R/is_numeric_linter.R
+++ b/R/is_numeric_linter.R
@@ -69,7 +69,7 @@ is_numeric_linter <- function() {
     /parent::expr
   "
 
-  Linter(function(source_expression) {
+  Linter(linter_level = "expression", function(source_expression) {
     xml <- source_expression$xml_parsed_content
     if (is.null(xml)) return(list())
 
@@ -104,5 +104,5 @@ is_numeric_linter <- function() {
     )
 
     c(or_lints, class_lints)
-  }, linter_level = "expression")
+  })
 }

--- a/R/keyword_quote_linter.R
+++ b/R/keyword_quote_linter.R
@@ -94,7 +94,7 @@ keyword_quote_linter <- function() {
   no_quote_msg <- "Use backticks to create non-syntactic names, not quotes."
   clarification <- "i.e., if the name is not a valid R symbol (see ?make.names)."
 
-  Linter(function(source_expression) {
+  Linter(linter_level = "expression", function(source_expression) {
     xml <- source_expression$xml_parsed_content
     if (is.null(xml)) return(list())
 
@@ -157,5 +157,5 @@ keyword_quote_linter <- function() {
     )
 
     c(call_arg_lints, string_assignment_lints, assignment_lints, string_extraction_lints, extraction_lints)
-  }, linter_level = "expression")
+  })
 }

--- a/R/length_test_linter.R
+++ b/R/length_test_linter.R
@@ -27,7 +27,7 @@ length_test_linter <- function() {
     /parent::expr
   ")
 
-  Linter(function(source_expression) {
+  Linter(linter_level = "expression", function(source_expression) {
     xml <- source_expression$xml_parsed_content
     if (is.null(xml)) return(list())
 
@@ -44,5 +44,5 @@ length_test_linter <- function() {
       lint_message = lint_message,
       type = "warning"
     )
-  }, linter_level = "expression")
+  })
 }

--- a/R/library_call_linter.R
+++ b/R/library_call_linter.R
@@ -148,7 +148,7 @@ library_call_linter <- function(allow_preamble = TRUE) {
     ]
   ")
 
-  Linter(function(source_expression) {
+  Linter(linter_level = "file", function(source_expression) {
     xml <- source_expression$full_xml_parsed_content
     if (is.null(xml)) return(list())
 
@@ -210,5 +210,5 @@ library_call_linter <- function(allow_preamble = TRUE) {
     )
 
     c(upfront_call_lints, char_only_direct_lints, char_only_indirect_lints, consecutive_suppress_lints)
-  }, linter_level = "file")
+  })
 }

--- a/R/line_length_linter.R
+++ b/R/line_length_linter.R
@@ -25,7 +25,7 @@
 line_length_linter <- function(length = 80L) {
   general_msg <- paste("Lines should not be more than", length, "characters.")
 
-  Linter(function(source_expression) {
+  Linter(linter_level = "file", function(source_expression) {
     # Only go over complete file
     line_lengths <- nchar(source_expression$file_lines)
     long_lines <- which(line_lengths > length)
@@ -45,5 +45,5 @@ line_length_linter <- function(length = 80L) {
       long_lines,
       line_lengths[long_lines]
     )
-  }, linter_level = "file")
+  })
 }

--- a/R/list_comparison_linter.R
+++ b/R/list_comparison_linter.R
@@ -39,7 +39,7 @@ list_comparison_linter <- function() {
     /parent::expr[{ xp_or(infix_metadata$xml_tag[infix_metadata$comparator]) }]
   ")
 
-  Linter(function(source_expression) {
+  Linter(linter_level = "expression", function(source_expression) {
     xml <- source_expression$xml_parsed_content
     if (is.null(xml)) return(list())
 
@@ -63,5 +63,5 @@ list_comparison_linter <- function() {
       lint_message = lint_message,
       type = "warning"
     )
-  }, linter_level = "expression")
+  })
 }

--- a/R/literal_coercion_linter.R
+++ b/R/literal_coercion_linter.R
@@ -73,7 +73,7 @@ literal_coercion_linter <- function() {
     ]
   ")
 
-  Linter(function(source_expression) {
+  Linter(linter_level = "expression", function(source_expression) {
     xml <- source_expression$xml_parsed_content
     if (is.null(xml)) return(list())
 
@@ -117,5 +117,5 @@ literal_coercion_linter <- function() {
       lint_message = lint_message,
       type = "warning"
     )
-  }, linter_level = "expression")
+  })
 }

--- a/R/make_linter_from_regex.R
+++ b/R/make_linter_from_regex.R
@@ -2,7 +2,7 @@ make_linter_from_regex <- function(regex,
                                    lint_type,
                                    lint_msg) {
   function() {
-    Linter(function(source_expression) {
+    Linter(linter_level = "file", function(source_expression) {
       all_matches <- re_matches(
         source_expression[["file_lines"]],
         regex,
@@ -28,7 +28,7 @@ make_linter_from_regex <- function(regex,
         )
       })
       lints[lengths(lints) > 0L]
-    }, linter_level = "file")
+    })
   }
 }
 

--- a/R/make_linter_from_xpath.R
+++ b/R/make_linter_from_xpath.R
@@ -23,7 +23,7 @@ make_linter_from_xpath <- function(xpath,
   xml_key <- if (level == "expression") "xml_parsed_content" else "full_xml_parsed_content"
 
   function() {
-    Linter(function(source_expression) {
+    Linter(linter_level = level, function(source_expression) {
       xml <- source_expression[[xml_key]]
       if (is.null(xml)) return(list())
 
@@ -35,6 +35,6 @@ make_linter_from_xpath <- function(xpath,
         lint_message = lint_message,
         type = type
       )
-    }, linter_level = level)
+    })
   }
 }

--- a/R/matrix_apply_linter.R
+++ b/R/matrix_apply_linter.R
@@ -76,7 +76,7 @@ matrix_apply_linter <- function() {
   margin_xpath <- "expr[position() = 3]"
   fun_xpath <- "expr[position() = 4]"
 
-  Linter(function(source_expression) {
+  Linter(linter_level = "expression", function(source_expression) {
     xml <- source_expression$xml_parsed_content
     if (is.null(xml)) return(list())
 
@@ -101,7 +101,7 @@ matrix_apply_linter <- function() {
       lint_message = sprintf("Use %1$s rather than %2$s", recos, get_r_string(bad_expr)),
       type = "warning"
     )
-  }, linter_level = "expression")
+  })
 }
 
 craft_colsums_rowsums_msg <- function(variable, margin, fun, narm_val) {

--- a/R/missing_argument_linter.R
+++ b/R/missing_argument_linter.R
@@ -43,7 +43,7 @@ missing_argument_linter <- function(except = c("alist", "quote", "switch"), allo
   xpath <- glue("//SYMBOL_FUNCTION_CALL/parent::expr/parent::expr/*[{xp_or(conds)}]")
   to_function_xpath <- "string(./preceding-sibling::expr[last()]/SYMBOL_FUNCTION_CALL)"
 
-  Linter(function(source_expression) {
+  Linter(linter_level = "file", function(source_expression) {
     xml <- source_expression$full_xml_parsed_content
     if (is.null(xml)) return(list())
 
@@ -55,5 +55,5 @@ missing_argument_linter <- function(except = c("alist", "quote", "switch"), allo
       source_expression = source_expression,
       lint_message = "Missing argument in function call."
     )
-  }, linter_level = "file")
+  })
 }

--- a/R/missing_package_linter.R
+++ b/R/missing_package_linter.R
@@ -42,7 +42,7 @@ missing_package_linter <- function() {
   "
   call_xpath <- paste(library_require_xpath, "|", load_require_namespace_xpath)
 
-  Linter(function(source_expression) {
+  Linter(linter_level = "file", function(source_expression) {
     xml <- source_expression$full_xml_parsed_content
     if (is.null(xml)) return(list())
 
@@ -62,5 +62,5 @@ missing_package_linter <- function() {
       lint_message = sprintf("Package '%s' is not installed.", pkg_names[missing_pkgs]),
       type = "warning"
     )
-  }, linter_level = "file")
+  })
 }

--- a/R/namespace_linter.R
+++ b/R/namespace_linter.R
@@ -39,7 +39,7 @@
 #' @seealso [linters] for a complete list of linters available in lintr.
 #' @export
 namespace_linter <- function(check_exports = TRUE, check_nonexports = TRUE) {
-  Linter(function(source_expression) {
+  Linter(linter_level = "file", function(source_expression) {
     xml <- source_expression$full_xml_parsed_content
     if (is.null(xml)) return(list())
 
@@ -117,7 +117,7 @@ namespace_linter <- function(check_exports = TRUE, check_nonexports = TRUE) {
     }
 
     lints
-  }, linter_level = "file")
+  })
 }
 
 namespace_symbols <- function(ns, exported = TRUE) {

--- a/R/nested_ifelse_linter.R
+++ b/R/nested_ifelse_linter.R
@@ -86,7 +86,7 @@ nested_ifelse_linter <- function() {
     /following-sibling::expr[expr[1][SYMBOL_FUNCTION_CALL[ {xp_text_in_table(ifelse_funs)} ]]]
   ")
 
-  Linter(function(source_expression) {
+  Linter(linter_level = "expression", function(source_expression) {
     xml <- source_expression$xml_parsed_content
     if (is.null(xml)) return(list())
 
@@ -98,5 +98,5 @@ nested_ifelse_linter <- function() {
       "instead, try (1) data.table::fcase; (2) dplyr::case_when; or (3) using a lookup table."
     )
     xml_nodes_to_lints(bad_expr, source_expression, lint_message, type = "warning")
-  }, linter_level = "expression")
+  })
 }

--- a/R/nested_pipe_linter.R
+++ b/R/nested_pipe_linter.R
@@ -67,7 +67,7 @@ nested_pipe_linter <- function(
     ]]
   ")
 
-  Linter(function(source_expression) {
+  Linter(linter_level = "expression", function(source_expression) {
     xml <- source_expression$xml_parsed_content
     if (is.null(xml)) return(list())
 
@@ -79,5 +79,5 @@ nested_pipe_linter <- function(
       lint_message = "Don't nest pipes inside other calls.",
       type = "warning"
     )
-  }, linter_level = "expression")
+  })
 }

--- a/R/nzchar_linter.R
+++ b/R/nzchar_linter.R
@@ -92,7 +92,7 @@ nzchar_linter <- function() {
     "nzchar(NA) is TRUE by default."
   )
 
-  Linter(function(source_expression) {
+  Linter(linter_level = "expression", function(source_expression) {
     xml <- source_expression$xml_parsed_content
     if (is.null(xml)) return(list())
 
@@ -121,5 +121,5 @@ nzchar_linter <- function() {
     )
 
     c(comparison_lints, nchar_lints)
-  }, linter_level = "expression")
+  })
 }

--- a/R/object_length_linter.R
+++ b/R/object_length_linter.R
@@ -37,7 +37,7 @@
 object_length_linter <- function(length = 30L) {
   lint_message <- paste("Variable and function names should not be longer than", length, "characters.")
 
-  Linter(function(source_expression) {
+  Linter(linter_level = "file", function(source_expression) {
     xml <- source_expression$full_xml_parsed_content
     if (is.null(xml)) return(list())
 
@@ -71,5 +71,5 @@ object_length_linter <- function(length = 30L) {
       lint_message = lint_message,
       type = "style"
     )
-  }, linter_level = "file")
+  })
 }

--- a/R/object_name_linter.R
+++ b/R/object_name_linter.R
@@ -110,7 +110,7 @@ object_name_linter <- function(styles = c("snake_case", "symbols"), regexes = ch
     glue_collapse(unique(names(style_list)), sep = ", ", last = " or "), "."
   )
 
-  Linter(function(source_expression) {
+  Linter(linter_level = "file", function(source_expression) {
     xml <- source_expression$full_xml_parsed_content
     if (is.null(xml)) return(list())
 
@@ -143,7 +143,7 @@ object_name_linter <- function(styles = c("snake_case", "symbols"), regexes = ch
       lint_message = lint_message,
       type = "style"
     )
-  }, linter_level = "file")
+  })
 }
 
 check_style <- function(nms, style, generics = character()) {

--- a/R/object_overwrite_linter.R
+++ b/R/object_overwrite_linter.R
@@ -93,7 +93,7 @@ object_overwrite_linter <- function(
       ]
   ")
 
-  Linter(function(source_expression) {
+  Linter(linter_level = "expression", function(source_expression) {
     xml <- source_expression$xml_parsed_content
     if (is.null(xml)) return(list())
 
@@ -114,5 +114,5 @@ object_overwrite_linter <- function(
       lint_message = lint_message,
       type = "warning"
     )
-  }, linter_level = "expression")
+  })
 }

--- a/R/object_usage_linter.R
+++ b/R/object_usage_linter.R
@@ -52,7 +52,7 @@ object_usage_linter <- function(interpret_glue = TRUE, skip_with = TRUE) {
     | descendant::LEFT_ASSIGN[text() = ':=']
   ")
 
-  Linter(function(source_expression) {
+  Linter(linter_level = "file", function(source_expression) {
     pkg_name <- pkg_name(find_package(dirname(source_expression$filename)))
 
     declared_globals <- try_silently(globalVariables(package = pkg_name %||% globalenv()))
@@ -123,7 +123,7 @@ object_usage_linter <- function(interpret_glue = TRUE, skip_with = TRUE) {
 
       xml_nodes_to_lints(nodes, source_expression = source_expression, lint_message = res$message, type = "warning")
     })
-  }, linter_level = "file")
+  })
 }
 
 make_check_env <- function(pkg_name, xml) {

--- a/R/one_call_pipe_linter.R
+++ b/R/one_call_pipe_linter.R
@@ -65,7 +65,7 @@ one_call_pipe_linter <- function() {
     ]
   ")
 
-  Linter(function(source_expression) {
+  Linter(linter_level = "expression", function(source_expression) {
     xml <- source_expression$xml_parsed_content
     if (is.null(xml)) return(list())
 
@@ -78,5 +78,5 @@ one_call_pipe_linter <- function() {
       lint_message = paste0("Expressions with only a single call shouldn't use pipe ", pipe, "."),
       type = "warning"
     )
-  }, linter_level = "expression")
+  })
 }

--- a/R/outer_negation_linter.R
+++ b/R/outer_negation_linter.R
@@ -50,7 +50,7 @@ outer_negation_linter <- function() {
     ]
   "
 
-  Linter(function(source_expression) {
+  Linter(linter_level = "expression", function(source_expression) {
     xml <- source_expression$xml_parsed_content
     if (is.null(xml)) return(list())
 
@@ -64,5 +64,5 @@ outer_negation_linter <- function() {
     )
 
     xml_nodes_to_lints(bad_expr, source_expression, lint_message, type = "warning")
-  }, linter_level = "expression")
+  })
 }

--- a/R/package_hooks_linter.R
+++ b/R/package_hooks_linter.R
@@ -126,7 +126,7 @@ package_hooks_linter <- function() {
     ]
   "
 
-  Linter(function(source_expression) {
+  Linter(linter_level = "file", function(source_expression) {
     xml <- source_expression$full_xml_parsed_content
     if (is.null(xml)) return(list())
 
@@ -199,5 +199,5 @@ package_hooks_linter <- function() {
       bad_unload_call_lints,
       unload_arg_name_lints
     )
-  }, linter_level = "file")
+  })
 }

--- a/R/paste_linter.R
+++ b/R/paste_linter.R
@@ -161,7 +161,7 @@ paste_linter <- function(allow_empty_sep = FALSE,
   empty_paste_note <-
     'Note that paste() converts empty inputs to "", whereas file.path() leaves it empty.'
 
-  Linter(function(source_expression) {
+  Linter(linter_level = "expression", function(source_expression) {
     xml <- source_expression$xml_parsed_content
     if (is.null(xml)) return(list())
     optional_lints <- list()
@@ -251,7 +251,7 @@ paste_linter <- function(allow_empty_sep = FALSE,
     }
 
     c(optional_lints, paste0_sep_lints, paste_strrep_lints)
-  }, linter_level = "expression")
+  })
 }
 
 check_is_not_file_path <- function(expr, allow_file_path) {

--- a/R/path_utils.R
+++ b/R/path_utils.R
@@ -136,7 +136,7 @@ split_path <- function(dirs, prefix) {
 #' @include utils.R
 path_linter_factory <- function(path_function, message, linter, name = linter_auto_name()) {
   force(name)
-  Linter(function(source_expression) {
+  Linter(name = name, linter_level = "expression", function(source_expression) {
     lapply(
       ids_with_token(source_expression, "STR_CONST"),
       function(id) {
@@ -157,5 +157,5 @@ path_linter_factory <- function(path_function, message, linter, name = linter_au
         }
       }
     )
-  }, name = name, linter_level = "expression")
+  })
 }

--- a/R/pipe_call_linter.R
+++ b/R/pipe_call_linter.R
@@ -26,7 +26,7 @@ pipe_call_linter <- function() {
   pipes <- setdiff(magrittr_pipes, "%$%")
   xpath <- glue("//SPECIAL[{ xp_text_in_table(pipes) }]/following-sibling::expr[*[1][self::SYMBOL]]")
 
-  Linter(function(source_expression) {
+  Linter(linter_level = "expression", function(source_expression) {
     xml <- source_expression$xml_parsed_content
     if (is.null(xml)) return(list())
 
@@ -40,5 +40,5 @@ pipe_call_linter <- function() {
         sprintf("Use explicit calls in magrittr pipes, i.e., `a %1$s foo` should be `a %1$s foo()`.", pipe),
       type = "warning"
     )
-  }, linter_level = "expression")
+  })
 }

--- a/R/pipe_consistency_linter.R
+++ b/R/pipe_consistency_linter.R
@@ -38,7 +38,7 @@ pipe_consistency_linter <- function(pipe = c("auto", "%>%", "|>")) {
   xpath_magrittr <- glue("//SPECIAL[{ xp_text_in_table(magrittr_pipes) }]")
   xpath_native <- "//PIPE"
 
-  Linter(function(source_expression) {
+  Linter(linter_level = "file", function(source_expression) {
     xml <- source_expression$full_xml_parsed_content
     if (is.null(xml)) return(list())
 
@@ -75,5 +75,5 @@ pipe_consistency_linter <- function(pipe = c("auto", "%>%", "|>")) {
     } else {
       list()
     }
-  }, linter_level = "file")
+  })
 }

--- a/R/pipe_continuation_linter.R
+++ b/R/pipe_continuation_linter.R
@@ -67,7 +67,7 @@ pipe_continuation_linter <- function() {
   ]
   ")
 
-  Linter(function(source_expression) {
+  Linter(linter_level = "file", function(source_expression) {
     xml <- source_expression$full_xml_parsed_content
     if (is.null(xml)) return(list())
 
@@ -83,5 +83,5 @@ pipe_continuation_linter <- function() {
       ),
       type = "style"
     )
-  }, linter_level = "file")
+  })
 }

--- a/R/quotes_linter.R
+++ b/R/quotes_linter.R
@@ -60,12 +60,12 @@ quotes_linter <- function(delimiter = c('"', "'")) {
     lint_message <- "Only use single-quotes."
   }
 
-  Linter(function(source_expression) {
+  Linter(linter_level = "expression", function(source_expression) {
     xml <- source_expression$xml_parsed_content
     if (is.null(xml)) return(list())
     string_exprs <- xml_find_all(xml, "//STR_CONST")
     is_bad <- re_matches(xml_text(string_exprs), quote_regex)
 
     xml_nodes_to_lints(string_exprs[is_bad], source_expression, lint_message)
-  }, linter_level = "expression")
+  })
 }

--- a/R/redundant_equals_linter.R
+++ b/R/redundant_equals_linter.R
@@ -43,7 +43,7 @@ redundant_equals_linter <- function() {
     /parent::expr
   "
 
-  Linter(function(source_expression) {
+  Linter(linter_level = "expression", function(source_expression) {
     xml <- source_expression$xml_parsed_content
     if (is.null(xml)) return(list())
 
@@ -60,5 +60,5 @@ redundant_equals_linter <- function() {
       ),
       type = "warning"
     )
-  }, linter_level = "expression")
+  })
 }

--- a/R/redundant_ifelse_linter.R
+++ b/R/redundant_ifelse_linter.R
@@ -70,7 +70,7 @@ redundant_ifelse_linter <- function(allow10 = FALSE) {
     ]
   ")
 
-  Linter(function(source_expression) {
+  Linter(linter_level = "expression", function(source_expression) {
     xml <- source_expression$xml_parsed_content
     if (is.null(xml)) return(list())
     lints <- list()
@@ -106,5 +106,5 @@ redundant_ifelse_linter <- function(allow10 = FALSE) {
     }
 
     lints
-  }, linter_level = "expression")
+  })
 }

--- a/R/regex_subset_linter.R
+++ b/R/regex_subset_linter.R
@@ -67,7 +67,7 @@ regex_subset_linter <- function() {
   grep_xpath <- glue(xpath_fmt, calls = c("grepl", "grep"), arg_pos = 3L)
   stringr_xpath <- glue(xpath_fmt, calls = c("str_detect", "str_which"), arg_pos = 2L)
 
-  Linter(function(source_expression) {
+  Linter(linter_level = "expression", function(source_expression) {
     xml <- source_expression$xml_parsed_content
     if (is.null(xml)) return(list())
 
@@ -92,5 +92,5 @@ regex_subset_linter <- function() {
     )
 
     c(grep_lints, stringr_lints)
-  }, linter_level = "expression")
+  })
 }

--- a/R/repeat_linter.R
+++ b/R/repeat_linter.R
@@ -22,7 +22,7 @@
 repeat_linter <- function() {
   xpath <- "//WHILE[following-sibling::expr[1]/NUM_CONST[text() = 'TRUE']]"
 
-  Linter(function(source_expression) {
+  Linter(linter_level = "expression", function(source_expression) {
     xml <- source_expression$xml_parsed_content
     if (is.null(xml)) return(list())
     lints <- xml_find_all(xml, xpath)
@@ -34,5 +34,5 @@ repeat_linter <- function() {
       range_start_xpath = "number(./@col1)",
       range_end_xpath = "number(./following-sibling::*[3]/@col2)"
     )
-  }, linter_level = "expression")
+  })
 }

--- a/R/return_linter.R
+++ b/R/return_linter.R
@@ -157,7 +157,7 @@ return_linter <- function(
     msg <- "All functions must have an explicit return()."
   }
 
-  Linter(function(source_expression) {
+  Linter(linter_level = "expression", function(source_expression) {
     xml <- source_expression$xml_parsed_content
     if (is.null(xml)) return(list())
 
@@ -169,5 +169,5 @@ return_linter <- function(
       lint_message = msg,
       type = "style"
     )
-  }, linter_level = "expression")
+  })
 }

--- a/R/sample_int_linter.R
+++ b/R/sample_int_linter.R
@@ -65,7 +65,7 @@ sample_int_linter <- function() {
     /parent::expr
   ")
 
-  Linter(function(source_expression) {
+  Linter(linter_level = "expression", function(source_expression) {
     xml <- source_expression$xml_parsed_content
     if (is.null(xml)) return(list())
 
@@ -81,5 +81,5 @@ sample_int_linter <- function() {
       lint_message = glue("sample.int(n, m, ...) is preferable to sample({original}, m, ...)."),
       type = "warning"
     )
-  }, linter_level = "expression")
+  })
 }

--- a/R/scalar_in_linter.R
+++ b/R/scalar_in_linter.R
@@ -37,7 +37,7 @@ scalar_in_linter <- function() {
     /parent::expr
   "
 
-  Linter(function(source_expression) {
+  Linter(linter_level = "expression", function(source_expression) {
     xml <- source_expression$xml_parsed_content
     if (is.null(xml)) return(list())
 
@@ -52,5 +52,5 @@ scalar_in_linter <- function() {
       lint_message = lint_msg,
       type = "warning"
     )
-  }, linter_level = "expression")
+  })
 }

--- a/R/semicolon_linter.R
+++ b/R/semicolon_linter.R
@@ -82,7 +82,7 @@ semicolon_linter <- function(allow_compound = FALSE, allow_trailing = FALSE) {
   }
   compound_xpath <- "self::*[@line1 = following-sibling::*[1]/@line1]"
 
-  Linter(function(source_expression) {
+  Linter(linter_level = "file", function(source_expression) {
     xml <- source_expression$full_xml_parsed_content
     if (is.null(xml)) return(list())
     bad_exprs <- xml_find_all(xml, xpath)
@@ -96,5 +96,5 @@ semicolon_linter <- function(allow_compound = FALSE, allow_trailing = FALSE) {
       source_expression = source_expression,
       lint_message = msg
     )
-  }, linter_level = "file")
+  })
 }

--- a/R/seq_linter.R
+++ b/R/seq_linter.R
@@ -86,7 +86,7 @@ seq_linter <- function() {
     fun
   }
 
-  Linter(function(source_expression) {
+  Linter(linter_level = "expression", function(source_expression) {
     xml <- source_expression$xml_parsed_content
     if (is.null(xml)) return(list())
 
@@ -114,5 +114,5 @@ seq_linter <- function() {
     )
 
     xml_nodes_to_lints(badx, source_expression, lint_message, type = "warning")
-  }, linter_level = "expression")
+  })
 }

--- a/R/sort_linter.R
+++ b/R/sort_linter.R
@@ -98,7 +98,7 @@ sort_linter <- function() {
 
   arg_values_xpath <- glue("{arguments_xpath}/following-sibling::expr[1]")
 
-  Linter(function(source_expression) {
+  Linter(linter_level = "expression", function(source_expression) {
     xml <- source_expression$xml_parsed_content
     if (is.null(xml)) return(list())
 
@@ -148,5 +148,5 @@ sort_linter <- function() {
     )
 
     c(order_lints, sorted_lints)
-  }, linter_level = "expression")
+  })
 }

--- a/R/spaces_inside_linter.R
+++ b/R/spaces_inside_linter.R
@@ -52,7 +52,7 @@ spaces_inside_linter <- function() {
   //OP-RIGHT-BRACKET[{right_xpath_condition}]
   | //OP-RIGHT-PAREN[{right_xpath_condition} and not(preceding-sibling::*[1][self::EQ_SUB])]")
 
-  Linter(function(source_expression) {
+  Linter(linter_level = "file", function(source_expression) {
     xml <- source_expression$full_xml_parsed_content
     if (is.null(xml)) return(list())
 
@@ -87,5 +87,5 @@ spaces_inside_linter <- function() {
     )
 
     c(left_lints, right_lints)
-  }, linter_level = "file")
+  })
 }

--- a/R/sprintf_linter.R
+++ b/R/sprintf_linter.R
@@ -104,7 +104,7 @@ sprintf_linter <- function() {
     }
   }
 
-  Linter(function(source_expression) {
+  Linter(linter_level = "file", function(source_expression) {
     xml <- source_expression$full_xml_parsed_content
     if (is.null(xml)) return(list())
 
@@ -119,5 +119,5 @@ sprintf_linter <- function() {
       lint_message = sprintf_warning[has_warning],
       type = "warning"
     )
-  }, linter_level = "file")
+  })
 }

--- a/R/string_boundary_linter.R
+++ b/R/string_boundary_linter.R
@@ -119,7 +119,7 @@ string_boundary_linter <- function(allow_grepl = FALSE) {
 
   substr_arg2_xpath <- "string(./expr[expr[1][SYMBOL_FUNCTION_CALL]]/expr[3])"
 
-  Linter(function(source_expression) {
+  Linter(linter_level = "expression", function(source_expression) {
     xml <- source_expression$xml_parsed_content
     if (is.null(xml)) return(list())
     lints <- list()
@@ -174,5 +174,5 @@ string_boundary_linter <- function(allow_grepl = FALSE) {
 
     lints <- c(lints, xml_nodes_to_lints(substr_expr, source_expression, substr_lint_message, type = "warning"))
     lints
-  }, linter_level = "expression")
+  })
 }

--- a/R/strings_as_factors_linter.R
+++ b/R/strings_as_factors_linter.R
@@ -82,7 +82,7 @@ strings_as_factors_linter <- function() {
     ]
   ")
 
-  Linter(function(source_expression) {
+  Linter(linter_level = "expression", function(source_expression) {
     xml <- source_expression$xml_parsed_content
     if (is.null(xml)) return(list())
 
@@ -99,5 +99,5 @@ strings_as_factors_linter <- function() {
       ),
       type = "warning"
     )
-  }, linter_level = "expression")
+  })
 }

--- a/R/system_file_linter.R
+++ b/R/system_file_linter.R
@@ -34,7 +34,7 @@ system_file_linter <- function() {
   ")
   xpath <- paste(xpath_parts, collapse = " | ")
 
-  Linter(function(source_expression) {
+  Linter(linter_level = "expression", function(source_expression) {
     xml <- source_expression$xml_parsed_content
     if (is.null(xml)) return(list())
 
@@ -52,5 +52,5 @@ system_file_linter <- function() {
     )
 
     xml_nodes_to_lints(bad_expr, source_expression, lint_message, type = "warning")
-  }, linter_level = "expression")
+  })
 }

--- a/R/trailing_whitespace_linter.R
+++ b/R/trailing_whitespace_linter.R
@@ -41,7 +41,7 @@
 #' @seealso [linters] for a complete list of linters available in lintr.
 #' @export
 trailing_whitespace_linter <- function(allow_empty_lines = FALSE, allow_in_strings = TRUE) {
-  Linter(function(source_expression) {
+  Linter(linter_level = "file", function(source_expression) {
     res <- re_matches(
       source_expression$file_lines,
       rex(blanks, end),
@@ -77,5 +77,5 @@ trailing_whitespace_linter <- function(allow_empty_lines = FALSE, allow_in_strin
         )
       }
     )
-  }, linter_level = "file")
+  })
 }

--- a/R/undesirable_function_linter.R
+++ b/R/undesirable_function_linter.R
@@ -79,7 +79,7 @@ undesirable_function_linter <- function(fun = default_undesirable_functions,
   }
 
 
-  Linter(function(source_expression) {
+  Linter(linter_level = "expression", function(source_expression) {
     xml <- source_expression$xml_parsed_content
     if (is.null(xml)) return(list())
     matched_nodes <- xml_find_all(xml, xpath)
@@ -103,5 +103,5 @@ undesirable_function_linter <- function(fun = default_undesirable_functions,
       source_expression = source_expression,
       lint_message = unname(msgs[fun_names])
     )
-  }, linter_level = "expression")
+  })
 }

--- a/R/undesirable_operator_linter.R
+++ b/R/undesirable_operator_linter.R
@@ -63,7 +63,7 @@ undesirable_operator_linter <- function(op = default_undesirable_operators) {
 
   xpath <- paste(paste0("//", operator_nodes), collapse = " | ")
 
-  Linter(function(source_expression) {
+  Linter(linter_level = "expression", function(source_expression) {
     xml <- source_expression$xml_parsed_content
     if (is.null(xml)) return(list())
 
@@ -76,5 +76,5 @@ undesirable_operator_linter <- function(op = default_undesirable_operators) {
     lint_message[has_alternative] <- paste(lint_message[has_alternative], alternative[has_alternative])
 
     xml_nodes_to_lints(bad_op, source_expression, lint_message, type = "warning")
-  }, linter_level = "expression")
+  })
 }

--- a/R/unnecessary_concatenation_linter.R
+++ b/R/unnecessary_concatenation_linter.R
@@ -99,7 +99,7 @@ unnecessary_concatenation_linter <- function(allow_single_expression = TRUE) { #
   ")
   num_args_xpath <- "count(./expr) - 1"
 
-  Linter(function(source_expression) {
+  Linter(linter_level = "expression", function(source_expression) {
     xml <- source_expression$xml_parsed_content
     if (is.null(xml)) return(list())
     c_calls <- xml_find_all(xml, call_xpath)
@@ -124,5 +124,5 @@ unnecessary_concatenation_linter <- function(allow_single_expression = TRUE) { #
       source_expression = source_expression,
       lint_message = msg
     )
-  }, linter_level = "expression")
+  })
 }

--- a/R/unnecessary_lambda_linter.R
+++ b/R/unnecessary_lambda_linter.R
@@ -159,7 +159,7 @@ unnecessary_lambda_linter <- function(allow_comparison = FALSE) {
   # path to the symbol of the simpler function that avoids a lambda
   symbol_xpath <- "expr[last()]//expr[SYMBOL_FUNCTION_CALL[text() != 'return']]"
 
-  Linter(function(source_expression) {
+  Linter(linter_level = "expression", function(source_expression) {
     xml <- source_expression$xml_parsed_content
     if (is.null(xml)) return(list())
 
@@ -220,5 +220,5 @@ unnecessary_lambda_linter <- function(allow_comparison = FALSE) {
     )
 
     c(default_fun_lints, inner_comparison_lints, purrr_fun_lints)
-  }, linter_level = "expression")
+  })
 }

--- a/R/unnecessary_nesting_linter.R
+++ b/R/unnecessary_nesting_linter.R
@@ -141,7 +141,7 @@ unnecessary_nesting_linter <- function(allow_assignment = TRUE) {
     ]
   ")
 
-  Linter(function(source_expression) {
+  Linter(linter_level = "expression", function(source_expression) {
     xml <- source_expression$xml_parsed_content
     if (is.null(xml)) return(list())
 
@@ -167,5 +167,5 @@ unnecessary_nesting_linter <- function(allow_assignment = TRUE) {
     )
 
     c(if_else_exit_lints, unnecessary_brace_lints)
-  }, linter_level = "expression")
+  })
 }

--- a/R/unnecessary_placeholder_linter.R
+++ b/R/unnecessary_placeholder_linter.R
@@ -49,7 +49,7 @@ unnecessary_placeholder_linter <- function() {
     ]
   ")
 
-  Linter(function(source_expression) {
+  Linter(linter_level = "expression", function(source_expression) {
     xml <- source_expression$xml_parsed_content
     if (is.null(xml)) return(list())
 
@@ -64,5 +64,5 @@ unnecessary_placeholder_linter <- function() {
       ),
       type = "warning"
     )
-  }, linter_level = "expression")
+  })
 }

--- a/R/unreachable_code_linter.R
+++ b/R/unreachable_code_linter.R
@@ -115,7 +115,7 @@ unreachable_code_linter <- function() {
     expr[!is_nolint_end_comment]
   }
 
-  Linter(function(source_expression) {
+  Linter(linter_level = "expression", function(source_expression) {
     xml <- source_expression$xml_parsed_content
     if (is.null(xml)) return(list())
 
@@ -156,5 +156,5 @@ unreachable_code_linter <- function() {
     )
 
     c(lints_return_stop, lints_next_break, lints_if_while, lints_else)
-  }, linter_level = "expression")
+  })
 }

--- a/R/unused_import_linter.R
+++ b/R/unused_import_linter.R
@@ -74,7 +74,7 @@ unused_import_linter <- function(allow_ns_usage = FALSE,
     sep = " | "
   )
 
-  Linter(function(source_expression) {
+  Linter(linter_level = "file", function(source_expression) {
     xml <- source_expression$full_xml_parsed_content
     if (is.null(xml)) return(list())
 
@@ -135,5 +135,5 @@ unused_import_linter <- function(allow_ns_usage = FALSE,
       paste0("Package '", unused_packages, "' is attached but never used.")
     )
     xml_nodes_to_lints(import_exprs, source_expression, lint_message, type = "warning")
-  }, linter_level = "file")
+  })
 }

--- a/R/vector_logic_linter.R
+++ b/R/vector_logic_linter.R
@@ -77,7 +77,7 @@ vector_logic_linter <- function() {
   ]
   "
 
-  Linter(function(source_expression) {
+  Linter(linter_level = "expression", function(source_expression) {
     xml <- source_expression$xml_parsed_content
     if (is.null(xml)) return(list())
     bad_expr <- xml_find_all(xml, xpath)
@@ -88,5 +88,5 @@ vector_logic_linter <- function() {
       lint_message = "Conditional expressions require scalar logical operators (&& and ||)",
       type = "warning"
     )
-  }, linter_level = "expression")
+  })
 }

--- a/R/yoda_test_linter.R
+++ b/R/yoda_test_linter.R
@@ -55,7 +55,7 @@ yoda_test_linter <- function() {
 
   second_const_xpath <- glue("expr[position() = 3 and ({const_condition})]")
 
-  Linter(function(source_expression) {
+  Linter(linter_level = "expression", function(source_expression) {
     xml <- source_expression$xml_parsed_content
     if (is.null(xml)) return(list())
 
@@ -73,5 +73,5 @@ yoda_test_linter <- function() {
     )
 
     xml_nodes_to_lints(bad_expr, source_expression, lint_message, type = "warning")
-  }, linter_level = "expression")
+  })
 }

--- a/vignettes/creating_linters.Rmd
+++ b/vignettes/creating_linters.Rmd
@@ -27,7 +27,7 @@ A good example of a simple linter is the `pipe_call_linter`.
 pipe_call_linter <- function() {
   xpath <- "//expr[preceding-sibling::SPECIAL[text() = '%>%'] and *[1][self::SYMBOL]]"
 
-  Linter(function(source_expression) {
+  Linter(linter_level = "expression", function(source_expression) {
     if (!is_lint_level(source_expression, "expression")) {
       return(list())
     }
@@ -43,7 +43,7 @@ pipe_call_linter <- function() {
       lint_message = "Use explicit calls in magrittr pipes, i.e., `a %>% foo` should be `a %>% foo()`.",
       type = "warning"
     )
-  }, linter_level = "expression")
+  })
 }
 ```
 


### PR DESCRIPTION
Closes #2355

FWIW I did this in VSCode-in-GitHub with the following find-and-replace:

Search pane:

```
\}, linter_level = "(file|expression)")
```

Find-and-replace:

```
Linter\(([\na-zA-Z._;%`()~|&#'"/:*\[\]0-9@+ {}<>!?^$,=-]+\}), (linter_level = "[a-z]+")\)
Linter($2, $1)
```

Note that `.+` doesn't work because it needs to include `\n`.

Two final usages not matching the above pattern were found in clean-up:

```
[^(]linter_level =
```