### PR TITLE
Use file-level where possible for faster computation

### DIFF
--- a/R/lint.R
+++ b/R/lint.R
@@ -77,9 +77,13 @@ lint <- function(filename, linters = NULL, ..., cache = FALSE, parse_settings = 
   if (!is_tainted(source_expressions$lines)) {
     for (expr in source_expressions$expressions) {
       if (is_lint_level(expr, "expression")) {
-        necessary_linters <- expression_linter_names
+        necessary_linters <- character()
       } else {
-        necessary_linters <- file_linter_names
+        necessary_linters <- names(linters)
+
+        expr$lines <- expr$file_lines
+        expr$xml_parsed_content <- expr$full_xml_parsed_content
+        expr$parsed_content <- expr$full_parsed_content
       }
       for (linter in necessary_linters) {
         # use withCallingHandlers for friendlier failures on unexpected linter errors


### PR DESCRIPTION
There are only two linters incompatible with file-level lints (as evidenced by the hacky PR failures here):

* cyclocomp_linter
* spaces_left_parentheses_linter

All other linters could compute on the single file-level source expression, for potentially huge gains by avoiding function calls, loops, appends, ...

What needs to be solved is how to cache and retrieve lints in this run mode.
Once that's done, we can add a new attribute (`max_level`?) to `Linter()` that signals `lint()` that the linter can handle parallel linting of all expression-level source expressions.

WDYT about the idea?
Do you have any ideas on the cache part?
I'm especially interested in the scenario where a cache entry is available for most, but not all individual expressions.