### PR TITLE
New 'function_body' test helper

### DIFF
--- a/tests/testthat/helper.R
+++ b/tests/testthat/helper.R
@@ -53,9 +53,9 @@ function_body <- function(x, signature = "", assign = TRUE) {
   } else {
     symbol <- ""
   }
-  x <- paste0("      ", unlist(strsplit(trim_some(x), "\n", fixed = TRUE)), collapse = "\n")
-  fmt <- "    %sfunction(%s) {\n%s\n    }"
-  trim_some(sprintf(fmt, symbol, signature, x))
+  x <- paste0("   ", unlist(strsplit(trim_some(x), "\n", fixed = TRUE)), collapse = "\n")
+  fmt <- "%sfunction(%s) {\n%s\n}"
+  sprintf(fmt, symbol, signature, x)
 }
 
 local_config <- function(config_dir, contents, filename = ".lintr", .local_envir = parent.frame()) {

--- a/tests/testthat/helper.R
+++ b/tests/testthat/helper.R
@@ -45,6 +45,19 @@ trim_some <- function(x, num = NULL) {
   rex::re_substitutes(x, rex::rex(start, n_times(any, num)), "", global = TRUE, options = "multi-line")
 }
 
+function_body <- function(x, signature = "", assign = TRUE) {
+  if (is.character(assign)) {
+    symbol <- paste(assign, "<- ")
+  } else if (assign) {
+    symbol <- "foo <- "
+  } else {
+    symbol <- ""
+  }
+  x <- paste0("      ", unlist(strsplit(trim_some(x), "\n", fixed = TRUE)), collapse = "\n")
+  fmt <- "    %sfunction(%s) {\n%s\n    }"
+  trim_some(sprintf(fmt, symbol, signature, x))
+}
+
 local_config <- function(config_dir, contents, filename = ".lintr", .local_envir = parent.frame()) {
   config_path <- file.path(config_dir, filename)
   writeLines(contents, config_path)

--- a/tests/testthat/test-function_return_linter.R
+++ b/tests/testthat/test-function_return_linter.R
@@ -1,7 +1,7 @@
 test_that("function_return_linter skips allowed usages", {
   linter <- function_return_linter()
 
-  lines_simple <- function_body(signature = "x", "
+  lines_simple <- function_body("
     x <- x + 1
     return(x)
   ")
@@ -9,7 +9,7 @@ test_that("function_return_linter skips allowed usages", {
 
   # arguably an expression as complicated as this should also be assigned,
   #   but for now that's out of the scope of this linter
-  lines_subassignment <- function_body(signature = "x", "
+  lines_subassignment <- function_body("
     return(x[, {
       col <- col + 1
       .(grp, col)
@@ -22,13 +22,13 @@ test_that("function_return_linter blocks simple disallowed usages", {
   linter <- function_return_linter()
   lint_msg <- rex::rex("Move the assignment outside of the return() clause")
 
-  expect_lint(function_body(signature = "x", "return(x <- x + 1)"), lint_msg, linter)
+  expect_lint(function_body("return(x <- x + 1)"), lint_msg, linter)
 
-  expect_lint(function_body(signature = "x", "return(x <<- x + 1)"), lint_msg, linter)
+  expect_lint(function_body("return(x <<- x + 1)"), lint_msg, linter)
 
-  expect_lint(function_body(signature = "x", "return(x + 1 ->> x)"), lint_msg, linter)
+  expect_lint(function_body("return(x + 1 ->> x)"), lint_msg, linter)
 
-  expect_lint(function_body(signature = "x", "return(x + 1 -> x)"), lint_msg, linter)
+  expect_lint(function_body("return(x + 1 -> x)"), lint_msg, linter)
 
   expect_lint(
     trim_some("

--- a/tests/testthat/test-function_return_linter.R
+++ b/tests/testthat/test-function_return_linter.R
@@ -22,13 +22,13 @@ test_that("function_return_linter blocks simple disallowed usages", {
   linter <- function_return_linter()
   lint_msg <- rex::rex("Move the assignment outside of the return() clause")
 
-  expect_lint(function_body("return(x <- x + 1)", signature = "x"), lint_msg, linter)
+  expect_lint(function_body(signature = "x", "return(x <- x + 1)"), lint_msg, linter)
 
-  expect_lint(function_body("return(x <<- x + 1)", signature = "x"), lint_msg, linter)
+  expect_lint(function_body(signature = "x", "return(x <<- x + 1)"), lint_msg, linter)
 
-  expect_lint(function_body("return(x + 1 ->> x)", signature = "x"), lint_msg, linter)
+  expect_lint(function_body(signature = "x", "return(x + 1 ->> x)"), lint_msg, linter)
 
-  expect_lint(function_body("return(x + 1 -> x)", signature = "x"), lint_msg, linter)
+  expect_lint(function_body(signature = "x", "return(x + 1 -> x)"), lint_msg, linter)
 
   expect_lint(
     trim_some("

--- a/tests/testthat/test-function_return_linter.R
+++ b/tests/testthat/test-function_return_linter.R
@@ -1,70 +1,36 @@
 test_that("function_return_linter skips allowed usages", {
-  lines_simple <- trim_some("
-    foo <- function(x) {
-      x <- x + 1
-      return(x)
-    }
+  linter <- function_return_linter()
+
+  lines_simple <- function_body(signature = "x", "
+    x <- x + 1
+    return(x)
   ")
-  expect_lint(lines_simple, NULL, function_return_linter())
+  expect_lint(lines_simple, NULL, linter)
 
   # arguably an expression as complicated as this should also be assigned,
   #   but for now that's out of the scope of this linter
-  lines_subassignment <- trim_some("
-    foo <- function(x) {
-      return(x[, {
-        col <- col + 1
-        .(grp, col)
-      }])
-    }
+  lines_subassignment <- function_body(signature = "x", "
+    return(x[, {
+      col <- col + 1
+      .(grp, col)
+    }])
   ")
-  expect_lint(lines_subassignment, NULL, function_return_linter())
+  expect_lint(lines_subassignment, NULL, linter)
 })
 
 test_that("function_return_linter blocks simple disallowed usages", {
   linter <- function_return_linter()
   lint_msg <- rex::rex("Move the assignment outside of the return() clause")
 
-  expect_lint(
-    trim_some("
-      foo <- function(x) {
-        return(x <- x + 1)
-      }
-    "),
-    lint_msg,
-    linter
-  )
+  expect_lint(function_body("return(x <- x + 1)", signature = "x"), lint_msg, linter)
+
+  expect_lint(function_body("return(x <<- x + 1)", signature = "x"), lint_msg, linter)
+
+  expect_lint(function_body("return(x + 1 ->> x)", signature = "x"), lint_msg, linter)
+
+  expect_lint(function_body("return(x + 1 -> x)", signature = "x"), lint_msg, linter)
 
   expect_lint(
-    trim_some("
-      foo <- function(x) {
-        return(x <<- x + 1)
-      }
-    "),
-    lint_msg,
-    linter
-  )
-
-  expect_lint(
-    trim_some("
-      foo <- function(x) {
-        return(x + 1 ->> x)
-      }
-    "),
-    lint_msg,
-    linter
-  )
-
-  expect_lint(
-    trim_some("
-      foo <- function(x) {
-        return(x + 1 -> x)
-      }
-    "),
-    lint_msg,
-    linter
-  )
-
-  side_effect_lines <- expect_lint(
     trim_some("
       e <- new.env()
       foo <- function(x) {


### PR DESCRIPTION
Noticed we have a lot of tests on linters that apply specifically to function bodies where we have to waste space+mental effort writing the boilerplate `foo <- function(...) {`.

This helper helps us focus on what actually matters -- the function body.

Applied it here to only one test script to get a sense of how it looks in practice.

If we agree this is useful I'll apply it more broadly.