### PR TITLE
New parameter 'land_on' to xml_find_function_calls()

### DIFF
--- a/R/any_duplicated_linter.R
+++ b/R/any_duplicated_linter.R
@@ -34,14 +34,13 @@
 #' @seealso [linters] for a complete list of linters available in lintr.
 #' @export
 any_duplicated_linter <- function() {
-  any_duplicated_xpath <- "
-  parent::expr
-    /following-sibling::expr[1][expr[1][SYMBOL_FUNCTION_CALL[text() = 'duplicated']]]
-    /parent::expr[
+  any_duplicated_xpath <- "self::expr[
+    expr[2]/expr[1]/SYMBOL_FUNCTION_CALL[text() = 'duplicated']
+    and (
       count(expr) = 2
       or (count(expr) = 3 and SYMBOL_SUB[text() = 'na.rm'])
-    ]
-  "
+    )
+  ]"
 
   # outline:
   #   EQ/NE/GT/LT: ensure we're in a comparison clause
@@ -86,7 +85,7 @@ any_duplicated_linter <- function() {
 
   Linter(linter_level = "expression", function(source_expression) {
     xml <- source_expression$xml_parsed_content
-    xml_calls <- source_expression$xml_find_function_calls("any")
+    xml_calls <- source_expression$xml_find_function_calls("any", land_on = "call_expr")
 
     any_duplicated_expr <- xml_find_all(xml_calls, any_duplicated_xpath)
     any_duplicated_lints <- xml_nodes_to_lints(

--- a/R/any_is_na_linter.R
+++ b/R/any_is_na_linter.R
@@ -36,20 +36,20 @@
 #' @seealso [linters] for a complete list of linters available in lintr.
 #' @export
 any_is_na_linter <- function() {
-  any_xpath <- "
-  parent::expr
-    /following-sibling::expr[1][expr[1][SYMBOL_FUNCTION_CALL[text() = 'is.na']]]
-    /parent::expr[
+  any_xpath <- "self::expr[
+    expr[2]/expr[1]/SYMBOL_FUNCTION_CALL[text() = 'is.na']
+    and (
       count(expr) = 2
       or (count(expr) = 3 and SYMBOL_SUB[text() = 'na.rm'])
-    ]
+    )
+  ]
   "
 
   in_xpath <- "//SPECIAL[text() = '%in%']/preceding-sibling::expr[NUM_CONST[starts-with(text(), 'NA')]]"
 
   Linter(linter_level = "expression", function(source_expression) {
     xml <- source_expression$xml_parsed_content
-    xml_calls <- source_expression$xml_find_function_calls("any")
+    xml_calls <- source_expression$xml_find_function_calls("any", land_on = "call_expr")
 
     any_expr <- xml_find_all(xml_calls, any_xpath)
     any_lints <- xml_nodes_to_lints(

--- a/R/class_equals_linter.R
+++ b/R/class_equals_linter.R
@@ -35,8 +35,7 @@
 #' @export
 class_equals_linter <- function() {
   xpath <- "
-  parent::expr
-    /parent::expr
+  self::expr
     /parent::expr[
       not(preceding-sibling::OP-LEFT-BRACKET)
       and (EQ or NE or SPECIAL[text() = '%in%'])
@@ -44,7 +43,7 @@ class_equals_linter <- function() {
   "
 
   Linter(linter_level = "expression", function(source_expression) {
-    xml_calls <- source_expression$xml_find_function_calls("class")
+    xml_calls <- source_expression$xml_find_function_calls("class", land_on = "call_expr")
     bad_expr <- xml_find_all(xml_calls, xpath)
 
     operator <- xml_find_chr(bad_expr, "string(*[2])")

--- a/R/condition_call_linter.R
+++ b/R/condition_call_linter.R
@@ -57,11 +57,11 @@
 #' @export
 condition_call_linter <- function(display_call = FALSE) {
   call_xpath <- glue::glue("
-    following-sibling::SYMBOL_SUB[text() = 'call.']
+    SYMBOL_SUB[text() = 'call.']
       /following-sibling::expr[1]
       /NUM_CONST[text() = '{!display_call}']
   ")
-  no_call_xpath <- "parent::expr[not(SYMBOL_SUB[text() = 'call.'])]"
+  no_call_xpath <- "not(SYMBOL_SUB[text() = 'call.'])"
 
   if (is.na(display_call)) {
     call_cond <- no_call_xpath
@@ -77,10 +77,10 @@ condition_call_linter <- function(display_call = FALSE) {
     msg_fmt <- "Use %s(., call. = FALSE) not to display the call in an error message."
   }
 
-  xpath <- glue::glue("parent::expr[{call_cond}]/parent::expr")
+  xpath <- glue::glue("self::expr[{call_cond}]")
 
   Linter(linter_level = "expression", function(source_expression) {
-    xml_calls <- source_expression$xml_find_function_calls(c("stop", "warning"))
+    xml_calls <- source_expression$xml_find_function_calls(c("stop", "warning"), land_on = "call_expr")
     bad_expr <- xml_find_all(xml_calls, xpath)
 
     xml_nodes_to_lints(

--- a/R/consecutive_assertion_linter.R
+++ b/R/consecutive_assertion_linter.R
@@ -35,14 +35,12 @@ consecutive_assertion_linter <- function() {
   next_expr <- "following-sibling::*[self::expr or self::expr_or_assign_or_help or self::equal_assign][1]"
 
   stopifnot_xpath <- glue("
-  parent::expr
-    /parent::expr[
+    self::expr[
       expr[1]/SYMBOL_FUNCTION_CALL = {next_expr}/expr[1]/SYMBOL_FUNCTION_CALL
     ]
   ")
   assert_that_xpath <- glue("
-  parent::expr
-    /parent::expr[
+    self::expr[
       not(SYMBOL_SUB[text() = 'msg'])
       and not(following-sibling::expr[1]/SYMBOL_SUB[text() = 'msg'])
       and expr[1]/SYMBOL_FUNCTION_CALL = {next_expr}/expr[1]/SYMBOL_FUNCTION_CALL
@@ -51,8 +49,8 @@ consecutive_assertion_linter <- function() {
 
   Linter(linter_level = "file", function(source_expression) {
     # need the full file to also catch usages at the top level
-    stopifnot_calls <- source_expression$xml_find_function_calls("stopifnot")
-    assert_that_calls <- source_expression$xml_find_function_calls("assert_that")
+    stopifnot_calls <- source_expression$xml_find_function_calls("stopifnot", land_on = "call_expr")
+    assert_that_calls <- source_expression$xml_find_function_calls("assert_that", land_on = "call_expr")
     bad_expr <- combine_nodesets(
       xml_find_all(stopifnot_calls, stopifnot_xpath),
       xml_find_all(assert_that_calls, assert_that_xpath)

--- a/R/get_source_expressions.R
+++ b/R/get_source_expressions.R
@@ -36,9 +36,11 @@
 #'  * `filename` (`character`) the name of the file.
 #'  * `line` (`integer`) the line in the file where this expression begins.
 #'  * `column` (`integer`) the column in the file where this expression begins.
-#'  * `lines` (named `character`) vector of all lines spanned by this expression, named with the corresponding line numbers.
+#'  * `lines` (named `character`) vector of all lines spanned by this expression,
+#'    named with the corresponding line numbers.
 #'  * `parsed_content` (`data.frame`) as given by [utils::getParseData()] for this expression.
-#'  * `xml_parsed_content` (`xml_document`) the XML parse tree of this expression as given by [xmlparsedata::xml_parse_data()].
+#'  * `xml_parsed_content` (`xml_document`) the XML parse tree of this expression
+#'    as given by [xmlparsedata::xml_parse_data()].
 #'  * `content` (`character`) the same as `lines` as a single string (not split across lines).
 #'  * `xml_find_function_calls(function_names, keep_names, land_on)` (`function`) a function for quickly
 #'    accessing cached function calls in the XML tree. There are three parameters:

--- a/R/get_source_expressions.R
+++ b/R/get_source_expressions.R
@@ -16,43 +16,51 @@
 #'   If `NULL`, then `filename` will be read.
 #' @return A `list` with three components:
 #' \describe{
-#'   \item{expressions}{a `list` of
-#'   `n+1` objects. The first `n` elements correspond to each expression in
-#'   `filename`, and consist of a list of 8 elements:
-#'   \itemize{
-#'     \item{`filename` (`character`) the name of the file.}
-#'     \item{`line` (`integer`) the line in the file where this expression begins.}
-#'     \item{`column` (`integer`) the column in the file where this expression begins.}
-#'     \item{`lines` (named `character`) vector of all lines spanned by this
-#'           expression, named with the corresponding line numbers.}
-#'     \item{`parsed_content` (`data.frame`) as given by [utils::getParseData()] for this expression.}
-#'     \item{`xml_parsed_content` (`xml_document`) the XML parse tree of this expression as given by
-#'           [xmlparsedata::xml_parse_data()].}
-#'     \item{`content` (`character`) the same as `lines` as a single string (not split across lines).}
-#'     \item{`xml_find_function_calls(function_names)` (`function`) a function that returns all `SYMBOL_FUNCTION_CALL`
-#'           XML nodes from `xml_parsed_content` with specified function names.}
-#'   }
-#'
-#'   The final element of `expressions` is a list corresponding to the full file
-#'   consisting of 7 elements:
-#'   \itemize{
-#'     \item{`filename` (`character`) the name of this file.}
-#'     \item{`file_lines` (`character`) the [readLines()] output for this file.}
-#'     \item{`content` (`character`) for .R files, the same as `file_lines`;
-#'           for .Rmd or .qmd scripts, this is the extracted R source code (as text).}
-#'     \item{`full_parsed_content` (`data.frame`) as given by
-#'           [utils::getParseData()] for the full content.}
-#'     \item{`full_xml_parsed_content` (`xml_document`) the XML parse tree of all
-#'           expressions as given by [xmlparsedata::xml_parse_data()].}
-#'     \item{`terminal_newline` (`logical`) records whether `filename` has a terminal
-#'           newline (as determined by [readLines()] producing a corresponding warning).}
-#'     \item{`xml_find_function_calls(function_names)` (`function`) a function that returns all `SYMBOL_FUNCTION_CALL`
-#'           XML nodes from `full_xml_parsed_content` with specified function names.}
-#'   }
-#'   }
+#'   \item{expressions}{a `list` of `n+1` objects. The first `n` elements correspond to each expression in
+#'     `filename`, and the last element corresponds to the full file. See sections on source expressions.}
 #'   \item{error}{A `Lint` object describing any parsing error.}
 #'   \item{lines}{The [readLines()] output for this file.}
 #' }
+#'
+#' @details
+#' # Source expressions
+#'
+#' The `expressions` objects come in two flavors: one for each expression in a file, the other for
+#'   the entire file. They are very similar but differ in important ways. Expression-level objects
+#'   are better for caching (since expressions change less often than whole files), but some lints
+#'   cannot be expressed at the expression level. A precise description follows:
+#'
+#' ## Expresion-level objects
+#'
+#' These correspond to each top-level expression in the file and consist of a list of 8 elements:
+#'  * `filename` (`character`) the name of the file.
+#'  * `line` (`integer`) the line in the file where this expression begins.
+#'  * `column` (`integer`) the column in the file where this expression begins.
+#'  * `lines` (named `character`) vector of all lines spanned by this expression, named with the corresponding line numbers.
+#'  * `parsed_content` (`data.frame`) as given by [utils::getParseData()] for this expression.
+#'  * `xml_parsed_content` (`xml_document`) the XML parse tree of this expression as given by [xmlparsedata::xml_parse_data()].
+#'  * `content` (`character`) the same as `lines` as a single string (not split across lines).
+#'  * `xml_find_function_calls(function_names, keep_names, land_on)` (`function`) a function for quickly
+#'    accessing cached function calls in the XML tree. There are three parameters:
+#'     * `function_names` (`character`, default `NULL`) The function(s) to return. `NULL` means all functions.
+#'     * `keep_names` (`logical`, default `FALSE`) Whether to associate each item with the associated function name.
+#'     * `land_on` (`character`, default `"call_symbol"`) Where in the tree should the returned object land?
+#'       The default is to land on the `<SYMBOL_FUNCTION_CALL>` node; `"call_symbol_expr"` gives the `parent::expr`
+#'       of this node, and `"call_expr"` gives the `parent::expr/parent::expr` of this node.
+#'
+#' ## File-level objects
+#'
+#' These encompass the entire file at once and consist of a list of 7 elements:
+#'
+#'  * `filename` (`character`) the name of this file.
+#'  * `file_lines` (`character`) the [readLines()] output for this file.
+#'  * `content` (`character`) for .R files, the same as `file_lines`;
+#'    for .Rmd or .qmd scripts, this is the extracted R source code (as text).
+#'  * `full_parsed_content` (`data.frame`) Same as expression-level `parsed_content`, for the whole file.
+#'  * `full_xml_parsed_content` (`xml_document`) Same as expression-level `xml_parsed_content`, for the whole file.
+#'  * `terminal_newline` (`logical`) records whether `filename` has a terminal
+#'    newline (as determined by [readLines()] producing a corresponding warning).
+#'  * `xml_find_function_calls(function_names, keep_names, land_on)` (`function`) Same as in expression level object.
 #'
 #' @examplesIf requireNamespace("withr", quietly = TRUE)
 #' tmp <- withr::local_tempfile(lines = c("x <- 1", "y <- x + 1"))

--- a/R/source_utils.R
+++ b/R/source_utils.R
@@ -12,12 +12,18 @@ build_xml_find_function_calls <- function(xml) {
   function_call_cache <- xml_find_all(xml, "//SYMBOL_FUNCTION_CALL")
   names(function_call_cache) <- get_r_string(function_call_cache)
 
-  function(function_names, keep_names = FALSE) {
+  function(function_names, keep_names = FALSE, land_on = c("call_symbol", "call_symbol_expr", "call_expr")) {
+    land_on <- match.arg(land_on)
     if (is.null(function_names)) {
       res <- function_call_cache
     } else {
       res <- function_call_cache[names(function_call_cache) %in% function_names]
     }
-    if (keep_names) res else unname(res)
+    if (!keep_names) res <- unname(res)
+    switch(land_on,
+      call_symbol = res,
+      call_symbol_expr = xml_find_first(res, "parent::expr"),
+      call_expr = xml_find_first(res, "parent::expr/parent::expr")
+    )
   }
 }

--- a/man/get_source_expressions.Rd
+++ b/man/get_source_expressions.Rd
@@ -15,40 +15,8 @@ If \code{NULL}, then \code{filename} will be read.}
 \value{
 A \code{list} with three components:
 \describe{
-\item{expressions}{a \code{list} of
-\code{n+1} objects. The first \code{n} elements correspond to each expression in
-\code{filename}, and consist of a list of 8 elements:
-\itemize{
-\item{\code{filename} (\code{character}) the name of the file.}
-\item{\code{line} (\code{integer}) the line in the file where this expression begins.}
-\item{\code{column} (\code{integer}) the column in the file where this expression begins.}
-\item{\code{lines} (named \code{character}) vector of all lines spanned by this
-expression, named with the corresponding line numbers.}
-\item{\code{parsed_content} (\code{data.frame}) as given by \code{\link[utils:getParseData]{utils::getParseData()}} for this expression.}
-\item{\code{xml_parsed_content} (\code{xml_document}) the XML parse tree of this expression as given by
-\code{\link[xmlparsedata:xml_parse_data]{xmlparsedata::xml_parse_data()}}.}
-\item{\code{content} (\code{character}) the same as \code{lines} as a single string (not split across lines).}
-\item{\code{xml_find_function_calls(function_names)} (\code{function}) a function that returns all \code{SYMBOL_FUNCTION_CALL}
-XML nodes from \code{xml_parsed_content} with specified function names.}
-}
-
-The final element of \code{expressions} is a list corresponding to the full file
-consisting of 7 elements:
-\itemize{
-\item{\code{filename} (\code{character}) the name of this file.}
-\item{\code{file_lines} (\code{character}) the \code{\link[=readLines]{readLines()}} output for this file.}
-\item{\code{content} (\code{character}) for .R files, the same as \code{file_lines};
-for .Rmd or .qmd scripts, this is the extracted R source code (as text).}
-\item{\code{full_parsed_content} (\code{data.frame}) as given by
-\code{\link[utils:getParseData]{utils::getParseData()}} for the full content.}
-\item{\code{full_xml_parsed_content} (\code{xml_document}) the XML parse tree of all
-expressions as given by \code{\link[xmlparsedata:xml_parse_data]{xmlparsedata::xml_parse_data()}}.}
-\item{\code{terminal_newline} (\code{logical}) records whether \code{filename} has a terminal
-newline (as determined by \code{\link[=readLines]{readLines()}} producing a corresponding warning).}
-\item{\code{xml_find_function_calls(function_names)} (\code{function}) a function that returns all \code{SYMBOL_FUNCTION_CALL}
-XML nodes from \code{full_xml_parsed_content} with specified function names.}
-}
-}
+\item{expressions}{a \code{list} of \code{n+1} objects. The first \code{n} elements correspond to each expression in
+\code{filename}, and the last element corresponds to the full file. See sections on source expressions.}
 \item{error}{A \code{Lint} object describing any parsing error.}
 \item{lines}{The \code{\link[=readLines]{readLines()}} output for this file.}
 }
@@ -66,6 +34,51 @@ This setting is found by taking the first valid result from the following locati
 \item \code{"UTF-8"} as a fallback.
 }
 }
+\section{Source expressions}{
+The \code{expressions} objects come in two flavors: one for each expression in a file, the other for
+the entire file. They are very similar but differ in important ways. Expression-level objects
+are better for caching (since expressions change less often than whole files), but some lints
+cannot be expressed at the expression level. A precise description follows:
+\subsection{Expresion-level objects}{
+
+These correspond to each top-level expression in the file and consist of a list of 8 elements:
+\itemize{
+\item \code{filename} (\code{character}) the name of the file.
+\item \code{line} (\code{integer}) the line in the file where this expression begins.
+\item \code{column} (\code{integer}) the column in the file where this expression begins.
+\item \code{lines} (named \code{character}) vector of all lines spanned by this expression, named with the corresponding line numbers.
+\item \code{parsed_content} (\code{data.frame}) as given by \code{\link[utils:getParseData]{utils::getParseData()}} for this expression.
+\item \code{xml_parsed_content} (\code{xml_document}) the XML parse tree of this expression as given by \code{\link[xmlparsedata:xml_parse_data]{xmlparsedata::xml_parse_data()}}.
+\item \code{content} (\code{character}) the same as \code{lines} as a single string (not split across lines).
+\item \code{xml_find_function_calls(function_names, keep_names, land_on)} (\code{function}) a function for quickly
+accessing cached function calls in the XML tree. There are three parameters:
+\itemize{
+\item \code{function_names} (\code{character}, default \code{NULL}) The function(s) to return. \code{NULL} means all functions.
+\item \code{keep_names} (\code{logical}, default \code{FALSE}) Whether to associate each item with the associated function name.
+\item \code{land_on} (\code{character}, default \code{"call_symbol"}) Where in the tree should the returned object land?
+The default is to land on the \verb{<SYMBOL_FUNCTION_CALL>} node; \code{"call_symbol_expr"} gives the \code{parent::expr}
+of this node, and \code{"call_expr"} gives the \code{parent::expr/parent::expr} of this node.
+}
+}
+}
+
+\subsection{File-level objects}{
+
+These encompass the entire file at once and consist of a list of 7 elements:
+\itemize{
+\item \code{filename} (\code{character}) the name of this file.
+\item \code{file_lines} (\code{character}) the \code{\link[=readLines]{readLines()}} output for this file.
+\item \code{content} (\code{character}) for .R files, the same as \code{file_lines};
+for .Rmd or .qmd scripts, this is the extracted R source code (as text).
+\item \code{full_parsed_content} (\code{data.frame}) Same as expression-level \code{parsed_content}, for the whole file.
+\item \code{full_xml_parsed_content} (\code{xml_document}) Same as expression-level \code{xml_parsed_content}, for the whole file.
+\item \code{terminal_newline} (\code{logical}) records whether \code{filename} has a terminal
+newline (as determined by \code{\link[=readLines]{readLines()}} producing a corresponding warning).
+\item \code{xml_find_function_calls(function_names, keep_names, land_on)} (\code{function}) Same as in expression level object.
+}
+}
+}
+
 \examples{
 \dontshow{if (requireNamespace("withr", quietly = TRUE)) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
 tmp <- withr::local_tempfile(lines = c("x <- 1", "y <- x + 1"))


### PR DESCRIPTION
Closes #2431.

Draft for now -- demonstrating what implementation could look like / how XPaths could be adjusted.

It's looking like the most common landing is `parent::expr/parent::expr`. If so, I think it makes sense for the implementation to land the cached calls there by default, and use `xml_find_first()` to "descend" optionally, rather than the default behavior being an extra call to "ascend" every time. That is, we want to save the extra call to `xml_find_first()` as often as possible.