### PR TITLE
don't allow ranges[1]==0

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -21,6 +21,7 @@
 * `object_name_linter()` no longer errors when user-supplied `regexes=` have capture groups (#2188, @MichaelChirico).
 * `.lintr` config validation correctly accepts regular expressions which only compile under `perl = TRUE` (#2375, @MichaelChirico). These have always been valid (since `rex::re_matches()`, which powers the lint exclusion logic, also uses this setting), but the new up-front validation in v3.1.1 incorrectly used `perl = FALSE`.
 * `.lintr` configs set by option `lintr.linter_file` or environment variable `R_LINTR_LINTER_FILE` can point to subdirectories (#2512, @MichaelChirico).
+* `indentation_linter()` returns `ranges[1L]==1L` when the offending line has 0 spaces (#2550, @MichaelChirico).
 
 ## Changes to default linters
 

--- a/R/indentation_linter.R
+++ b/R/indentation_linter.R
@@ -276,9 +276,13 @@ indentation_linter <- function(indent = 2L, hanging_indent_style = c("tidy", "al
       )
       lint_lines <- unname(as.integer(names(source_expression$file_lines)[bad_lines]))
       lint_ranges <- cbind(
-        pmin(expected_indent_levels[bad_lines] + 1L, indent_levels[bad_lines]),
+        # when indent_levels==0, need to start ranges at column 1.
+        pmax(
+          pmin(expected_indent_levels[bad_lines] + 1L, indent_levels[bad_lines]),
+          1L
+        ),
         # If the expected indent is larger than the current line width, the lint range would become invalid.
-        # Therefor, limit range end to end of line.
+        # Therefore, limit range end to end of line.
         pmin(
           pmax(expected_indent_levels[bad_lines], indent_levels[bad_lines]),
           nchar(source_expression$file_lines[bad_lines]) + 1L

--- a/tests/testthat/test-indentation_linter.R
+++ b/tests/testthat/test-indentation_linter.R
@@ -867,3 +867,15 @@ test_that("function shorthand is handled", {
     linter
   )
 })
+
+test_that("lint metadata works for 0-space case", {
+  expect_lint(
+    trim_some("
+    if (TRUE) {
+    FALSE
+    }
+    "),
+    list(ranges = list(1:2)),
+    indentation_linter()
+  )
+})

--- a/tests/testthat/test-indentation_linter.R
+++ b/tests/testthat/test-indentation_linter.R
@@ -875,7 +875,7 @@ test_that("lint metadata works for 0-space case", {
     FALSE
     }
     "),
-    list(ranges = list(1:2)),
+    list(ranges = list(1L:2L)),
     indentation_linter()
   )
 })


### PR DESCRIPTION
Closes #2550.

The lint still has `column_number==0L`, show we bump that to `1L` as well?

```
lint(text = sprintf("if (TRUE) {\n%sFALSE\n}", strrep(" ", 0:5)), linters = indentation_linter())
<text>:2:0: style: [indentation_linter] Indentation should be 2 spaces but is 0 spaces.
FALSE
^~
<text>:5:1: style: [indentation_linter] Indentation should be 2 spaces but is 1 spaces.
 FALSE
^~
<text>:11:3: style: [indentation_linter] Indentation should be 2 spaces but is 3 spaces.
   FALSE
  ^
<text>:14:4: style: [indentation_linter] Indentation should be 2 spaces but is 4 spaces.
    FALSE
  ~^
<text>:17:5: style: [indentation_linter] Indentation should be 2 spaces but is 5 spaces.
     FALSE
  ~~^
```