### PR TITLE
Follow tidyverse style guide for inline statements

### DIFF
--- a/R/T_and_F_symbol_linter.R
+++ b/R/T_and_F_symbol_linter.R
@@ -45,7 +45,9 @@ T_and_F_symbol_linter <- function() { # nolint: object_name.
 
   Linter(linter_level = "expression", function(source_expression) {
     xml <- source_expression$xml_parsed_content
-    if (is.null(xml)) return(list())
+    if (is.null(xml)) {
+      return(list())
+    }
     bad_usage <- xml_find_all(xml, usage_xpath)
     bad_assignment <- xml_find_all(xml, assignment_xpath)
 

--- a/R/any_duplicated_linter.R
+++ b/R/any_duplicated_linter.R
@@ -87,7 +87,9 @@ any_duplicated_linter <- function() {
 
   Linter(linter_level = "expression", function(source_expression) {
     xml <- source_expression$xml_parsed_content
-    if (is.null(xml)) return(list())
+    if (is.null(xml)) {
+      return(list())
+    }
 
     any_duplicated_expr <- xml_find_all(xml, any_duplicated_xpath)
     any_duplicated_lints <- xml_nodes_to_lints(

--- a/R/any_is_na_linter.R
+++ b/R/any_is_na_linter.R
@@ -48,7 +48,9 @@ any_is_na_linter <- function() {
 
   Linter(linter_level = "expression", function(source_expression) {
     xml <- source_expression$xml_parsed_content
-    if (is.null(xml)) return(list())
+    if (is.null(xml)) {
+      return(list())
+    }
 
     bad_expr <- xml_find_all(xml, xpath)
 

--- a/R/assignment_linter.R
+++ b/R/assignment_linter.R
@@ -101,7 +101,9 @@ assignment_linter <- function(allow_cascading_assign = TRUE,
 
   Linter(linter_level = "expression", function(source_expression) {
     xml <- source_expression$xml_parsed_content
-    if (is.null(xml)) return(list())
+    if (is.null(xml)) {
+      return(list())
+    }
 
     bad_expr <- xml_find_all(xml, xpath)
     if (length(bad_expr) == 0L) {

--- a/R/backport_linter.R
+++ b/R/backport_linter.R
@@ -49,7 +49,9 @@ backport_linter <- function(r_version = getRversion(), except = character()) {
 
   Linter(linter_level = "expression", function(source_expression) {
     xml <- source_expression$xml_parsed_content
-    if (is.null(xml)) return(list())
+    if (is.null(xml)) {
+      return(list())
+    }
 
     all_names_nodes <- xml_find_all(xml, names_xpath)
     all_names <- xml_text(all_names_nodes)

--- a/R/boolean_arithmetic_linter.R
+++ b/R/boolean_arithmetic_linter.R
@@ -57,7 +57,9 @@ boolean_arithmetic_linter <- function() {
 
   Linter(linter_level = "expression", function(source_expression) {
     xml <- source_expression$xml_parsed_content
-    if (is.null(xml)) return(list())
+    if (is.null(xml)) {
+      return(list())
+    }
 
     any_expr <- xml_find_all(xml, any_xpath)
 

--- a/R/brace_linter.R
+++ b/R/brace_linter.R
@@ -148,7 +148,9 @@ brace_linter <- function(allow_single_line = FALSE) {
 
   Linter(linter_level = "expression", function(source_expression) {
     xml <- source_expression$xml_parsed_content
-    if (is.null(xml)) return(list())
+    if (is.null(xml)) {
+      return(list())
+    }
     lints <- list()
 
     lints <- c(

--- a/R/class_equals_linter.R
+++ b/R/class_equals_linter.R
@@ -46,7 +46,9 @@ class_equals_linter <- function() {
 
   Linter(linter_level = "expression", function(source_expression) {
     xml <- source_expression$xml_parsed_content
-    if (is.null(xml)) return(list())
+    if (is.null(xml)) {
+      return(list())
+    }
 
     bad_expr <- xml_find_all(xml, xpath)
 

--- a/R/commas_linter.R
+++ b/R/commas_linter.R
@@ -79,7 +79,9 @@ commas_linter <- function(allow_trailing = FALSE) {
 
   Linter(linter_level = "expression", function(source_expression) {
     xml <- source_expression$xml_parsed_content
-    if (is.null(xml)) return(list())
+    if (is.null(xml)) {
+      return(list())
+    }
 
     before_lints <- xml_nodes_to_lints(
       xml_find_all(xml, xpath_before),

--- a/R/comment_linters.R
+++ b/R/comment_linters.R
@@ -78,7 +78,9 @@ commented_code_linter <- function() {
 
   Linter(linter_level = "file", function(source_expression) {
     xml <- source_expression$full_xml_parsed_content
-    if (is.null(xml)) return(list())
+    if (is.null(xml)) {
+      return(list())
+    }
     all_comment_nodes <- xml_find_all(xml, "//COMMENT")
     all_comments <- xml_text(all_comment_nodes)
     code_candidates <- re_matches(all_comments, code_candidate_regex, global = FALSE, locations = TRUE)

--- a/R/comparison_negation_linter.R
+++ b/R/comparison_negation_linter.R
@@ -62,7 +62,9 @@ comparison_negation_linter <- function() {
 
   Linter(linter_level = "expression", function(source_expression) {
     xml <- source_expression$xml_parsed_content
-    if (is.null(xml)) return(list())
+    if (is.null(xml)) {
+      return(list())
+    }
 
     bad_expr <- xml_find_all(xml, xpath)
 

--- a/R/condition_call_linter.R
+++ b/R/condition_call_linter.R
@@ -85,9 +85,10 @@ condition_call_linter <- function(display_call = FALSE) {
   ")
 
   Linter(linter_level = "expression", function(source_expression) {
-
     xml <- source_expression$xml_parsed_content
-    if (is.null(xml)) return(list())
+    if (is.null(xml)) {
+      return(list())
+    }
 
     bad_expr <- xml_find_all(xml, xpath)
 

--- a/R/condition_message_linter.R
+++ b/R/condition_message_linter.R
@@ -58,7 +58,9 @@ condition_message_linter <- function() {
 
   Linter(linter_level = "expression", function(source_expression) {
     xml <- source_expression$xml_parsed_content
-    if (is.null(xml)) return(list())
+    if (is.null(xml)) {
+      return(list())
+    }
 
     bad_expr <- xml_find_all(xml, xpath)
     sep_value <- get_r_string(bad_expr, xpath = "./expr/SYMBOL_SUB[text() = 'sep']/following-sibling::expr/STR_CONST")

--- a/R/conjunct_test_linter.R
+++ b/R/conjunct_test_linter.R
@@ -119,7 +119,9 @@ conjunct_test_linter <- function(allow_named_stopifnot = TRUE,
   Linter(linter_level = "file", function(source_expression) {
     # need the full file to also catch usages at the top level
     xml <- source_expression$full_xml_parsed_content
-    if (is.null(xml)) return(list())
+    if (is.null(xml)) {
+      return(list())
+    }
 
     test_expr <- xml_find_all(xml, test_xpath)
 

--- a/R/consecutive_assertion_linter.R
+++ b/R/consecutive_assertion_linter.R
@@ -50,7 +50,9 @@ consecutive_assertion_linter <- function() {
   Linter(linter_level = "file", function(source_expression) {
     # need the full file to also catch usages at the top level
     xml <- source_expression$full_xml_parsed_content
-    if (is.null(xml)) return(list())
+    if (is.null(xml)) {
+      return(list())
+    }
 
     bad_expr <- xml_find_all(xml, xpath)
 

--- a/R/consecutive_mutate_linter.R
+++ b/R/consecutive_mutate_linter.R
@@ -74,7 +74,9 @@ consecutive_mutate_linter <- function(invalid_backends = "dbplyr") {
   Linter(linter_level = "file", function(source_expression) {
     # need the full file to also catch usages at the top level
     xml <- source_expression$full_xml_parsed_content
-    if (is.null(xml)) return(list())
+    if (is.null(xml)) {
+      return(list())
+    }
 
     attach_str <- get_r_string(xml_find_all(xml, attach_pkg_xpath))
     if (any(invalid_backends %in% attach_str)) {

--- a/R/duplicate_argument_linter.R
+++ b/R/duplicate_argument_linter.R
@@ -42,7 +42,9 @@ duplicate_argument_linter <- function(except = c("mutate", "transmute")) {
 
   Linter(linter_level = "file", function(source_expression) {
     xml <- source_expression$full_xml_parsed_content
-    if (is.null(xml)) return(list())
+    if (is.null(xml)) {
+      return(list())
+    }
 
     calls <- xml_find_all(xml, xpath_call_with_args)
 

--- a/R/equals_na_linter.R
+++ b/R/equals_na_linter.R
@@ -48,7 +48,9 @@ equals_na_linter <- function() {
 
   Linter(linter_level = "expression", function(source_expression) {
     xml <- source_expression$xml_parsed_content
-    if (is.null(xml)) return(list())
+    if (is.null(xml)) {
+      return(list())
+    }
 
     bad_expr <- xml_find_all(xml, xpath)
 

--- a/R/expect_comparison_linter.R
+++ b/R/expect_comparison_linter.R
@@ -65,7 +65,9 @@ expect_comparison_linter <- function() {
 
   Linter(linter_level = "expression", function(source_expression) {
     xml <- source_expression$xml_parsed_content
-    if (is.null(xml)) return(list())
+    if (is.null(xml)) {
+      return(list())
+    }
 
     bad_expr <- xml_find_all(xml, xpath)
 

--- a/R/expect_identical_linter.R
+++ b/R/expect_identical_linter.R
@@ -83,7 +83,9 @@ expect_identical_linter <- function() {
 
   Linter(linter_level = "expression", function(source_expression) {
     xml <- source_expression$xml_parsed_content
-    if (is.null(xml)) return(list())
+    if (is.null(xml)) {
+      return(list())
+    }
 
     bad_expr <- xml_find_all(xml, xpath)
     xml_nodes_to_lints(

--- a/R/expect_length_linter.R
+++ b/R/expect_length_linter.R
@@ -34,7 +34,9 @@ expect_length_linter <- function() {
 
   Linter(linter_level = "expression", function(source_expression) {
     xml <- source_expression$xml_parsed_content
-    if (is.null(xml)) return(list())
+    if (is.null(xml)) {
+      return(list())
+    }
 
     bad_expr <- xml_find_all(xml, xpath)
     matched_function <- xp_call_name(bad_expr)

--- a/R/expect_named_linter.R
+++ b/R/expect_named_linter.R
@@ -43,7 +43,9 @@ expect_named_linter <- function() {
 
   Linter(linter_level = "expression", function(source_expression) {
     xml <- source_expression$xml_parsed_content
-    if (is.null(xml)) return(list())
+    if (is.null(xml)) {
+      return(list())
+    }
 
     bad_expr <- xml_find_all(xml, xpath)
     matched_function <- xp_call_name(bad_expr)

--- a/R/expect_null_linter.R
+++ b/R/expect_null_linter.R
@@ -55,7 +55,9 @@ expect_null_linter <- function() {
 
   Linter(linter_level = "expression", function(source_expression) {
     xml <- source_expression$xml_parsed_content
-    if (is.null(xml)) return(list())
+    if (is.null(xml)) {
+      return(list())
+    }
 
     bad_expr <- xml_find_all(xml, xpath)
 

--- a/R/expect_s3_class_linter.R
+++ b/R/expect_s3_class_linter.R
@@ -71,7 +71,9 @@ expect_s3_class_linter <- function() {
 
   Linter(linter_level = "expression", function(source_expression) {
     xml <- source_expression$xml_parsed_content
-    if (is.null(xml)) return(list())
+    if (is.null(xml)) {
+      return(list())
+    }
 
     bad_expr <- xml_find_all(xml, xpath)
     matched_function <- xp_call_name(bad_expr)

--- a/R/expect_s4_class_linter.R
+++ b/R/expect_s4_class_linter.R
@@ -34,7 +34,9 @@ expect_s4_class_linter <- function() {
 
   Linter(linter_level = "expression", function(source_expression) {
     xml <- source_expression$xml_parsed_content
-    if (is.null(xml)) return(list())
+    if (is.null(xml)) {
+      return(list())
+    }
 
     # TODO(michaelchirico): also catch expect_{equal,identical}(methods::is(x), k).
     #   this seems empirically rare, but didn't check many S4-heavy packages.

--- a/R/expect_true_false_linter.R
+++ b/R/expect_true_false_linter.R
@@ -41,7 +41,9 @@ expect_true_false_linter <- function() {
 
   Linter(linter_level = "expression", function(source_expression) {
     xml <- source_expression$xml_parsed_content
-    if (is.null(xml)) return(list())
+    if (is.null(xml)) {
+      return(list())
+    }
 
     bad_expr <- xml_find_all(xml, xpath)
 

--- a/R/expect_type_linter.R
+++ b/R/expect_type_linter.R
@@ -61,7 +61,9 @@ expect_type_linter <- function() {
 
   Linter(linter_level = "expression", function(source_expression) {
     xml <- source_expression$xml_parsed_content
-    if (is.null(xml)) return(list())
+    if (is.null(xml)) {
+      return(list())
+    }
 
     bad_expr <- xml_find_all(xml, xpath)
     matched_function <- xp_call_name(bad_expr)

--- a/R/extraction_operator_linter.R
+++ b/R/extraction_operator_linter.R
@@ -63,7 +63,9 @@ extraction_operator_linter <- function() {
 
   Linter(linter_level = "expression", function(source_expression) {
     xml <- source_expression$xml_parsed_content
-    if (is.null(xml)) return(list())
+    if (is.null(xml)) {
+      return(list())
+    }
     bad_exprs <- xml_find_all(xml, xpath)
     msgs <- sprintf("Use `[[` instead of `%s` to extract an element.", xml_text(bad_exprs))
 

--- a/R/fixed_regex_linter.R
+++ b/R/fixed_regex_linter.R
@@ -141,7 +141,9 @@ fixed_regex_linter <- function(allow_unescaped = FALSE) {
 
   Linter(linter_level = "expression", function(source_expression) {
     xml <- source_expression$xml_parsed_content
-    if (is.null(xml)) return(list())
+    if (is.null(xml)) {
+      return(list())
+    }
 
     patterns <- xml_find_all(xml, xpath)
     pattern_strings <- get_r_string(patterns)

--- a/R/function_argument_linter.R
+++ b/R/function_argument_linter.R
@@ -61,7 +61,9 @@ function_argument_linter <- function() {
 
   Linter(linter_level = "expression", function(source_expression) {
     xml <- source_expression$xml_parsed_content
-    if (is.null(xml)) return(list())
+    if (is.null(xml)) {
+      return(list())
+    }
 
     bad_expr <- xml_find_all(xml, xpath)
 

--- a/R/function_left_parentheses_linter.R
+++ b/R/function_left_parentheses_linter.R
@@ -59,7 +59,9 @@ function_left_parentheses_linter <- function() { # nolint: object_length.
 
   Linter(linter_level = "expression", function(source_expression) {
     xml <- source_expression$xml_parsed_content
-    if (is.null(xml)) return(list())
+    if (is.null(xml)) {
+      return(list())
+    }
 
     bad_line_fun_exprs <- xml_find_all(xml, bad_line_fun_xpath)
     bad_line_fun_lints <- xml_nodes_to_lints(

--- a/R/if_not_else_linter.R
+++ b/R/if_not_else_linter.R
@@ -85,7 +85,9 @@ if_not_else_linter <- function(exceptions = c("is.null", "is.na", "missing")) {
 
   Linter(linter_level = "expression", function(source_expression) {
     xml <- source_expression$xml_parsed_content
-    if (is.null(xml)) return(list())
+    if (is.null(xml)) {
+      return(list())
+    }
 
     if_expr <- xml_find_all(xml, if_xpath)
     if_lints <- xml_nodes_to_lints(

--- a/R/if_switch_linter.R
+++ b/R/if_switch_linter.R
@@ -63,7 +63,9 @@ if_switch_linter <- function() {
 
   Linter(linter_level = "expression", function(source_expression) {
     xml <- source_expression$xml_parsed_content
-    if (is.null(xml)) return(list())
+    if (is.null(xml)) {
+      return(list())
+    }
 
     bad_expr <- xml_find_all(xml, xpath)
 

--- a/R/ifelse_censor_linter.R
+++ b/R/ifelse_censor_linter.R
@@ -48,7 +48,9 @@ ifelse_censor_linter <- function() {
 
   Linter(linter_level = "expression", function(source_expression) {
     xml <- source_expression$xml_parsed_content
-    if (is.null(xml)) return(list())
+    if (is.null(xml)) {
+      return(list())
+    }
 
     bad_expr <- xml_find_all(xml, xpath)
 

--- a/R/implicit_assignment_linter.R
+++ b/R/implicit_assignment_linter.R
@@ -105,7 +105,9 @@ implicit_assignment_linter <- function(except = c("bquote", "expression", "expr"
   Linter(linter_level = "file", function(source_expression) {
     # need the full file to also catch usages at the top level
     xml <- source_expression$full_xml_parsed_content
-    if (is.null(xml)) return(list())
+    if (is.null(xml)) {
+      return(list())
+    }
 
     bad_expr <- xml_find_all(xml, xpath)
 

--- a/R/implicit_integer_linter.R
+++ b/R/implicit_integer_linter.R
@@ -53,7 +53,9 @@ implicit_integer_linter <- function(allow_colon = FALSE) {
   }
   Linter(linter_level = "file", function(source_expression) {
     xml <- source_expression$full_xml_parsed_content
-    if (is.null(xml)) return(list())
+    if (is.null(xml)) {
+      return(list())
+    }
 
     numbers <- xml_find_all(xml, xpath)
 

--- a/R/indentation_linter.R
+++ b/R/indentation_linter.R
@@ -213,7 +213,9 @@ indentation_linter <- function(indent = 2L, hanging_indent_style = c("tidy", "al
     # will have "# comment" as a separate expression
 
     xml <- source_expression$full_xml_parsed_content
-    if (is.null(xml)) return(list())
+    if (is.null(xml)) {
+      return(list())
+    }
     # Indentation increases by 1 for:
     #  - { } blocks that span multiple lines
     #  - ( ), [ ], or [[ ]] calls that span multiple lines

--- a/R/infix_spaces_linter.R
+++ b/R/infix_spaces_linter.R
@@ -107,7 +107,9 @@ infix_spaces_linter <- function(exclude_operators = NULL, allow_multiple_spaces 
 
   Linter(linter_level = "expression", function(source_expression) {
     xml <- source_expression$xml_parsed_content
-    if (is.null(xml)) return(list())
+    if (is.null(xml)) {
+      return(list())
+    }
     bad_expr <- xml_find_all(xml, xpath)
 
     xml_nodes_to_lints(

--- a/R/inner_combine_linter.R
+++ b/R/inner_combine_linter.R
@@ -85,7 +85,9 @@ inner_combine_linter <- function() {
 
   Linter(linter_level = "expression", function(source_expression) {
     xml <- source_expression$xml_parsed_content
-    if (is.null(xml)) return(list())
+    if (is.null(xml)) {
+      return(list())
+    }
 
     bad_expr <- xml_find_all(xml, xpath)
 

--- a/R/is_numeric_linter.R
+++ b/R/is_numeric_linter.R
@@ -71,7 +71,9 @@ is_numeric_linter <- function() {
 
   Linter(linter_level = "expression", function(source_expression) {
     xml <- source_expression$xml_parsed_content
-    if (is.null(xml)) return(list())
+    if (is.null(xml)) {
+      return(list())
+    }
 
     or_expr <- xml_find_all(xml, or_xpath)
     or_lints <- xml_nodes_to_lints(

--- a/R/keyword_quote_linter.R
+++ b/R/keyword_quote_linter.R
@@ -96,7 +96,9 @@ keyword_quote_linter <- function() {
 
   Linter(linter_level = "expression", function(source_expression) {
     xml <- source_expression$xml_parsed_content
-    if (is.null(xml)) return(list())
+    if (is.null(xml)) {
+      return(list())
+    }
 
     call_arg_expr <- xml_find_all(xml, call_arg_xpath)
 

--- a/R/length_test_linter.R
+++ b/R/length_test_linter.R
@@ -29,7 +29,9 @@ length_test_linter <- function() {
 
   Linter(linter_level = "expression", function(source_expression) {
     xml <- source_expression$xml_parsed_content
-    if (is.null(xml)) return(list())
+    if (is.null(xml)) {
+      return(list())
+    }
 
     bad_expr <- xml_find_all(xml, xpath)
     expr_parts <- vapply(lapply(bad_expr, xml_find_all, "expr[2]/*"), xml_text, character(3L))

--- a/R/library_call_linter.R
+++ b/R/library_call_linter.R
@@ -150,7 +150,9 @@ library_call_linter <- function(allow_preamble = TRUE) {
 
   Linter(linter_level = "file", function(source_expression) {
     xml <- source_expression$full_xml_parsed_content
-    if (is.null(xml)) return(list())
+    if (is.null(xml)) {
+      return(list())
+    }
 
     upfront_call_expr <- xml_find_all(xml, upfront_call_xpath)
 

--- a/R/list_comparison_linter.R
+++ b/R/list_comparison_linter.R
@@ -41,7 +41,9 @@ list_comparison_linter <- function() {
 
   Linter(linter_level = "expression", function(source_expression) {
     xml <- source_expression$xml_parsed_content
-    if (is.null(xml)) return(list())
+    if (is.null(xml)) {
+      return(list())
+    }
 
     bad_expr <- xml_find_all(xml, xpath)
 

--- a/R/literal_coercion_linter.R
+++ b/R/literal_coercion_linter.R
@@ -75,7 +75,9 @@ literal_coercion_linter <- function() {
 
   Linter(linter_level = "expression", function(source_expression) {
     xml <- source_expression$xml_parsed_content
-    if (is.null(xml)) return(list())
+    if (is.null(xml)) {
+      return(list())
+    }
 
     bad_expr <- xml_find_all(xml, xpath)
 

--- a/R/make_linter_from_xpath.R
+++ b/R/make_linter_from_xpath.R
@@ -25,7 +25,9 @@ make_linter_from_xpath <- function(xpath,
   function() {
     Linter(linter_level = level, function(source_expression) {
       xml <- source_expression[[xml_key]]
-      if (is.null(xml)) return(list())
+      if (is.null(xml)) {
+        return(list())
+      }
 
       expr <- xml_find_all(xml, xpath)
 

--- a/R/matrix_apply_linter.R
+++ b/R/matrix_apply_linter.R
@@ -78,7 +78,9 @@ matrix_apply_linter <- function() {
 
   Linter(linter_level = "expression", function(source_expression) {
     xml <- source_expression$xml_parsed_content
-    if (is.null(xml)) return(list())
+    if (is.null(xml)) {
+      return(list())
+    }
 
     bad_expr <- xml_find_all(xml, xpath)
 

--- a/R/missing_argument_linter.R
+++ b/R/missing_argument_linter.R
@@ -45,7 +45,9 @@ missing_argument_linter <- function(except = c("alist", "quote", "switch"), allo
 
   Linter(linter_level = "file", function(source_expression) {
     xml <- source_expression$full_xml_parsed_content
-    if (is.null(xml)) return(list())
+    if (is.null(xml)) {
+      return(list())
+    }
 
     missing_args <- xml_find_all(xml, xpath)
     function_call_name <- get_r_string(xml_find_chr(missing_args, to_function_xpath))

--- a/R/missing_package_linter.R
+++ b/R/missing_package_linter.R
@@ -44,7 +44,9 @@ missing_package_linter <- function() {
 
   Linter(linter_level = "file", function(source_expression) {
     xml <- source_expression$full_xml_parsed_content
-    if (is.null(xml)) return(list())
+    if (is.null(xml)) {
+      return(list())
+    }
 
     pkg_calls <- xml_find_all(xml, call_xpath)
     pkg_names <- get_r_string(xml_find_all(

--- a/R/namespace_linter.R
+++ b/R/namespace_linter.R
@@ -41,7 +41,9 @@
 namespace_linter <- function(check_exports = TRUE, check_nonexports = TRUE) {
   Linter(linter_level = "file", function(source_expression) {
     xml <- source_expression$full_xml_parsed_content
-    if (is.null(xml)) return(list())
+    if (is.null(xml)) {
+      return(list())
+    }
 
     ns_nodes <- xml_find_all(xml, "//NS_GET | //NS_GET_INT")
 

--- a/R/nested_ifelse_linter.R
+++ b/R/nested_ifelse_linter.R
@@ -88,7 +88,9 @@ nested_ifelse_linter <- function() {
 
   Linter(linter_level = "expression", function(source_expression) {
     xml <- source_expression$xml_parsed_content
-    if (is.null(xml)) return(list())
+    if (is.null(xml)) {
+      return(list())
+    }
 
     bad_expr <- xml_find_all(xml, xpath)
 

--- a/R/nested_pipe_linter.R
+++ b/R/nested_pipe_linter.R
@@ -69,7 +69,9 @@ nested_pipe_linter <- function(
 
   Linter(linter_level = "expression", function(source_expression) {
     xml <- source_expression$xml_parsed_content
-    if (is.null(xml)) return(list())
+    if (is.null(xml)) {
+      return(list())
+    }
 
     bad_expr <- xml_find_all(xml, xpath)
 

--- a/R/nzchar_linter.R
+++ b/R/nzchar_linter.R
@@ -94,7 +94,9 @@ nzchar_linter <- function() {
 
   Linter(linter_level = "expression", function(source_expression) {
     xml <- source_expression$xml_parsed_content
-    if (is.null(xml)) return(list())
+    if (is.null(xml)) {
+      return(list())
+    }
 
     comparison_expr <- xml_find_all(xml, comparison_xpath)
     comparison_lints <- xml_nodes_to_lints(

--- a/R/object_length_linter.R
+++ b/R/object_length_linter.R
@@ -39,7 +39,9 @@ object_length_linter <- function(length = 30L) {
 
   Linter(linter_level = "file", function(source_expression) {
     xml <- source_expression$full_xml_parsed_content
-    if (is.null(xml)) return(list())
+    if (is.null(xml)) {
+      return(list())
+    }
 
     assignments <- xml_find_all(xml, object_name_xpath)
 

--- a/R/object_name_linter.R
+++ b/R/object_name_linter.R
@@ -112,7 +112,9 @@ object_name_linter <- function(styles = c("snake_case", "symbols"), regexes = ch
 
   Linter(linter_level = "file", function(source_expression) {
     xml <- source_expression$full_xml_parsed_content
-    if (is.null(xml)) return(list())
+    if (is.null(xml)) {
+      return(list())
+    }
 
     assignments <- xml_find_all(xml, object_name_xpath)
 

--- a/R/object_overwrite_linter.R
+++ b/R/object_overwrite_linter.R
@@ -95,7 +95,9 @@ object_overwrite_linter <- function(
 
   Linter(linter_level = "expression", function(source_expression) {
     xml <- source_expression$xml_parsed_content
-    if (is.null(xml)) return(list())
+    if (is.null(xml)) {
+      return(list())
+    }
 
     assigned_exprs <- xml_find_all(xml, xpath_assignments)
     assigned_symbols <- get_r_string(assigned_exprs, "SYMBOL|STR_CONST")

--- a/R/object_usage_linter.R
+++ b/R/object_usage_linter.R
@@ -58,7 +58,9 @@ object_usage_linter <- function(interpret_glue = TRUE, skip_with = TRUE) {
     declared_globals <- try_silently(globalVariables(package = pkg_name %||% globalenv()))
 
     xml <- source_expression$full_xml_parsed_content
-    if (is.null(xml)) return(list())
+    if (is.null(xml)) {
+      return(list())
+    }
 
     # run the following at run-time, not "compile" time to allow package structure to change
     env <- make_check_env(pkg_name, xml)

--- a/R/one_call_pipe_linter.R
+++ b/R/one_call_pipe_linter.R
@@ -67,7 +67,9 @@ one_call_pipe_linter <- function() {
 
   Linter(linter_level = "expression", function(source_expression) {
     xml <- source_expression$xml_parsed_content
-    if (is.null(xml)) return(list())
+    if (is.null(xml)) {
+      return(list())
+    }
 
     bad_expr <- xml_find_all(xml, xpath)
     pipe <- xml_find_chr(bad_expr, "string(SPECIAL | PIPE)")

--- a/R/outer_negation_linter.R
+++ b/R/outer_negation_linter.R
@@ -52,7 +52,9 @@ outer_negation_linter <- function() {
 
   Linter(linter_level = "expression", function(source_expression) {
     xml <- source_expression$xml_parsed_content
-    if (is.null(xml)) return(list())
+    if (is.null(xml)) {
+      return(list())
+    }
 
     bad_expr <- xml_find_all(xml, xpath)
 

--- a/R/package_hooks_linter.R
+++ b/R/package_hooks_linter.R
@@ -128,7 +128,9 @@ package_hooks_linter <- function() {
 
   Linter(linter_level = "file", function(source_expression) {
     xml <- source_expression$full_xml_parsed_content
-    if (is.null(xml)) return(list())
+    if (is.null(xml)) {
+      return(list())
+    }
 
     any_hook <- xml_find_first(xml, any_hook_xpath)
     if (is.na(any_hook)) {

--- a/R/paste_linter.R
+++ b/R/paste_linter.R
@@ -163,7 +163,9 @@ paste_linter <- function(allow_empty_sep = FALSE,
 
   Linter(linter_level = "expression", function(source_expression) {
     xml <- source_expression$xml_parsed_content
-    if (is.null(xml)) return(list())
+    if (is.null(xml)) {
+      return(list())
+    }
     optional_lints <- list()
 
     # Both of these look for paste(..., sep = "..."), differing in which 'sep' is linted,

--- a/R/pipe_call_linter.R
+++ b/R/pipe_call_linter.R
@@ -28,7 +28,9 @@ pipe_call_linter <- function() {
 
   Linter(linter_level = "expression", function(source_expression) {
     xml <- source_expression$xml_parsed_content
-    if (is.null(xml)) return(list())
+    if (is.null(xml)) {
+      return(list())
+    }
 
     bad_expr <- xml_find_all(xml, xpath)
     pipe <- xml_text(xml_find_first(bad_expr, "preceding-sibling::SPECIAL[1]"))

--- a/R/pipe_consistency_linter.R
+++ b/R/pipe_consistency_linter.R
@@ -40,7 +40,9 @@ pipe_consistency_linter <- function(pipe = c("auto", "%>%", "|>")) {
 
   Linter(linter_level = "file", function(source_expression) {
     xml <- source_expression$full_xml_parsed_content
-    if (is.null(xml)) return(list())
+    if (is.null(xml)) {
+      return(list())
+    }
 
     match_magrittr <- xml_find_all(xml, xpath_magrittr)
     match_native <- xml_find_all(xml, xpath_native)

--- a/R/pipe_continuation_linter.R
+++ b/R/pipe_continuation_linter.R
@@ -69,7 +69,9 @@ pipe_continuation_linter <- function() {
 
   Linter(linter_level = "file", function(source_expression) {
     xml <- source_expression$full_xml_parsed_content
-    if (is.null(xml)) return(list())
+    if (is.null(xml)) {
+      return(list())
+    }
 
     pipe_exprs <- xml_find_all(xml, xpath)
     pipe_text <- xml_text(pipe_exprs)

--- a/R/quotes_linter.R
+++ b/R/quotes_linter.R
@@ -62,7 +62,9 @@ quotes_linter <- function(delimiter = c('"', "'")) {
 
   Linter(linter_level = "expression", function(source_expression) {
     xml <- source_expression$xml_parsed_content
-    if (is.null(xml)) return(list())
+    if (is.null(xml)) {
+      return(list())
+    }
     string_exprs <- xml_find_all(xml, "//STR_CONST")
     is_bad <- re_matches(xml_text(string_exprs), quote_regex)
 

--- a/R/redundant_equals_linter.R
+++ b/R/redundant_equals_linter.R
@@ -45,7 +45,9 @@ redundant_equals_linter <- function() {
 
   Linter(linter_level = "expression", function(source_expression) {
     xml <- source_expression$xml_parsed_content
-    if (is.null(xml)) return(list())
+    if (is.null(xml)) {
+      return(list())
+    }
 
     bad_expr <- xml_find_all(xml, xpath)
     op <- xml_text(xml_find_first(bad_expr, "*[2]"))

--- a/R/redundant_ifelse_linter.R
+++ b/R/redundant_ifelse_linter.R
@@ -72,7 +72,9 @@ redundant_ifelse_linter <- function(allow10 = FALSE) {
 
   Linter(linter_level = "expression", function(source_expression) {
     xml <- source_expression$xml_parsed_content
-    if (is.null(xml)) return(list())
+    if (is.null(xml)) {
+      return(list())
+    }
     lints <- list()
 
     tf_expr <- xml_find_all(xml, tf_xpath)

--- a/R/regex_subset_linter.R
+++ b/R/regex_subset_linter.R
@@ -69,7 +69,9 @@ regex_subset_linter <- function() {
 
   Linter(linter_level = "expression", function(source_expression) {
     xml <- source_expression$xml_parsed_content
-    if (is.null(xml)) return(list())
+    if (is.null(xml)) {
+      return(list())
+    }
 
     grep_expr <- xml_find_all(xml, grep_xpath)
 

--- a/R/repeat_linter.R
+++ b/R/repeat_linter.R
@@ -24,7 +24,9 @@ repeat_linter <- function() {
 
   Linter(linter_level = "expression", function(source_expression) {
     xml <- source_expression$xml_parsed_content
-    if (is.null(xml)) return(list())
+    if (is.null(xml)) {
+      return(list())
+    }
     lints <- xml_find_all(xml, xpath)
 
     xml_nodes_to_lints(

--- a/R/return_linter.R
+++ b/R/return_linter.R
@@ -47,7 +47,6 @@
 #'   linters = return_linter(return_style = "explicit")
 #' )
 #'
-#'
 #' @evalRd rd_tags("return_linter")
 #' @seealso
 #'  - [linters] for a complete list of linters available in lintr.
@@ -159,7 +158,9 @@ return_linter <- function(
 
   Linter(linter_level = "expression", function(source_expression) {
     xml <- source_expression$xml_parsed_content
-    if (is.null(xml)) return(list())
+    if (is.null(xml)) {
+      return(list())
+    }
 
     xml_nodes <- xml_find_all(xml, xpath)
 

--- a/R/sample_int_linter.R
+++ b/R/sample_int_linter.R
@@ -67,7 +67,9 @@ sample_int_linter <- function() {
 
   Linter(linter_level = "expression", function(source_expression) {
     xml <- source_expression$xml_parsed_content
-    if (is.null(xml)) return(list())
+    if (is.null(xml)) {
+      return(list())
+    }
 
     bad_expr <- xml_find_all(xml, xpath)
     first_call <- xp_call_name(bad_expr, depth = 2L)

--- a/R/scalar_in_linter.R
+++ b/R/scalar_in_linter.R
@@ -39,7 +39,9 @@ scalar_in_linter <- function() {
 
   Linter(linter_level = "expression", function(source_expression) {
     xml <- source_expression$xml_parsed_content
-    if (is.null(xml)) return(list())
+    if (is.null(xml)) {
+      return(list())
+    }
 
     bad_expr <- xml_find_all(xml, xpath)
     in_op <- xml_find_chr(bad_expr, "string(SPECIAL)")

--- a/R/semicolon_linter.R
+++ b/R/semicolon_linter.R
@@ -87,7 +87,9 @@ semicolon_linter <- function(allow_compound = FALSE, allow_trailing = FALSE) {
 
   Linter(linter_level = "file", function(source_expression) {
     xml <- source_expression$full_xml_parsed_content
-    if (is.null(xml)) return(list())
+    if (is.null(xml)) {
+      return(list())
+    }
     bad_exprs <- xml_find_all(xml, xpath)
     if (need_detection) {
       is_trailing <- is.na(xml_find_first(bad_exprs, compound_xpath))

--- a/R/seq_linter.R
+++ b/R/seq_linter.R
@@ -88,7 +88,9 @@ seq_linter <- function() {
 
   Linter(linter_level = "expression", function(source_expression) {
     xml <- source_expression$xml_parsed_content
-    if (is.null(xml)) return(list())
+    if (is.null(xml)) {
+      return(list())
+    }
 
     badx <- xml_find_all(xml, xpath)
 

--- a/R/settings.R
+++ b/R/settings.R
@@ -159,7 +159,8 @@ validate_config_file <- function(config, config_file, defaults) {
     )
   }
 
-  validate_regex(config,
+  validate_regex(
+    config,
     c("exclude", "exclude_next", "exclude_start", "exclude_end", "exclude_linter", "exclude_linter_sep")
   )
   validate_character_string(config, c("encoding", "cache_directory", "comment_token"))

--- a/R/sort_linter.R
+++ b/R/sort_linter.R
@@ -100,7 +100,9 @@ sort_linter <- function() {
 
   Linter(linter_level = "expression", function(source_expression) {
     xml <- source_expression$xml_parsed_content
-    if (is.null(xml)) return(list())
+    if (is.null(xml)) {
+      return(list())
+    }
 
     order_expr <- xml_find_all(xml, order_xpath)
 

--- a/R/spaces_inside_linter.R
+++ b/R/spaces_inside_linter.R
@@ -54,7 +54,9 @@ spaces_inside_linter <- function() {
 
   Linter(linter_level = "file", function(source_expression) {
     xml <- source_expression$full_xml_parsed_content
-    if (is.null(xml)) return(list())
+    if (is.null(xml)) {
+      return(list())
+    }
 
     left_expr <- xml_find_all(xml, left_xpath)
     left_msg <- ifelse(

--- a/R/sprintf_linter.R
+++ b/R/sprintf_linter.R
@@ -106,7 +106,9 @@ sprintf_linter <- function() {
 
   Linter(linter_level = "file", function(source_expression) {
     xml <- source_expression$full_xml_parsed_content
-    if (is.null(xml)) return(list())
+    if (is.null(xml)) {
+      return(list())
+    }
 
     sprintf_calls <- xml_find_all(xml, call_xpath)
 

--- a/R/string_boundary_linter.R
+++ b/R/string_boundary_linter.R
@@ -121,7 +121,9 @@ string_boundary_linter <- function(allow_grepl = FALSE) {
 
   Linter(linter_level = "expression", function(source_expression) {
     xml <- source_expression$xml_parsed_content
-    if (is.null(xml)) return(list())
+    if (is.null(xml)) {
+      return(list())
+    }
     lints <- list()
 
     str_detect_lint_data <- get_regex_lint_data(xml, str_detect_xpath)

--- a/R/strings_as_factors_linter.R
+++ b/R/strings_as_factors_linter.R
@@ -84,7 +84,9 @@ strings_as_factors_linter <- function() {
 
   Linter(linter_level = "expression", function(source_expression) {
     xml <- source_expression$xml_parsed_content
-    if (is.null(xml)) return(list())
+    if (is.null(xml)) {
+      return(list())
+    }
 
     bad_expr <- xml_find_all(xml, xpath)
 

--- a/R/system_file_linter.R
+++ b/R/system_file_linter.R
@@ -36,7 +36,9 @@ system_file_linter <- function() {
 
   Linter(linter_level = "expression", function(source_expression) {
     xml <- source_expression$xml_parsed_content
-    if (is.null(xml)) return(list())
+    if (is.null(xml)) {
+      return(list())
+    }
 
     bad_expr <- xml_find_all(xml, xpath)
 

--- a/R/undesirable_function_linter.R
+++ b/R/undesirable_function_linter.R
@@ -84,7 +84,9 @@ undesirable_function_linter <- function(fun = default_undesirable_functions,
 
   Linter(linter_level = "expression", function(source_expression) {
     xml <- source_expression$xml_parsed_content
-    if (is.null(xml)) return(list())
+    if (is.null(xml)) {
+      return(list())
+    }
     matched_nodes <- xml_find_all(xml, xpath)
     fun_names <- get_r_string(matched_nodes)
 

--- a/R/undesirable_operator_linter.R
+++ b/R/undesirable_operator_linter.R
@@ -68,7 +68,9 @@ undesirable_operator_linter <- function(op = default_undesirable_operators) {
 
   Linter(linter_level = "expression", function(source_expression) {
     xml <- source_expression$xml_parsed_content
-    if (is.null(xml)) return(list())
+    if (is.null(xml)) {
+      return(list())
+    }
 
     bad_op <- xml_find_all(xml, xpath)
 

--- a/R/unnecessary_concatenation_linter.R
+++ b/R/unnecessary_concatenation_linter.R
@@ -101,7 +101,9 @@ unnecessary_concatenation_linter <- function(allow_single_expression = TRUE) { #
 
   Linter(linter_level = "expression", function(source_expression) {
     xml <- source_expression$xml_parsed_content
-    if (is.null(xml)) return(list())
+    if (is.null(xml)) {
+      return(list())
+    }
     c_calls <- xml_find_all(xml, call_xpath)
 
     # bump count(args) by 1 if inside a pipeline

--- a/R/unnecessary_lambda_linter.R
+++ b/R/unnecessary_lambda_linter.R
@@ -161,7 +161,9 @@ unnecessary_lambda_linter <- function(allow_comparison = FALSE) {
 
   Linter(linter_level = "expression", function(source_expression) {
     xml <- source_expression$xml_parsed_content
-    if (is.null(xml)) return(list())
+    if (is.null(xml)) {
+      return(list())
+    }
 
     default_fun_expr <- xml_find_all(xml, default_fun_xpath)
 

--- a/R/unnecessary_nesting_linter.R
+++ b/R/unnecessary_nesting_linter.R
@@ -143,7 +143,9 @@ unnecessary_nesting_linter <- function(allow_assignment = TRUE) {
 
   Linter(linter_level = "expression", function(source_expression) {
     xml <- source_expression$xml_parsed_content
-    if (is.null(xml)) return(list())
+    if (is.null(xml)) {
+      return(list())
+    }
 
     if_else_exit_expr <- xml_find_all(xml, if_else_exit_xpath)
     if_else_exit_lints <- xml_nodes_to_lints(

--- a/R/unnecessary_placeholder_linter.R
+++ b/R/unnecessary_placeholder_linter.R
@@ -51,7 +51,9 @@ unnecessary_placeholder_linter <- function() {
 
   Linter(linter_level = "expression", function(source_expression) {
     xml <- source_expression$xml_parsed_content
-    if (is.null(xml)) return(list())
+    if (is.null(xml)) {
+      return(list())
+    }
 
     bad_expr <- xml_find_all(xml, xpath)
 

--- a/R/unreachable_code_linter.R
+++ b/R/unreachable_code_linter.R
@@ -117,7 +117,9 @@ unreachable_code_linter <- function() {
 
   Linter(linter_level = "expression", function(source_expression) {
     xml <- source_expression$xml_parsed_content
-    if (is.null(xml)) return(list())
+    if (is.null(xml)) {
+      return(list())
+    }
 
     expr_return_stop <- xml_find_all(xml, xpath_return_stop)
 

--- a/R/unused_import_linter.R
+++ b/R/unused_import_linter.R
@@ -76,7 +76,9 @@ unused_import_linter <- function(allow_ns_usage = FALSE,
 
   Linter(linter_level = "file", function(source_expression) {
     xml <- source_expression$full_xml_parsed_content
-    if (is.null(xml)) return(list())
+    if (is.null(xml)) {
+      return(list())
+    }
 
     import_exprs <- xml_find_all(xml, import_xpath)
     if (length(import_exprs) == 0L) {

--- a/R/vector_logic_linter.R
+++ b/R/vector_logic_linter.R
@@ -79,7 +79,9 @@ vector_logic_linter <- function() {
 
   Linter(linter_level = "expression", function(source_expression) {
     xml <- source_expression$xml_parsed_content
-    if (is.null(xml)) return(list())
+    if (is.null(xml)) {
+      return(list())
+    }
     bad_expr <- xml_find_all(xml, xpath)
 
     xml_nodes_to_lints(

--- a/R/with_id.R
+++ b/R/with_id.R
@@ -1,4 +1,3 @@
-
 #' Extract row by ID
 #'
 #' @describeIn ids_with_token

--- a/R/yoda_test_linter.R
+++ b/R/yoda_test_linter.R
@@ -57,7 +57,9 @@ yoda_test_linter <- function() {
 
   Linter(linter_level = "expression", function(source_expression) {
     xml <- source_expression$xml_parsed_content
-    if (is.null(xml)) return(list())
+    if (is.null(xml)) {
+      return(list())
+    }
 
     bad_expr <- xml_find_all(xml, xpath)
 


### PR DESCRIPTION
https://style.tidyverse.org/syntax.html#inline-statements

> Function calls that affect control flow (like [`return()`](https://rdrr.io/r/base/function.html), [`stop()`](https://rdrr.io/r/base/stop.html) or `continue`) should always go in their own `{}` block