### PR TITLE
Get rid of outdated comments from GHA for R CMD check

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -28,14 +28,12 @@ jobs:
         config:
           - {os: macOS-latest,   r: 'release'}
 
-          - {os: windows-latest, r: 'next'}
           - {os: windows-latest, r: 'release'}
           # Use 3.6 to trigger usage of RTools35
           - {os: windows-latest, r: '3.6'}
           # use 4.1 to check with rtools40's older compiler
           - {os: windows-latest, r: '4.1'}
 
-          - {os: ubuntu-latest,  r: 'next'}
           - {os: ubuntu-latest,  r: 'devel', http-user-agent: 'release'}
           - {os: ubuntu-latest,  r: 'devel', http-user-agent: 'release', locale: 'en_US'}
           - {os: ubuntu-latest,  r: 'release', http-user-agent: 'release', locale: 'zh_CN'}

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -28,6 +28,7 @@ jobs:
         config:
           - {os: macOS-latest,   r: 'release'}
 
+          - {os: windows-latest, r: 'next'}
           - {os: windows-latest, r: 'release'}
           # Use 3.6 to trigger usage of RTools35
           - {os: windows-latest, r: '3.6'}
@@ -72,7 +73,6 @@ jobs:
           http-user-agent: ${{ matrix.config.http-user-agent }}
           use-public-rspm: true
 
-      # `{patrick}` imports `{purrr}`, and so needs to be ignored on R < 3.5
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
           extra-packages: |

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -34,7 +34,7 @@ jobs:
           # use 4.1 to check with rtools40's older compiler
           - {os: windows-latest, r: '4.1'}
 
-          # Use older ubuntu to maximise backward compatibility
+          - {os: ubuntu-latest,  r: 'next'}
           - {os: ubuntu-latest,  r: 'devel', http-user-agent: 'release'}
           - {os: ubuntu-latest,  r: 'devel', http-user-agent: 'release', locale: 'en_US'}
           - {os: ubuntu-latest,  r: 'release', http-user-agent: 'release', locale: 'zh_CN'}


### PR DESCRIPTION
> `next` corresponds to the next version of R, either R-patched, or R-alpha, R-beta, R-rc, or R-prerelease