### PR TITLE
Move symbol search into XPath in backport_linter

### DIFF
--- a/R/backport_linter.R
+++ b/R/backport_linter.R
@@ -44,8 +44,9 @@ backport_linter <- function(r_version = getRversion(), except = character()) {
   backport_blacklist <- lapply(backport_blacklist, setdiff, except)
   backport_index <- rep(names(backport_blacklist), times = lengths(backport_blacklist))
   names(backport_index) <- unlist(backport_blacklist)
+  backport_cond <- xp_text_in_table(names(backport_index))
 
-  names_xpath <- "//SYMBOL | //SYMBOL_FUNCTION_CALL"
+  names_xpath <- glue("//SYMBOL[{backport_cond}] | //SYMBOL_FUNCTION_CALL[{backport_cond}]")
 
   Linter(linter_level = "expression", function(source_expression) {
     xml <- source_expression$xml_parsed_content

--- a/R/backport_linter.R
+++ b/R/backport_linter.R
@@ -56,19 +56,18 @@ backport_linter <- function(r_version = getRversion(), except = character()) {
     all_names <- xml_text(all_names_nodes)
 
     bad_versions <- unname(backport_index[all_names])
-    needs_backport <- !is.na(bad_versions)
 
     lint_message <- sprintf(
       paste(
         "%s (R %s) is not available for dependency R >= %s.",
         "Use the `except` argument of `backport_linter()` to configure available backports."
       ),
-      all_names[needs_backport],
-      bad_versions[needs_backport],
+      all_names,
+      bad_versions,
       r_version
     )
     xml_nodes_to_lints(
-      all_names_nodes[needs_backport],
+      all_names_nodes,
       source_expression = source_expression,
       lint_message = lint_message,
       type = "warning"


### PR DESCRIPTION
For #2338. This approach presents a bit of a conundrum as it seems the performance of the XPath algorithm degrades with the number of objects to search for:

(`new`: this PR; `old`: current `main`. `413`: `backport_linter("4.1.3")`; `300`: `backport_linter("3.0.0")`)

```r
system.time(lint_all(f, old413))
#    user  system elapsed 
#  71.890   1.442  74.399 
system.time(lint_all(f, old300))
#    user  system elapsed 
#  70.846   1.036  72.075

system.time(lint_all(f, new413))
#    user  system elapsed 
#  65.206   0.711  66.198 
system.time(lint_all(f, new300))
#    user  system elapsed 
#  76.417   0.854  77.541 
```

i.e. we get about 10% improvement from the "easier" linter where there are fewer objects to look up, but 7% slowdown in the "harder" case with many objects to look up.

Not sure how to proceed. We may also want to check other linters that use a huge list of `or` checks & check alternate approaches.