### PR TITLE
Handle comparison to negative non-integer in expect_identical_linter

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -20,7 +20,7 @@
 
 ## Bug fixes
 
-* `expect_identical_linter()` no longer lints `expect_equal()` comparison to negative non-integers (#2411, @Bisaloo).
+* `expect_identical_linter()` also skips `expect_equal()` comparison to _negative_ non-integers like `-1.034` (#2411, @Bisaloo). This is a parity fix since _positive_ reals have always been skipped because "high-precision" comparisons are typically done to get tests within `tolerance`, so `expect_identical()` is not a great substitution.
 * `object_name_linter()` no longer errors when user-supplied `regexes=` have capture groups (#2188, @MichaelChirico).
 * `.lintr` config validation correctly accepts regular expressions which only compile under `perl = TRUE` (#2375, @MichaelChirico). These have always been valid (since `rex::re_matches()`, which powers the lint exclusion logic, also uses this setting), but the new up-front validation in v3.1.1 incorrectly used `perl = FALSE`.
 * `.lintr` configs set by option `lintr.linter_file` or environment variable `R_LINTR_LINTER_FILE` can point to subdirectories (#2512, @MichaelChirico).

--- a/NEWS.md
+++ b/NEWS.md
@@ -20,6 +20,7 @@
 
 ## Bug fixes
 
+* `expect_identical_linter()` no longer lints `expect_equal()` comparison to negative non-integers (#2411, @Bisaloo).
 * `object_name_linter()` no longer errors when user-supplied `regexes=` have capture groups (#2188, @MichaelChirico).
 * `.lintr` config validation correctly accepts regular expressions which only compile under `perl = TRUE` (#2375, @MichaelChirico). These have always been valid (since `rex::re_matches()`, which powers the lint exclusion logic, also uses this setting), but the new up-front validation in v3.1.1 incorrectly used `perl = FALSE`.
 * `.lintr` configs set by option `lintr.linter_file` or environment variable `R_LINTR_LINTER_FILE` can point to subdirectories (#2512, @MichaelChirico).

--- a/R/expect_identical_linter.R
+++ b/R/expect_identical_linter.R
@@ -60,33 +60,30 @@ expect_identical_linter <- function() {
   #   - skip cases like expect_equal(x, 1.02) or the constant vector version
   #     where a numeric constant indicates inexact testing is preferable
   #   - skip calls using dots (`...`); see tests
-  expect_equal_xpath <- "
+  non_integer <- "NUM_CONST[contains(text(), '.')]"
+  non_integer_negative <- glue::glue("
+    OP-MINUS
+    and count(expr) = 1
+    and expr[{non_integer}]
+  ")
+
+  expect_equal_xpath <- glue::glue("
   parent::expr[not(
       following-sibling::EQ_SUB
       or following-sibling::expr[
         (
           expr[1][SYMBOL_FUNCTION_CALL[text() = 'c']]
           and expr[
-            NUM_CONST[contains(text(), '.')]
-            or (
-              OP-MINUS
-              and count(expr) = 1
-              and expr[
-                NUM_CONST[contains(text(), '.')]
-              ]
-            )
+            {non_integer} or {non_integer_negative}
           ]
         ) or (
-          NUM_CONST[contains(text(), '.')]
+          {non_integer} or {non_integer_negative}
         ) or (
           OP-MINUS
           and count(expr) = 1
           and expr[
-            NUM_CONST[contains(text(), '.')]
-            or (
-              expr[1][SYMBOL_FUNCTION_CALL[text() = 'c']]
-              and expr[NUM_CONST[contains(text(), '.')]]
-            )
+            expr[1][SYMBOL_FUNCTION_CALL[text() = 'c']]
+            and expr[{non_integer}]
           ]
         ) or (
           SYMBOL[text() = '...']
@@ -94,7 +91,7 @@ expect_identical_linter <- function() {
       ]
     )]
     /parent::expr
-  "
+  ")
   expect_true_xpath <- "
   parent::expr
     /following-sibling::expr[1][expr[1]/SYMBOL_FUNCTION_CALL[text() = 'identical']]

--- a/R/expect_identical_linter.R
+++ b/R/expect_identical_linter.R
@@ -70,6 +70,7 @@ expect_identical_linter <- function() {
       or following-sibling::expr[NUM_CONST[contains(text(), '.')]]
       or following-sibling::expr[
         OP-MINUS
+        and count(expr) = 1
         and expr[NUM_CONST[contains(text(), '.')]]
       ]
       or following-sibling::expr[SYMBOL[text() = '...']]

--- a/R/expect_identical_linter.R
+++ b/R/expect_identical_linter.R
@@ -66,7 +66,16 @@ expect_identical_linter <- function() {
       or following-sibling::expr[
         (
           expr[1][SYMBOL_FUNCTION_CALL[text() = 'c']]
-          and expr[NUM_CONST[contains(text(), '.')]]
+          and expr[
+            NUM_CONST[contains(text(), '.')]
+            or (
+              OP-MINUS
+              and count(expr) = 1
+              and expr[
+                NUM_CONST[contains(text(), '.')]
+              ]
+            )
+          ]
         ) or (
           NUM_CONST[contains(text(), '.')]
         ) or (

--- a/R/expect_identical_linter.R
+++ b/R/expect_identical_linter.R
@@ -68,6 +68,10 @@ expect_identical_linter <- function() {
         and expr[NUM_CONST[contains(text(), '.')]]
       ]
       or following-sibling::expr[NUM_CONST[contains(text(), '.')]]
+      or following-sibling::expr[
+        OP-MINUS
+        and expr[NUM_CONST[contains(text(), '.')]]
+      ]
       or following-sibling::expr[SYMBOL[text() = '...']]
     )]
     /parent::expr

--- a/R/expect_identical_linter.R
+++ b/R/expect_identical_linter.R
@@ -64,16 +64,19 @@ expect_identical_linter <- function() {
   parent::expr[not(
       following-sibling::EQ_SUB
       or following-sibling::expr[
-        expr[1][SYMBOL_FUNCTION_CALL[text() = 'c']]
-        and expr[NUM_CONST[contains(text(), '.')]]
+        (
+          expr[1][SYMBOL_FUNCTION_CALL[text() = 'c']]
+          and expr[NUM_CONST[contains(text(), '.')]]
+        ) or (
+          NUM_CONST[contains(text(), '.')]
+        ) or (
+          OP-MINUS
+          and count(expr) = 1
+          and expr[NUM_CONST[contains(text(), '.')]]
+        ) or (
+          SYMBOL[text() = '...']
+        )
       ]
-      or following-sibling::expr[NUM_CONST[contains(text(), '.')]]
-      or following-sibling::expr[
-        OP-MINUS
-        and count(expr) = 1
-        and expr[NUM_CONST[contains(text(), '.')]]
-      ]
-      or following-sibling::expr[SYMBOL[text() = '...']]
     )]
     /parent::expr
   "

--- a/R/expect_identical_linter.R
+++ b/R/expect_identical_linter.R
@@ -72,7 +72,13 @@ expect_identical_linter <- function() {
         ) or (
           OP-MINUS
           and count(expr) = 1
-          and expr[NUM_CONST[contains(text(), '.')]]
+          and expr[
+            NUM_CONST[contains(text(), '.')]
+            or (
+              expr[1][SYMBOL_FUNCTION_CALL[text() = 'c']]
+              and expr[NUM_CONST[contains(text(), '.')]]
+            )
+          ]
         ) or (
           SYMBOL[text() = '...']
         )

--- a/R/expect_identical_linter.R
+++ b/R/expect_identical_linter.R
@@ -60,11 +60,13 @@ expect_identical_linter <- function() {
   #   - skip cases like expect_equal(x, 1.02) or the constant vector version
   #     where a numeric constant indicates inexact testing is preferable
   #   - skip calls using dots (`...`); see tests
-  non_integer <- "NUM_CONST[contains(text(), '.')]"
-  non_integer_negative <- glue::glue("
-    OP-MINUS
-    and count(expr) = 1
-    and expr[{non_integer}]
+  non_integer <- glue::glue("
+    NUM_CONST[contains(text(), '.')]
+    or (
+      OP-MINUS
+      and count(expr) = 1
+      and expr[NUM_CONST[contains(text(), '.')]]
+    )
   ")
 
   expect_equal_xpath <- glue::glue("
@@ -73,11 +75,9 @@ expect_identical_linter <- function() {
       or following-sibling::expr[
         (
           expr[1][SYMBOL_FUNCTION_CALL[text() = 'c']]
-          and expr[
-            {non_integer} or {non_integer_negative}
-          ]
+          and expr[{non_integer}]
         ) or (
-          {non_integer} or {non_integer_negative}
+          {non_integer}
         ) or (
           OP-MINUS
           and count(expr) = 1

--- a/tests/testthat/test-expect_identical_linter.R
+++ b/tests/testthat/test-expect_identical_linter.R
@@ -41,7 +41,8 @@ test_that("expect_identical_linter skips cases likely testing numeric equality",
   #   also a violation of expect_true_false_linter()
   expect_lint("expect_equal(x, TRUE)", lint_msg, linter)
 
-  expect_lint("expect_equal(x, 1.01-y)", lint_msg, linter)
+  expect_lint("expect_equal(x, 1.01 - y)", lint_msg, linter)
+  expect_lint("expect_equal(x, foo() - 0.01)", lint_msg, linter)
 })
 
 test_that("expect_identical_linter skips 3e cases needing expect_equal", {

--- a/tests/testthat/test-expect_identical_linter.R
+++ b/tests/testthat/test-expect_identical_linter.R
@@ -30,6 +30,7 @@ test_that("expect_identical_linter skips cases likely testing numeric equality",
   lint_msg <- rex::rex("Use expect_identical(x, y) by default; resort to expect_equal() only when needed")
 
   expect_lint("expect_equal(x, 1.034)", NULL, linter)
+  expect_lint("expect_equal(x, -1.034)", NULL, linter)
   expect_lint("expect_equal(x, c(1.01, 1.02))", NULL, linter)
   # whole numbers with explicit decimals are OK, even in mixed scenarios
   expect_lint("expect_equal(x, c(1.0, 2))", NULL, linter)

--- a/tests/testthat/test-expect_identical_linter.R
+++ b/tests/testthat/test-expect_identical_linter.R
@@ -31,6 +31,9 @@ test_that("expect_identical_linter skips cases likely testing numeric equality",
 
   expect_lint("expect_equal(x, 1.034)", NULL, linter)
   expect_lint("expect_equal(x, -1.034)", NULL, linter)
+  expect_lint("expect_equal(x, c(-1.034))", NULL, linter)
+  expect_lint("expect_equal(x, -c(1.034))", NULL, linter)
+
   expect_lint("expect_equal(x, c(1.01, 1.02))", NULL, linter)
   # whole numbers with explicit decimals are OK, even in mixed scenarios
   expect_lint("expect_equal(x, c(1.0, 2))", NULL, linter)

--- a/tests/testthat/test-expect_identical_linter.R
+++ b/tests/testthat/test-expect_identical_linter.R
@@ -40,6 +40,8 @@ test_that("expect_identical_linter skips cases likely testing numeric equality",
   # NB: TRUE is a NUM_CONST so we want test matching it, even though this test is
   #   also a violation of expect_true_false_linter()
   expect_lint("expect_equal(x, TRUE)", lint_msg, linter)
+
+  expect_lint("expect_equal(x, 1.01-y)", lint_msg, linter)
 })
 
 test_that("expect_identical_linter skips 3e cases needing expect_equal", {


### PR DESCRIPTION
Fix #2410 