### PR TITLE
Skip basename() call when finding configs

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -19,6 +19,7 @@
 
 * `object_name_linter()` no longer errors when user-supplied `regexes=` have capture groups (#2188, @MichaelChirico).
 * `.lintr` config validation correctly accepts regular expressions which only compile under `perl = TRUE` (#2375, @MichaelChirico). These have always been valid (since `rex::re_matches()`, which powers the lint exclusion logic, also uses this setting), but the new up-front validation in v3.1.1 incorrectly used `perl = FALSE`.
+* `.lintr` configs set by option `lintr.linter_file` or environment variable `R_LINTR_LINTER_FILE` can point to specific package directories (#2512, @MichaelChirico).
 
 ## Changes to default linters
 

--- a/R/settings_utils.R
+++ b/R/settings_utils.R
@@ -75,7 +75,7 @@ find_config <- function(filename) {
   # may exist in subsequent directories are ignored
   file_locations <- c(
     # Local (incl. parent) directories
-    find_local_config(path, basename(linter_file)),
+    find_local_config(path, linter_file),
     # User directory
     # cf: rstudio@bc9b6a5 SessionRSConnect.R#L32
     file.path(Sys.getenv("HOME", unset = "~"), linter_file),

--- a/tests/testthat/test-settings.R
+++ b/tests/testthat/test-settings.R
@@ -282,3 +282,19 @@ test_that("perl-only regular expressions are accepted in config", {
   writeLines("a <- 1", "aaa.R")
   expect_silent(lint("aaa.R"))
 })
+
+test_that("settings can be put in a sub-directory", {
+  withr::local_dir(withr::local_tempdir())
+
+  dir.create(".settings")
+  .lintr <- ".settings/.lintr.R"
+  writeLines("linters <- list(line_length_linter(10))", .lintr)
+
+  dir.create("R")
+  writeLines("abcdefghijklmnopqrstuvwxyz=1", "R/a.R")
+
+  writeLines(c("Package: foo", "Version: 0.1"), "DESCRIPTION")
+
+  withr::local_options(lintr.linter_file = .lintr)
+  expect_length(lint_package(), 1L)
+})


### PR DESCRIPTION
Closes #2512. Didn't break any existing tests, so assume it's extraneous as posited.

BTW, I do find it a bit odd that `R_LINTR_LINTER_FILE` can _only_ be set at the R session level (that env is only read in `.onLoad()`):

https://github.com/r-lib/lintr/blob/bad1632f23b77f41cec13fb6f1c883302f64f506/R/zzz.R#L294-L296

Is that WAI? I am not sure the documentation reflects this well, if so:

https://github.com/r-lib/lintr/blob/bad1632f23b77f41cec13fb6f1c883302f64f506/R/settings.R#L10-L11

Therefore to test that `R_LINTR_LINTER_FILE` is working under this PR we'd need to invoke a subprocess, that felt like overkill.