### PR TITLE
workaround for roxygen2 bug

### DIFF
--- a/R/lintr-package.R
+++ b/R/lintr-package.R
@@ -17,11 +17,7 @@
 #' @importFrom xml2 as_list
 #'   xml_attr xml_children xml_find_all xml_find_chr xml_find_lgl xml_find_num xml_find_first xml_name xml_text
 #' @rawNamespace
-#' if (getRversion() >= "4.0.0") {
-#'   importFrom(tools, R_user_dir)
-#' } else {
-#'   importFrom(backports, R_user_dir)
-#' }
+#' if (getRversion() >= "4.0.0") importFrom(tools, R_user_dir) else importFrom(backports, R_user_dir)
 ## lintr namespace: end
 NULL
 

--- a/R/lintr-package.R
+++ b/R/lintr-package.R
@@ -17,6 +17,7 @@
 #' @importFrom xml2 as_list
 #'   xml_attr xml_children xml_find_all xml_find_chr xml_find_lgl xml_find_num xml_find_first xml_name xml_text
 #' @rawNamespace
+# TODO(#2516): Use multi-line directive for readability
 #' if (getRversion() >= "4.0.0") importFrom(tools, R_user_dir) else importFrom(backports, R_user_dir)
 ## lintr namespace: end
 NULL


### PR DESCRIPTION
See #2510, https://github.com/r-lib/roxygen2/issues/1572.

This workaround fits the full `@rawNamespace` directive on one line, thus impervious to the `sort()` issue.

We can revert this to the more readable version either at release or when {roxygen2} releases again, but for now it's causing some of our CI tests to fail e.g.

https://github.com/r-lib/lintr/actions/runs/7607480388/job/20714878154?pr=2514