### PR TITLE
Remove local_tempfile() usage in examples following breakage by withr 3.0.0

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -56,7 +56,7 @@ Config/Needs/development: pkgload, cli, testthat, patrick
 Config/testthat/edition: 3
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.2.3
+RoxygenNote: 7.3.1
 Collate:
     'make_linter_from_xpath.R'
     'xp_utils.R'

--- a/R/get_source_expressions.R
+++ b/R/get_source_expressions.R
@@ -54,9 +54,11 @@
 #'   \item{lines}{The [readLines()] output for this file.}
 #' }
 #'
-#' @examplesIf requireNamespace("withr", quietly = TRUE)
-#' tmp <- withr::local_tempfile(lines = c("x <- 1", "y <- x + 1"))
+#' @examples
+#' tmp <- tempfile()
+#' writeLines(c("x <- 1", "y <- x + 1"), tmp)
 #' get_source_expressions(tmp)
+#' unlink(tmp)
 #' @export
 get_source_expressions <- function(filename, lines = NULL) {
   source_expression <- srcfile(filename, encoding = settings$encoding)

--- a/R/ids_with_token.R
+++ b/R/ids_with_token.R
@@ -17,11 +17,13 @@
 #' the `token` column of `parsed_content`. Typically `==` or `%in%`.
 #' @param source_file (DEPRECATED) Same as `source_expression`. Will be removed.
 #'
-#' @examplesIf requireNamespace("withr", quietly = TRUE)
-#' tmp <- withr::local_tempfile(lines = c("x <- 1", "y <- x + 1"))
+#' @examples
+#' tmp <- tempfile()
+#' writeLines(c("x <- 1", "y <- x + 1"), tmp)
 #' source_exprs <- get_source_expressions(tmp)
 #' ids_with_token(source_exprs$expressions[[1L]], value = "SYMBOL")
 #' with_id(source_exprs$expressions[[1L]], 2L)
+#' unlink(tmp)
 #'
 #' @return `ids_with_token`: The indices of the `parsed_content` data frame
 #' entry of the list of source expressions. Indices correspond to the

--- a/R/is_lint_level.R
+++ b/R/is_lint_level.R
@@ -9,13 +9,15 @@
 #'   means an individual expression, while `"file"` means all expressions
 #'   in the current file are available.
 #'
-#' @examplesIf requireNamespace("withr", quietly = TRUE)
-#' tmp <- withr::local_tempfile(lines = c("x <- 1", "y <- x + 1"))
+#' @examples
+#' tmp <- tempfile()
+#' writeLines(c("x <- 1", "y <- x + 1"), tmp)
 #' source_exprs <- get_source_expressions(tmp)
 #' is_lint_level(source_exprs$expressions[[1L]], level = "expression")
 #' is_lint_level(source_exprs$expressions[[1L]], level = "file")
 #' is_lint_level(source_exprs$expressions[[3L]], level = "expression")
 #' is_lint_level(source_exprs$expressions[[3L]], level = "file")
+#' unlink(tmp)
 #'
 #' @export
 is_lint_level <- function(source_expression, level = c("expression", "file")) {

--- a/R/lint.R
+++ b/R/lint.R
@@ -26,11 +26,13 @@
 #'
 #' @return An object of class `c("lints", "list")`, each element of which is a `"list"` object.
 #'
-#' @examplesIf requireNamespace("withr", quietly = TRUE)
-#' f <- withr::local_tempfile(lines = "a=1", fileext = "R")
+#' @examples
+#' f <- tempfile()
+#' writeLines("a=1", f)
 #' lint(f)                # linting a file
 #' lint("a = 123\n")      # linting inline-code
 #' lint(text = "a = 123") # linting inline-code
+#' unlink(f)
 #'
 #' @export
 lint <- function(filename, linters = NULL, ..., cache = FALSE, parse_settings = TRUE, text = NULL) {

--- a/R/trailing_blank_lines_linter.R
+++ b/R/trailing_blank_lines_linter.R
@@ -2,22 +2,25 @@
 #'
 #' Check that there are no trailing blank lines in source code.
 #'
-#' @examplesIf requireNamespace("withr", quietly = TRUE)
+#' @examples
 #' # will produce lints
-#' f <- withr::local_tempfile(lines = "x <- 1\n")
-#' readLines(f)
+#' f <- tempfile()
+#' cat("x <- 1\n\n", f)
+#' writeLines(readChar(f, file.size(f)))
 #' lint(
 #'   filename = f,
 #'   linters = trailing_blank_lines_linter()
 #' )
+#' unlink(f)
 #'
 #' # okay
-#' f <- withr::local_tempfile(lines = "x <- 1")
-#' readLines(f)
+#' cat("x <- 1\n", f)
+#' writeLines(readChar(f, file.size(f)))
 #' lint(
 #'   filename = f,
 #'   linters = trailing_blank_lines_linter()
 #' )
+#' unlink(f)
 #'
 #' @evalRd rd_tags("trailing_blank_lines_linter")
 #' @seealso [linters] for a complete list of linters available in lintr.

--- a/R/trailing_blank_lines_linter.R
+++ b/R/trailing_blank_lines_linter.R
@@ -5,7 +5,7 @@
 #' @examples
 #' # will produce lints
 #' f <- tempfile()
-#' cat("x <- 1\n\n", f)
+#' cat("x <- 1\n\n", file = f)
 #' writeLines(readChar(f, file.size(f)))
 #' lint(
 #'   filename = f,
@@ -14,7 +14,7 @@
 #' unlink(f)
 #'
 #' # okay
-#' cat("x <- 1\n", f)
+#' cat("x <- 1\n", file = f)
 #' writeLines(readChar(f, file.size(f)))
 #' lint(
 #'   filename = f,

--- a/R/utils.R
+++ b/R/utils.R
@@ -221,21 +221,24 @@ platform_independent_sort <- function(x) x[platform_independent_order(x)]
 #'   and `xpath` is specified, it is extracted with [xml2::xml_find_chr()].
 #' @param xpath An XPath, passed on to [xml2::xml_find_chr()] after wrapping with `string()`.
 #'
-#' @examplesIf requireNamespace("withr", quietly = TRUE)
-#' tmp <- withr::local_tempfile(lines = "c('a', 'b')")
-#' stopifnot(file.exists(tmp))
+#' @examples
+#' tmp <- tempfile()
+#' writeLines("c('a', 'b')", tmp)
 #' expr_as_xml <- get_source_expressions(tmp)$expressions[[1L]]$xml_parsed_content
 #' writeLines(as.character(expr_as_xml))
 #' get_r_string(expr_as_xml, "expr[2]") # "a"
 #' get_r_string(expr_as_xml, "expr[3]") # "b"
+#' unlink(tmp)
 #'
 #' # more importantly, extract strings under R>=4 raw strings
 #' @examplesIf getRversion() >= "4.0.0"
-#' tmp4.0 <- withr::local_tempfile(lines = "c(R'(a\\b)', R'--[a\\\"\'\"\\b]--')")
+#' tmp4.0 <- tempfile()
+#' writeLines("c(R'(a\\b)', R'--[a\\\"\'\"\\b]--')", tmp4.0)
 #' expr_as_xml4.0 <- get_source_expressions(tmp4.0)$expressions[[1L]]$xml_parsed_content
 #' writeLines(as.character(expr_as_xml4.0))
 #' get_r_string(expr_as_xml4.0, "expr[2]") # "a\\b"
 #' get_r_string(expr_as_xml4.0, "expr[3]") # "a\\\"'\"\\b"
+#' unlink(tmp4.0)
 #'
 #' @export
 get_r_string <- function(s, xpath = NULL) {

--- a/R/utils.R
+++ b/R/utils.R
@@ -223,6 +223,7 @@ platform_independent_sort <- function(x) x[platform_independent_order(x)]
 #'
 #' @examplesIf requireNamespace("withr", quietly = TRUE)
 #' tmp <- withr::local_tempfile(lines = "c('a', 'b')")
+#' stopifnot(file.exists(tmp))
 #' expr_as_xml <- get_source_expressions(tmp)$expressions[[1L]]$xml_parsed_content
 #' writeLines(as.character(expr_as_xml))
 #' get_r_string(expr_as_xml, "expr[2]") # "a"

--- a/R/with.R
+++ b/R/with.R
@@ -149,10 +149,12 @@ all_linters <- function(..., packages = "lintr") {
 #'
 #' @param defaults Default list of linters to modify. Must be named.
 #' @inheritParams linters_with_tags
-#' @examplesIf requireNamespace("withr", quietly = TRUE)
+#' @examples
 #' # When using interactively you will usually pass the result onto `lint` or `lint_package()`
-#' f <- withr::local_tempfile(lines = "my_slightly_long_variable_name <- 2.3", fileext = "R")
+#' f <- tempfile()
+#' writeLines("my_slightly_long_variable_name <- 2.3", f)
 #' lint(f, linters = linters_with_defaults(line_length_linter = line_length_linter(120L)))
+#' unlink(f)
 #'
 #' # the default linter list with a different line length cutoff
 #' my_linters <- linters_with_defaults(line_length_linter = line_length_linter(120L))

--- a/man/get_r_string.Rd
+++ b/man/get_r_string.Rd
@@ -23,21 +23,22 @@ NB: this is also properly vectorized on \code{s}, and accepts a variety of input
 will become \code{NA} outputs, which helps ensure that \code{length(get_r_string(s)) == length(s)}.
 }
 \examples{
-\dontshow{if (requireNamespace("withr", quietly = TRUE)) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
-tmp <- withr::local_tempfile(lines = "c('a', 'b')")
-stopifnot(file.exists(tmp))
+tmp <- tempfile()
+writeLines("c('a', 'b')", tmp)
 expr_as_xml <- get_source_expressions(tmp)$expressions[[1L]]$xml_parsed_content
 writeLines(as.character(expr_as_xml))
 get_r_string(expr_as_xml, "expr[2]") # "a"
 get_r_string(expr_as_xml, "expr[3]") # "b"
+unlink(tmp)
 
 # more importantly, extract strings under R>=4 raw strings
-\dontshow{\}) # examplesIf}
 \dontshow{if (getRversion() >= "4.0.0") (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
-tmp4.0 <- withr::local_tempfile(lines = "c(R'(a\\\\b)', R'--[a\\\\\"\'\"\\\\b]--')")
+tmp4.0 <- tempfile()
+writeLines("c(R'(a\\\\b)', R'--[a\\\\\"\'\"\\\\b]--')", tmp4.0)
 expr_as_xml4.0 <- get_source_expressions(tmp4.0)$expressions[[1L]]$xml_parsed_content
 writeLines(as.character(expr_as_xml4.0))
 get_r_string(expr_as_xml4.0, "expr[2]") # "a\\b"
 get_r_string(expr_as_xml4.0, "expr[3]") # "a\\\"'\"\\b"
+unlink(tmp4.0)
 \dontshow{\}) # examplesIf}
 }

--- a/man/get_r_string.Rd
+++ b/man/get_r_string.Rd
@@ -25,6 +25,7 @@ will become \code{NA} outputs, which helps ensure that \code{length(get_r_string
 \examples{
 \dontshow{if (requireNamespace("withr", quietly = TRUE)) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
 tmp <- withr::local_tempfile(lines = "c('a', 'b')")
+stopifnot(file.exists(tmp))
 expr_as_xml <- get_source_expressions(tmp)$expressions[[1L]]$xml_parsed_content
 writeLines(as.character(expr_as_xml))
 get_r_string(expr_as_xml, "expr[2]") # "a"

--- a/man/get_source_expressions.Rd
+++ b/man/get_source_expressions.Rd
@@ -67,8 +67,8 @@ This setting is found by taking the first valid result from the following locati
 }
 }
 \examples{
-\dontshow{if (requireNamespace("withr", quietly = TRUE)) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
-tmp <- withr::local_tempfile(lines = c("x <- 1", "y <- x + 1"))
+tmp <- tempfile()
+writeLines(c("x <- 1", "y <- x + 1"), tmp)
 get_source_expressions(tmp)
-\dontshow{\}) # examplesIf}
+unlink(tmp)
 }

--- a/man/ids_with_token.Rd
+++ b/man/ids_with_token.Rd
@@ -48,10 +48,11 @@ conjunction with \code{ids_with_token} to iterate over rows containing desired t
 
 }}
 \examples{
-\dontshow{if (requireNamespace("withr", quietly = TRUE)) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
-tmp <- withr::local_tempfile(lines = c("x <- 1", "y <- x + 1"))
+tmp <- tempfile()
+writeLines(c("x <- 1", "y <- x + 1"), tmp)
 source_exprs <- get_source_expressions(tmp)
 ids_with_token(source_exprs$expressions[[1L]], value = "SYMBOL")
 with_id(source_exprs$expressions[[1L]], 2L)
-\dontshow{\}) # examplesIf}
+unlink(tmp)
+
 }

--- a/man/is_lint_level.Rd
+++ b/man/is_lint_level.Rd
@@ -19,12 +19,13 @@ Helper for determining whether the current \code{source_expression} contains
 all expressions in the current file, or just a single expression.
 }
 \examples{
-\dontshow{if (requireNamespace("withr", quietly = TRUE)) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
-tmp <- withr::local_tempfile(lines = c("x <- 1", "y <- x + 1"))
+tmp <- tempfile()
+writeLines(c("x <- 1", "y <- x + 1"), tmp)
 source_exprs <- get_source_expressions(tmp)
 is_lint_level(source_exprs$expressions[[1L]], level = "expression")
 is_lint_level(source_exprs$expressions[[1L]], level = "file")
 is_lint_level(source_exprs$expressions[[3L]], level = "expression")
 is_lint_level(source_exprs$expressions[[3L]], level = "file")
-\dontshow{\}) # examplesIf}
+unlink(tmp)
+
 }

--- a/man/lint.Rd
+++ b/man/lint.Rd
@@ -89,12 +89,13 @@ Note that if files contain unparseable encoding problems, only the encoding prob
 unintelligible error messages from other linters.
 }
 \examples{
-\dontshow{if (requireNamespace("withr", quietly = TRUE)) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
-f <- withr::local_tempfile(lines = "a=1", fileext = "R")
+f <- tempfile()
+writeLines("a=1", f)
 lint(f)                # linting a file
 lint("a = 123\n")      # linting inline-code
 lint(text = "a = 123") # linting inline-code
-\dontshow{\}) # examplesIf}
+unlink(f)
+
 if (FALSE) {
   lint_dir()
 

--- a/man/linters_with_defaults.Rd
+++ b/man/linters_with_defaults.Rd
@@ -19,10 +19,11 @@ The result of this function is meant to be passed to the \code{linters} argument
 or to be put in your configuration file.
 }
 \examples{
-\dontshow{if (requireNamespace("withr", quietly = TRUE)) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
 # When using interactively you will usually pass the result onto `lint` or `lint_package()`
-f <- withr::local_tempfile(lines = "my_slightly_long_variable_name <- 2.3", fileext = "R")
+f <- tempfile()
+writeLines("my_slightly_long_variable_name <- 2.3", f)
 lint(f, linters = linters_with_defaults(line_length_linter = line_length_linter(120L)))
+unlink(f)
 
 # the default linter list with a different line length cutoff
 my_linters <- linters_with_defaults(line_length_linter = line_length_linter(120L))
@@ -39,7 +40,7 @@ my_linters <- linters_with_defaults(
 
 # checking the included linters
 names(my_linters)
-\dontshow{\}) # examplesIf}
+
 }
 \seealso{
 \itemize{

--- a/man/trailing_blank_lines_linter.Rd
+++ b/man/trailing_blank_lines_linter.Rd
@@ -10,23 +10,25 @@ trailing_blank_lines_linter()
 Check that there are no trailing blank lines in source code.
 }
 \examples{
-\dontshow{if (requireNamespace("withr", quietly = TRUE)) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
 # will produce lints
-f <- withr::local_tempfile(lines = "x <- 1\n")
-readLines(f)
+f <- tempfile()
+cat("x <- 1\n\n", f)
+writeLines(readChar(f, file.size(f)))
 lint(
   filename = f,
   linters = trailing_blank_lines_linter()
 )
+unlink(f)
 
 # okay
-f <- withr::local_tempfile(lines = "x <- 1")
-readLines(f)
+cat("x <- 1\n", f)
+writeLines(readChar(f, file.size(f)))
 lint(
   filename = f,
   linters = trailing_blank_lines_linter()
 )
-\dontshow{\}) # examplesIf}
+unlink(f)
+
 }
 \seealso{
 \link{linters} for a complete list of linters available in lintr.

--- a/man/trailing_blank_lines_linter.Rd
+++ b/man/trailing_blank_lines_linter.Rd
@@ -12,7 +12,7 @@ Check that there are no trailing blank lines in source code.
 \examples{
 # will produce lints
 f <- tempfile()
-cat("x <- 1\n\n", f)
+cat("x <- 1\n\n", file = f)
 writeLines(readChar(f, file.size(f)))
 lint(
   filename = f,
@@ -21,7 +21,7 @@ lint(
 unlink(f)
 
 # okay
-cat("x <- 1\n", f)
+cat("x <- 1\n", file = f)
 writeLines(readChar(f, file.size(f)))
 lint(
   filename = f,


### PR DESCRIPTION
Per discussion here:

https://github.com/r-lib/withr/issues/256

This is an expected failure, and it seems `local_tempfile()` never really behaved as I'd've thought in examples anyway (namely, to clean up the file after each example runs).

There are ways to keep using {withr} if we really want, e.g. I think adding a line to set `withr.hook_source` option in the `check-all-examples` GHA would work, but now I think it's best to just stick with base functionality for these examples.