### PR TITLE
Ensure roxygen2 available for GHA

### DIFF
--- a/.github/workflows/repo-meta-tests.yaml
+++ b/.github/workflows/repo-meta-tests.yaml
@@ -22,6 +22,9 @@ jobs:
           use-public-rspm: true
 
       - uses: r-lib/actions/setup-r-dependencies@v2
+        with:
+          extra-packages: |
+            any::roxygen2
 
       - name: Ensure lint metadata is tested
         run: |


### PR DESCRIPTION
Based on https://github.com/r-lib/lintr/actions/runs/7454773326 failure.

I don't see how #2494 is related, so I assume what's happened is {roxygen2} fell out of the recursive dependencies of our deps with some recent package update. TBH I was surprised this entry in GHA wasn't needed when first implemented.