### PR TITLE
Fix `paste_linter()` Rd docs

### DIFF
--- a/R/paste_linter.R
+++ b/R/paste_linter.R
@@ -1,5 +1,7 @@
 #' Raise lints for several common poor usages of `paste()`
 #'
+#' @description
+#'
 #' The following issues are linted by default by this linter
 #'   (see arguments for which can be de-activated optionally):
 #'

--- a/man/paste_linter.Rd
+++ b/man/paste_linter.Rd
@@ -28,8 +28,6 @@ when it comes at the beginning or end of the input, to avoid requiring empty inp
 \description{
 The following issues are linted by default by this linter
 (see arguments for which can be de-activated optionally):
-}
-\details{
 \enumerate{
 \item Block usage of \code{\link[=paste]{paste()}} with \code{sep = ""}. \code{\link[=paste0]{paste0()}} is a faster, more concise alternative.
 \item Block usage of \code{paste()} or \code{paste0()} with \code{collapse = ", "}. \code{\link[=toString]{toString()}} is a direct


### PR DESCRIPTION
The description breaks in the middle because of an empty line.

cf. https://lintr.r-lib.org/dev/reference/paste_linter.html