### PR TITLE
Bump package version to devel

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: lintr
 Title: A 'Linter' for R Code
-Version: 3.1.1.9000
+Version: 3.1.2.9000
 Authors@R: c(
     person("Jim", "Hester", , role = "aut"),
     person("Florent", "Angly", role = "aut",


### PR DESCRIPTION
Since CRAN version is `3.1.2`, the default branch's "devel" version is lagging CRAN version.