### PR TITLE
Sort default_undesirable docs robustly

### DIFF
--- a/.lintr
+++ b/.lintr
@@ -16,6 +16,7 @@ linters: all_linters(
     ),
     undesirable_function_linter(modify_defaults(
       defaults = default_undesirable_functions,
+      Sys.setlocale = NULL,
       library = NULL,
       options = NULL
     )),

--- a/.lintr
+++ b/.lintr
@@ -16,7 +16,6 @@ linters: all_linters(
     ),
     undesirable_function_linter(modify_defaults(
       defaults = default_undesirable_functions,
-      Sys.setlocale = NULL,
       library = NULL,
       options = NULL
     )),

--- a/R/utils.R
+++ b/R/utils.R
@@ -201,14 +201,9 @@ release_bullets <- function() {
 }
 # nocov end
 
-# see issue #923, PR #2455 -- some locales ignore _ when running sort(), others don't.
-#   we want to consistently treat "_" < "n" = "N"
-platform_independent_order <- function(x) {
-  old <- Sys.getlocale("LC_COLLATE")
-  Sys.setlocale("LC_COLLATE", "C")
-  on.exit(Sys.setlocale("LC_COLLATE", old))
-  order(tolower(x))
-}
+# see issue #923, PR #2455 -- some locales ignore _ when running sort(), others don't. so use C locale
+#   We want to consistently treat "_" < "n" = "N"; C locale does this, which 'radix' uses.
+platform_independent_order <- function(x) order(tolower(x), method = "radix")
 platform_independent_sort <- function(x) x[platform_independent_order(x)]
 
 #' Extract text from `STR_CONST` nodes

--- a/R/utils.R
+++ b/R/utils.R
@@ -201,9 +201,14 @@ release_bullets <- function() {
 }
 # nocov end
 
-# see issue #923 -- some locales ignore _ when running sort(), others don't.
+# see issue #923, PR #2455 -- some locales ignore _ when running sort(), others don't.
 #   we want to consistently treat "_" < "n" = "N"
-platform_independent_order <- function(x) order(tolower(gsub("_", "0", x, fixed = TRUE)))
+platform_independent_order <- function(x) {
+  old <- Sys.getlocale("LC_COLLATE")
+  Sys.setlocale("LC_COLLATE", "C")
+  on.exit(Sys.setlocale("LC_COLLATE", old))
+  order(tolower(x))
+}
 platform_independent_sort <- function(x) x[platform_independent_order(x)]
 
 #' Extract text from `STR_CONST` nodes

--- a/R/utils.R
+++ b/R/utils.R
@@ -201,7 +201,7 @@ release_bullets <- function() {
 }
 # nocov end
 
-# see issue #923, PR #2455 -- some locales ignore _ when running sort(), others don't. so use C locale
+# see issue #923, PR #2455 -- some locales ignore _ when running sort(), others don't.
 #   We want to consistently treat "_" < "n" = "N"; C locale does this, which 'radix' uses.
 platform_independent_order <- function(x) order(tolower(x), method = "radix")
 platform_independent_sort <- function(x) x[platform_independent_order(x)]

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -237,7 +237,7 @@ rd_undesirable_operators <- function() {
     "The following operators are sometimes regarded as undesirable:",
     "\\itemize{",
     sprintf(
-      "\\item \\code{%1$s} As an alternative, %2$s",
+      "\\item \\code{%1$s}. %2$s",
       op_link_map[op], alternatives
     ),
     "}"

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -176,15 +176,14 @@ rd_auto_link <- function(x) {
 }
 
 rd_undesirable_functions <- function() {
-  funs <- default_undesirable_functions[platform_independent_order(names(default_undesirable_functions))]
-  alternatives <- rd_auto_link(funs)
+  alternatives <- rd_auto_link(default_undesirable_functions)
 
   c(
     "The following functions are sometimes regarded as undesirable:",
     "\\itemize{",
     sprintf(
       "\\item \\code{\\link[=%1$s]{%1$s()}} As an alternative, %2$s.",
-      names(funs), alternatives
+      names(default_undesirable_functions), alternatives
     ),
     "}"
   )
@@ -225,22 +224,21 @@ default_undesirable_operators <- all_undesirable_operators[names(all_undesirable
 )]
 
 rd_undesirable_operators <- function() {
-  ops <- default_undesirable_operators[platform_independent_order(names(default_undesirable_operators))]
-
   op_link_map <- c(
     `:::` = "\\link[base:ns-dblcolon]{:::}",
     `<<-` = "\\link[base:assignOps]{<<-}",
     `->>` = "\\link[base:assignOps]{<<-}"
   )
+  op <- names(default_undesirable_operators)
 
-  alternatives <- rd_auto_link(ops)
+  alternatives <- rd_auto_link(default_undesirable_operators)
 
   c(
     "The following operators are sometimes regarded as undesirable:",
     "\\itemize{",
     sprintf(
       "\\item \\code{%1$s} As an alternative, %2$s",
-      op_link_map[names(ops)], alternatives
+      op_link_map[op], alternatives
     ),
     "}"
   )

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -176,14 +176,15 @@ rd_auto_link <- function(x) {
 }
 
 rd_undesirable_functions <- function() {
-  alternatives <- rd_auto_link(default_undesirable_functions)
+  funs <- default_undesirable_functions[platform_independent_order(names(default_undesirable_functions))]
+  alternatives <- rd_auto_link(funs)
 
   c(
     "The following functions are sometimes regarded as undesirable:",
     "\\itemize{",
     sprintf(
       "\\item \\code{\\link[=%1$s]{%1$s()}} As an alternative, %2$s.",
-      names(default_undesirable_functions), alternatives
+      names(funs), alternatives
     ),
     "}"
   )
@@ -224,21 +225,22 @@ default_undesirable_operators <- all_undesirable_operators[names(all_undesirable
 )]
 
 rd_undesirable_operators <- function() {
+  ops <- default_undesirable_operators[platform_independent_order(names(default_undesirable_operators))]
+
   op_link_map <- c(
     `:::` = "\\link[base:ns-dblcolon]{:::}",
     `<<-` = "\\link[base:assignOps]{<<-}",
     `->>` = "\\link[base:assignOps]{<<-}"
   )
-  op <- names(default_undesirable_operators)
 
-  alternatives <- rd_auto_link(default_undesirable_operators)
+  alternatives <- rd_auto_link(ops)
 
   c(
     "The following operators are sometimes regarded as undesirable:",
     "\\itemize{",
     sprintf(
       "\\item \\code{%1$s} As an alternative, %2$s",
-      op_link_map[op], alternatives
+      op_link_map[names(ops)], alternatives
     ),
     "}"
   )

--- a/man/default_undesirable_functions.Rd
+++ b/man/default_undesirable_functions.Rd
@@ -54,8 +54,8 @@ The following functions are sometimes regarded as undesirable:
 
 The following operators are sometimes regarded as undesirable:
 \itemize{
-\item \code{\link[base:assignOps]{<<-}} As an alternative, It assigns outside the current environment in a way that can be hard to reason about. Prefer fully-encapsulated functions wherever possible, or, if necessary, assign to a specific environment with \code{\link[=assign]{assign()}}. Recall that you can create an environment at the desired scope with \code{\link[=new.env]{new.env()}}.
-\item \code{\link[base:ns-dblcolon]{:::}} As an alternative, It accesses non-exported functions inside packages. Code relying on these is likely to break in future versions of the package because the functions are not part of the public interface and may be changed or removed by the maintainers without notice. Use public functions via \code{::} instead.
-\item \code{\link[base:assignOps]{<<-}} As an alternative, It assigns outside the current environment in a way that can be hard to reason about. Prefer fully-encapsulated functions wherever possible, or, if necessary, assign to a specific environment with \code{\link[=assign]{assign()}}. Recall that you can create an environment at the desired scope with \code{\link[=new.env]{new.env()}}.
+\item \code{\link[base:assignOps]{<<-}}. It assigns outside the current environment in a way that can be hard to reason about. Prefer fully-encapsulated functions wherever possible, or, if necessary, assign to a specific environment with \code{\link[=assign]{assign()}}. Recall that you can create an environment at the desired scope with \code{\link[=new.env]{new.env()}}.
+\item \code{\link[base:ns-dblcolon]{:::}}. It accesses non-exported functions inside packages. Code relying on these is likely to break in future versions of the package because the functions are not part of the public interface and may be changed or removed by the maintainers without notice. Use public functions via \code{::} instead.
+\item \code{\link[base:assignOps]{<<-}}. It assigns outside the current environment in a way that can be hard to reason about. Prefer fully-encapsulated functions wherever possible, or, if necessary, assign to a specific environment with \code{\link[=assign]{assign()}}. Recall that you can create an environment at the desired scope with \code{\link[=new.env]{new.env()}}.
 }
 }

--- a/man/default_undesirable_functions.Rd
+++ b/man/default_undesirable_functions.Rd
@@ -28,13 +28,13 @@ Use \code{\link[=modify_defaults]{modify_defaults()}} to produce a custom list.
 \details{
 The following functions are sometimes regarded as undesirable:
 \itemize{
+\item \code{\link[=.libPaths]{.libPaths()}} As an alternative, use \code{\link[withr:with_libpaths]{withr::with_libpaths()}} for a temporary change instead of permanently modifying the library location.
 \item \code{\link[=attach]{attach()}} As an alternative, use roxygen2's @importFrom statement in packages, or \code{::} in scripts. \code{\link[=attach]{attach()}} modifies the global search path.
 \item \code{\link[=browser]{browser()}} As an alternative, remove this likely leftover from debugging. It pauses execution when run.
 \item \code{\link[=debug]{debug()}} As an alternative, remove this likely leftover from debugging. It traps a function and causes execution to pause when that function is run.
 \item \code{\link[=debugcall]{debugcall()}} As an alternative, remove this likely leftover from debugging. It traps a function and causes execution to pause when that function is run.
 \item \code{\link[=debugonce]{debugonce()}} As an alternative, remove this likely leftover from debugging. It traps a function and causes execution to pause when that function is run.
 \item \code{\link[=detach]{detach()}} As an alternative, avoid modifying the global search path. Detaching environments from the search path is rarely necessary in production code.
-\item \code{\link[=.libPaths]{.libPaths()}} As an alternative, use \code{\link[withr:with_libpaths]{withr::with_libpaths()}} for a temporary change instead of permanently modifying the library location.
 \item \code{\link[=library]{library()}} As an alternative, use roxygen2's @importFrom statement in packages and \code{::} in scripts, instead of modifying the global search path.
 \item \code{\link[=mapply]{mapply()}} As an alternative, use \code{\link[=Map]{Map()}} to guarantee a list is returned and simplify accordingly.
 \item \code{\link[=options]{options()}} As an alternative, use \code{\link[withr:with_options]{withr::with_options()}} for a temporary change instead of permanently modifying the session options.
@@ -55,7 +55,7 @@ The following functions are sometimes regarded as undesirable:
 The following operators are sometimes regarded as undesirable:
 \itemize{
 \item \code{\link[base:assignOps]{<<-}} As an alternative, It assigns outside the current environment in a way that can be hard to reason about. Prefer fully-encapsulated functions wherever possible, or, if necessary, assign to a specific environment with \code{\link[=assign]{assign()}}. Recall that you can create an environment at the desired scope with \code{\link[=new.env]{new.env()}}.
-\item \code{\link[base:assignOps]{<<-}} As an alternative, It assigns outside the current environment in a way that can be hard to reason about. Prefer fully-encapsulated functions wherever possible, or, if necessary, assign to a specific environment with \code{\link[=assign]{assign()}}. Recall that you can create an environment at the desired scope with \code{\link[=new.env]{new.env()}}.
 \item \code{\link[base:ns-dblcolon]{:::}} As an alternative, It accesses non-exported functions inside packages. Code relying on these is likely to break in future versions of the package because the functions are not part of the public interface and may be changed or removed by the maintainers without notice. Use public functions via \code{::} instead.
+\item \code{\link[base:assignOps]{<<-}} As an alternative, It assigns outside the current environment in a way that can be hard to reason about. Prefer fully-encapsulated functions wherever possible, or, if necessary, assign to a specific environment with \code{\link[=assign]{assign()}}. Recall that you can create an environment at the desired scope with \code{\link[=new.env]{new.env()}}.
 }
 }

--- a/man/todo_comment_linter.Rd
+++ b/man/todo_comment_linter.Rd
@@ -18,22 +18,17 @@ Check that the source contains no TODO comments (case-insensitive).
 \examples{
 # will produce lints
 lint(
-  text = "x + y # TODO",
-  linters = todo_comment_linter()
+  text = "x + y # TOODOO",
+  linters = todo_comment_linter(todo = "toodoo")
 )
 
 lint(
-  text = "pi <- 1.0 # FIXME",
-  linters = todo_comment_linter()
+  text = "pi <- 1.0 # FIIXMEE",
+  linters = todo_comment_linter(todo = "fiixmee")
 )
 
 lint(
-  text = "x <- TRUE # hack",
-  linters = todo_comment_linter(todo = c("todo", "fixme", "hack"))
-)
-
-lint(
-  text = "x <- TRUE # TODO(#1234): Fix this hack.",
+  text = "x <- TRUE # TOODOO(#1234): Fix this hack.",
   linters = todo_comment_linter()
 )
 


### PR DESCRIPTION
Have been getting some spurious diffs vs. `main` on this. Is anyone else seeing it? I'm a bit surprised because the `default*` objects are coming from `modify_defaults()`, which uses `platform_independent_order()` already:

https://github.com/r-lib/lintr/blob/fdbb9bfa1ea868ad66c6fe9a30b4ae872c03f56e/R/with.R#L59

Maybe this is a call to improve `platform_independent_order()`? That's pretty rudimentary indeed:

https://github.com/r-lib/lintr/blob/fdbb9bfa1ea868ad66c6fe9a30b4ae872c03f56e/R/utils.R#L206-L207