### PR TITLE
Remove reference to specific functions in help

### DIFF
--- a/R/undesirable_function_linter.R
+++ b/R/undesirable_function_linter.R
@@ -1,7 +1,6 @@
 #' Undesirable function linter
 #'
-#' Report the use of undesirable functions (e.g. [base::return()], [base::options()], or
-#' [base::sapply()]) and suggest an alternative.
+#' Report the use of undesirable functions and suggest an alternative.
 #'
 #' @param fun Named character vector. `names(fun)` correspond to undesirable functions,
 #'   while the values give a description of why the function is undesirable.

--- a/man/undesirable_function_linter.Rd
+++ b/man/undesirable_function_linter.Rd
@@ -20,8 +20,7 @@ use \code{\link[=modify_defaults]{modify_defaults()}}.}
 name as a symbol undesirable or not.}
 }
 \description{
-Report the use of undesirable functions (e.g. \code{\link[base:function]{base::return()}}, \code{\link[base:options]{base::options()}}, or
-\code{\link[base:lapply]{base::sapply()}}) and suggest an alternative.
+Report the use of undesirable functions and suggest an alternative.
 }
 \examples{
 # defaults for which functions are considered undesirable


### PR DESCRIPTION
Closes #2532. No sense keeping specific functions named here, which might change over time; better to just link `?default_undesirable_functions`, which is already done.