### PR TITLE
Move shared constant to the right file

### DIFF
--- a/R/object_name_linter.R
+++ b/R/object_name_linter.R
@@ -174,25 +174,6 @@ check_style <- function(nms, style, generics = character()) {
   conforming
 }
 
-# see ?".onLoad", ?Startup, and ?quit. Remove leading dot to match behavior of strip_names().
-#   All of .onLoad, .onAttach, and .onUnload are used in base packages,
-#   and should be caught in is_base_function; they're included here for completeness / stability
-#   (they don't strictly _have_ to be defined in base, so could in principle be removed).
-#   .Last.sys and .First.sys are part of base itself, so aren't included here.
-special_funs <- c(
-  ".onLoad",
-  ".onAttach",
-  ".onUnload",
-  ".onDetach",
-  ".Last.lib",
-  ".First",
-  ".Last"
-)
-
-is_special_function <- function(x) {
-  x %in% special_funs
-}
-
 loweralnum <- rex(one_of(lower, digit))
 upperalnum <- rex(one_of(upper, digit))
 

--- a/R/shared_constants.R
+++ b/R/shared_constants.R
@@ -309,3 +309,22 @@ purrr_mappers <- c(
   "map_raw", "map_lgl", "map_int", "map_dbl", "map_chr", "map_vec",
   "map_df", "map_dfr", "map_dfc"
 )
+
+# see ?".onLoad", ?Startup, and ?quit.
+#   All of .onLoad, .onAttach, and .onUnload are used in base packages,
+#   and should be caught in is_base_function; they're included here for completeness / stability
+#   (they don't strictly _have_ to be defined in base, so could in principle be removed).
+#   .Last.sys and .First.sys are part of base itself, so aren't included here.
+special_funs <- c(
+  ".onLoad",
+  ".onAttach",
+  ".onUnload",
+  ".onDetach",
+  ".Last.lib",
+  ".First",
+  ".Last"
+)
+
+is_special_function <- function(x) {
+  x %in% special_funs
+}


### PR DESCRIPTION
Shared between `object_name_linter()` and `return_linter()`.