### PR TITLE
Change URL order in DESCRIPTION to be pkgdown-friendly

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -18,7 +18,7 @@ Description: Checks adherence to a given style, syntax errors and possible
     'RStudio IDE', 'Emacs', 'Vim', 'Sublime Text', 'Atom' and 'Visual
     Studio Code'.
 License: MIT + file LICENSE
-URL: https://github.com/r-lib/lintr, https://lintr.r-lib.org
+URL: https://lintr.r-lib.org, https://github.com/r-lib/lintr
 BugReports: https://github.com/r-lib/lintr/issues
 Depends:
     R (>= 3.6)


### PR DESCRIPTION
- On main:

```r
downlit:::autolink_curly("{lintr}")
#> "<a href='https://github.com/r-lib/lintr'>lintr</a>"
```

- On current branch:

```r
downlit:::autolink_curly("{lintr}")
#> "<a href='https://lintr.r-lib.org'>lintr</a>"
```

