### PR TITLE
Skip rlang name injections

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -72,6 +72,10 @@
 * `one_call_pipe_linter()` for discouraging one-step pipelines like `x |> as.character()` (#2330 and part of #884, @MichaelChirico).
 * `object_overwrite_linter()` for discouraging re-use of upstream package exports as local variables (#2344, #2346 and part of #884, @MichaelChirico and @AshesITR).
 
+### Lint accuracy fixes: removing false positives
+
+* `object_name_linter()` and `object_length_linter()` ignore {rlang} name injection like `x |> mutate("{new_name}" := foo(col))` (#1926, @MichaelChirico). No checking is applied in such cases. {data.table} in-place assignments like `DT[, "sPoNGeBob" := "friend"]` are still eligible for lints.
+
 # lintr 3.1.2
 
 ## New and improved features

--- a/R/object_name_linter.R
+++ b/R/object_name_linter.R
@@ -116,9 +116,7 @@ object_name_linter <- function(styles = c("snake_case", "symbols"), regexes = ch
     assignments <- xml_find_all(xml, object_name_xpath)
 
     # Retrieve assigned name
-    nms <- strip_names(
-      xml_text(assignments)
-    )
+    nms <- strip_names(xml_text(assignments))
 
     # run namespace_imports at run-time, not "compile" time to allow package structure to change
     pkg <- find_package(source_expression$filename)

--- a/R/object_name_linter.R
+++ b/R/object_name_linter.R
@@ -116,7 +116,7 @@ object_name_linter <- function(styles = c("snake_case", "symbols"), regexes = ch
     assignments <- xml_find_all(xml, object_name_xpath)
 
     # Retrieve assigned name
-    nms <- nms <- strip_names(
+    nms <- strip_names(
       xml_text(assignments)
     )
 

--- a/R/object_name_linter.R
+++ b/R/object_name_linter.R
@@ -116,7 +116,9 @@ object_name_linter <- function(styles = c("snake_case", "symbols"), regexes = ch
     assignments <- xml_find_all(xml, object_name_xpath)
 
     # Retrieve assigned name
-    nms <- strip_names(xml_text(assignments))
+    nms <- nms <- strip_names(
+      xml_text(assignments)
+    )
 
     # run namespace_imports at run-time, not "compile" time to allow package structure to change
     pkg <- find_package(source_expression$filename)

--- a/R/shared_constants.R
+++ b/R/shared_constants.R
@@ -203,7 +203,7 @@ object_name_xpath <- local({
   xp_assignment_target_fmt <- paste0(
     "not(parent::expr[OP-DOLLAR or OP-AT])",
     "and %1$s::expr[",
-    " following-sibling::LEFT_ASSIGN",
+    " following-sibling::LEFT_ASSIGN%2$s",
     " or preceding-sibling::RIGHT_ASSIGN",
     " or following-sibling::EQ_ASSIGN",
     "]",
@@ -213,9 +213,15 @@ object_name_xpath <- local({
     "])"
   )
 
+  # strings on LHS of := are only checked if they look like data.table usage DT[, "a" := ...]
+  dt_walrus_cond <- "[
+    text() != ':='
+    or parent::expr/preceding-sibling::OP-LEFT-BRACKET
+  ]"
+
   glue("
-  //SYMBOL[ {sprintf(xp_assignment_target_fmt, 'ancestor')} ]
-  |  //STR_CONST[ {sprintf(xp_assignment_target_fmt, 'parent')} ]
+  //SYMBOL[ {sprintf(xp_assignment_target_fmt, 'ancestor', '')} ]
+  |  //STR_CONST[ {sprintf(xp_assignment_target_fmt, 'parent', dt_walrus_cond)} ]
   |  //SYMBOL_FORMALS
   ")
 })

--- a/tests/testthat/test-object_length_linter.R
+++ b/tests/testthat/test-object_length_linter.R
@@ -74,3 +74,10 @@ test_that("function shorthand is caught", {
     object_length_linter(length = 10L)
   )
 })
+
+test_that("rlang name injection is handled", {
+  linter <- object_length_linter(length = 10L)
+
+  expect_lint("tibble('{foo() |> bar() |> baz()}' := TRUE)", NULL, linter)
+  expect_lint("DT[, 'a_very_long_name' := FALSE]", "names should not be longer than 10 characters", linter)
+})

--- a/tests/testthat/test-object_name_linter.R
+++ b/tests/testthat/test-object_name_linter.R
@@ -278,3 +278,11 @@ test_that("capture groups in style are fine", {
   expect_lint("a <- 1\nab <- 2", NULL, object_name_linter(regexes = c(capture = "^(a)")))
   expect_lint("ab <- 1\nabc <- 2", NULL, object_name_linter(regexes = c(capture = "^(a)(b)")))
 })
+
+test_that("rlang name injection is handled", {
+  linter <- object_name_linter()
+
+  expect_lint('tibble("{name}" := 2)', NULL, linter)
+  expect_lint('x %>% mutate("{name}" := 2)', NULL, linter)
+  expect_lint('DT[, "{name}" := 2]', "style should match snake_case", linter)
+})


### PR DESCRIPTION
Closes #1926

`object_length_linter()` change comes "for free". We could ignore this with some more effort, but I think the change is also welcome.