### PR TITLE
Make `scalar_in_linter()` configurable

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -16,6 +16,7 @@
 * `unnecessary_nested_if_linter()` is deprecated and subsumed into the new/more general `unnecessary_nesting_linter()`.
 * Drop support for posting GitHub comments from inside GitHub comment bot, Travis, Wercker, and Jenkins CI tools (spurred by #2148, @MichaelChirico). We rely on GitHub Actions for linting in CI, and don't see any active users relying on these alternatives. We welcome and encourage community contributions to get support for different CI system going again.
 * `cyclocomp_linter()` is no longer part of the default linters (#2555, @IndrajeetPatil) because the tidyverse style guide doesn't contain any guidelines on meeting certain complexity requirements. Note that users with `cyclocomp_linter()` in their configs may now need to install {cyclocomp} intentionally, in particular in CI/CD pipelines.
+* `scalar_in_linter` is now configurable to allow other `%in%` like operators to be linted. The data.table operator `%chin%` is no longer linted by default; use `in_operators = "%chin%"` to continue linting it. (@F-Noelle)
 
 ## Bug fixes
 
@@ -54,7 +55,6 @@
 * `any_is_na_linter()` is extended to catch the unusual usage `NA %in% x` (#2113, @MichaelChirico).
 * `make_linter_from_xpath()` errors up front when `lint_message` is missing (instead of delaying this error until the linter is used, #2541, @MichaelChirico).
 * `paste_linter()`  is extended to recommend using `paste()` instead of `paste0()` for simply aggregating a character vector with `collapse=`, i.e., when `sep=` is irrelevant (#1108, @MichaelChirico).
-* `scalar_in_linter` is now configurable to allow other `%in%` like operators to be linted. The data.table operator `%chin%` is no longer linted by default; use `in_operators = "%chin%"` to continue linting it. (@F-Noelle)
 
 ### New linters
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -54,7 +54,7 @@
 * `any_is_na_linter()` is extended to catch the unusual usage `NA %in% x` (#2113, @MichaelChirico).
 * `make_linter_from_xpath()` errors up front when `lint_message` is missing (instead of delaying this error until the linter is used, #2541, @MichaelChirico).
 * `paste_linter()`  is extended to recommend using `paste()` instead of `paste0()` for simply aggregating a character vector with `collapse=`, i.e., when `sep=` is irrelevant (#1108, @MichaelChirico).
-* `scalar_in_linter` is now configurable to allow other `%in%` like operators to be linted. `%chin%` is no longer linted by default. (@F-Noelle)
+* `scalar_in_linter` is now configurable to allow other `%in%` like operators to be linted. The data.table operator `%chin%` is no longer linted by default; use `in_operators = "%chin%"` to continue linting it. (@F-Noelle)
 
 ### New linters
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -54,6 +54,7 @@
 * `any_is_na_linter()` is extended to catch the unusual usage `NA %in% x` (#2113, @MichaelChirico).
 * `make_linter_from_xpath()` errors up front when `lint_message` is missing (instead of delaying this error until the linter is used, #2541, @MichaelChirico).
 * `paste_linter()`  is extended to recommend using `paste()` instead of `paste0()` for simply aggregating a character vector with `collapse=`, i.e., when `sep=` is irrelevant (#1108, @MichaelChirico).
+* `scalar_in_linter` is now configurable to allow other `%in%` like operators to be linted. `%chin%` is no longer linted by default. (@F-Noelle)
 
 ### New linters
 

--- a/R/scalar_in_linter.R
+++ b/R/scalar_in_linter.R
@@ -6,7 +6,8 @@
 #' `scalar %in% vector` is OK, because the alternative (`any(vector == scalar)`)
 #'   is more circuitous & potentially less clear.
 #'
-#' @param in_operators Character vector of additional infix operators that behave like the `%in%` operator
+#' @param in_operators Character vector of additional infix operators that behave like the `%in%` operator,
+#'   e.g. `{data.table}`'s `%chin%` operator.
 #'
 #' @examples
 #' # will produce lints

--- a/R/scalar_in_linter.R
+++ b/R/scalar_in_linter.R
@@ -44,8 +44,8 @@ scalar_in_linter <- function(in_operators = NULL) {
     bad_expr <- xml_find_all(xml, xpath)
     in_op <- xml_find_chr(bad_expr, "string(SPECIAL)")
     lint_msg <- glue(
-      "Use comparison operators (e.g. ==) to match length-1 scalars instead of {in_op}. ",
-      "Note that == preserves NA where %in% does not."
+      "Use comparison operators (e.g. ==, !=, etc.) to match length-1 scalars instead of {in_op} ",
+      "as these operators preserve NA where {in_op} does not."
     )
 
     xml_nodes_to_lints(

--- a/R/scalar_in_linter.R
+++ b/R/scalar_in_linter.R
@@ -6,7 +6,7 @@
 #' `scalar %in% vector` is OK, because the alternative (`any(vector == scalar)`)
 #'   is more circuitous & potentially less clear.
 #'
-#' @param in_operators Character vector of additional functions that behave like the `%in%` operator
+#' @param in_operators Character vector of additional infix operators that behave like the `%in%` operator
 #'
 #' @examples
 #' # will produce lints
@@ -43,19 +43,15 @@ scalar_in_linter <- function(in_operators = NULL) {
 
     bad_expr <- xml_find_all(xml, xpath)
     in_op <- xml_find_chr(bad_expr, "string(SPECIAL)")
-    msg <- ifelse(
-      in_op == "%in%",
-      "Use == to match length-1 scalars instead of %in%. Note that == preserves NA where %in% does not.",
-      glue(
-        "{in_op} behaves similar to %in%. ",
-        "Use operators like == to match length-1 scalars instead of operators like %in%."
-      )
+    lint_msg <- glue(
+      "Use comparison operators (e.g. ==) to match length-1 scalars instead of {in_op}. ",
+      "Note that == preserves NA where %in% does not."
     )
 
     xml_nodes_to_lints(
       bad_expr,
       source_expression = source_expression,
-      lint_message = msg,
+      lint_message = lint_msg,
       type = "warning"
     )
   })

--- a/R/scalar_in_linter.R
+++ b/R/scalar_in_linter.R
@@ -7,6 +7,8 @@
 #' `scalar %in% vector` is OK, because the alternative (`any(vector == scalar)`)
 #'   is more circuitous & potentially less clear.
 #'
+#' @param add_in_operators Character vector of additional functions that behave like the %in% operator
+#'
 #' @examples
 #' # will produce lints
 #' lint(
@@ -28,14 +30,16 @@
 #' @evalRd rd_tags("scalar_in_linter")
 #' @seealso [linters] for a complete list of linters available in lintr.
 #' @export
-scalar_in_linter <- function() {
+scalar_in_linter <- function(add_in_operators = "%chin%") {
   # TODO(#2085): Extend to include other cases where the RHS is clearly a scalar
   # NB: all of logical, integer, double, hex, complex are parsed as NUM_CONST
-  xpath <- "
-  //SPECIAL[text() = '%in%' or text() = '%chin%']
+  special <- paste(paste0("text() = '", c("%in%", add_in_operators), "'"), collapse = " or ")
+
+  xpath <- paste0("
+  //SPECIAL[", special, "]
     /following-sibling::expr[NUM_CONST[not(starts-with(text(), 'NA'))] or STR_CONST]
     /parent::expr
-  "
+  ")
 
   Linter(linter_level = "expression", function(source_expression) {
     xml <- source_expression$xml_parsed_content

--- a/R/scalar_in_linter.R
+++ b/R/scalar_in_linter.R
@@ -45,8 +45,8 @@ scalar_in_linter <- function(in_operators = NULL) {
     bad_expr <- xml_find_all(xml, xpath)
     in_op <- xml_find_chr(bad_expr, "string(SPECIAL)")
     lint_msg <- glue(
-      "Use comparison operators (e.g. ==, !=, etc.) to match length-1 scalars instead of {in_op} ",
-      "as these operators preserve NA where {in_op} does not."
+      "Use comparison operators (e.g. ==, !=, etc.) to match length-1 scalars instead of {in_op}. ",
+      "Note that comparison operators preserve NA where {in_op} does not."
     )
 
     xml_nodes_to_lints(

--- a/inst/lintr/linters.csv
+++ b/inst/lintr/linters.csv
@@ -90,7 +90,7 @@ repeat_linter,style readability
 return_linter,style configurable default
 routine_registration_linter,best_practices efficiency robustness
 sample_int_linter,efficiency readability robustness
-scalar_in_linter,readability consistency best_practices efficiency
+scalar_in_linter,readability consistency best_practices efficiency configurable
 semicolon_linter,style readability default configurable
 semicolon_terminator_linter,defunct
 seq_linter,robustness efficiency consistency best_practices default

--- a/man/configurable_linters.Rd
+++ b/man/configurable_linters.Rd
@@ -44,6 +44,7 @@ The following linters are tagged with 'configurable':
 \item{\code{\link{quotes_linter}}}
 \item{\code{\link{redundant_ifelse_linter}}}
 \item{\code{\link{return_linter}}}
+\item{\code{\link{scalar_in_linter}}}
 \item{\code{\link{semicolon_linter}}}
 \item{\code{\link{string_boundary_linter}}}
 \item{\code{\link{todo_comment_linter}}}

--- a/man/linters.Rd
+++ b/man/linters.Rd
@@ -19,7 +19,7 @@ The following tags exist:
 \itemize{
 \item{\link[=best_practices_linters]{best_practices} (63 linters)}
 \item{\link[=common_mistakes_linters]{common_mistakes} (11 linters)}
-\item{\link[=configurable_linters]{configurable} (43 linters)}
+\item{\link[=configurable_linters]{configurable} (44 linters)}
 \item{\link[=consistency_linters]{consistency} (32 linters)}
 \item{\link[=correctness_linters]{correctness} (7 linters)}
 \item{\link[=default_linters]{default} (25 linters)}
@@ -123,7 +123,7 @@ The following linters exist:
 \item{\code{\link{return_linter}} (tags: configurable, default, style)}
 \item{\code{\link{routine_registration_linter}} (tags: best_practices, efficiency, robustness)}
 \item{\code{\link{sample_int_linter}} (tags: efficiency, readability, robustness)}
-\item{\code{\link{scalar_in_linter}} (tags: best_practices, consistency, efficiency, readability)}
+\item{\code{\link{scalar_in_linter}} (tags: best_practices, configurable, consistency, efficiency, readability)}
 \item{\code{\link{semicolon_linter}} (tags: configurable, default, readability, style)}
 \item{\code{\link{seq_linter}} (tags: best_practices, consistency, default, efficiency, robustness)}
 \item{\code{\link{sort_linter}} (tags: best_practices, efficiency, readability)}

--- a/man/scalar_in_linter.Rd
+++ b/man/scalar_in_linter.Rd
@@ -4,7 +4,10 @@
 \alias{scalar_in_linter}
 \title{Block usage like x \%in\% "a"}
 \usage{
-scalar_in_linter()
+scalar_in_linter(add_in_operators = "\%chin\%")
+}
+\arguments{
+\item{add_in_operators}{Character vector of additional functions that behave like the \%in\% operator}
 }
 \description{
 \code{vector \%in\% set} is appropriate for matching a vector to a set, but if
@@ -38,5 +41,5 @@ lint(
 \link{linters} for a complete list of linters available in lintr.
 }
 \section{Tags}{
-\link[=best_practices_linters]{best_practices}, \link[=consistency_linters]{consistency}, \link[=efficiency_linters]{efficiency}, \link[=readability_linters]{readability}
+\link[=best_practices_linters]{best_practices}, \link[=configurable_linters]{configurable}, \link[=consistency_linters]{consistency}, \link[=efficiency_linters]{efficiency}, \link[=readability_linters]{readability}
 }

--- a/man/scalar_in_linter.Rd
+++ b/man/scalar_in_linter.Rd
@@ -7,7 +7,8 @@
 scalar_in_linter(in_operators = NULL)
 }
 \arguments{
-\item{in_operators}{Character vector of additional infix operators that behave like the \code{\%in\%} operator}
+\item{in_operators}{Character vector of additional infix operators that behave like the \code{\%in\%} operator,
+e.g. \code{{data.table}}'s \verb{\%chin\%} operator.}
 }
 \description{
 \code{vector \%in\% set} is appropriate for matching a vector to a set, but if

--- a/man/scalar_in_linter.Rd
+++ b/man/scalar_in_linter.Rd
@@ -7,7 +7,7 @@
 scalar_in_linter(in_operators = NULL)
 }
 \arguments{
-\item{in_operators}{Character vector of additional functions that behave like the \code{\%in\%} operator}
+\item{in_operators}{Character vector of additional infix operators that behave like the \code{\%in\%} operator}
 }
 \description{
 \code{vector \%in\% set} is appropriate for matching a vector to a set, but if

--- a/man/scalar_in_linter.Rd
+++ b/man/scalar_in_linter.Rd
@@ -4,15 +4,14 @@
 \alias{scalar_in_linter}
 \title{Block usage like x \%in\% "a"}
 \usage{
-scalar_in_linter(add_in_operators = "\%chin\%")
+scalar_in_linter(in_operators = NULL)
 }
 \arguments{
-\item{add_in_operators}{Character vector of additional functions that behave like the \%in\% operator}
+\item{in_operators}{Character vector of additional functions that behave like the \code{\%in\%} operator}
 }
 \description{
 \code{vector \%in\% set} is appropriate for matching a vector to a set, but if
-that set has size 1, \code{==} is more appropriate. \verb{\%chin\%} from \code{{data.table}}
-is matched as well.
+that set has size 1, \code{==} is more appropriate.
 }
 \details{
 \code{scalar \%in\% vector} is OK, because the alternative (\code{any(vector == scalar)})
@@ -27,7 +26,7 @@ lint(
 
 lint(
   text = "x \%chin\% 'a'",
-  linters = scalar_in_linter()
+  linters = scalar_in_linter(in_operators = "\%chin\%")
 )
 
 # okay

--- a/tests/testthat/test-scalar_in_linter.R
+++ b/tests/testthat/test-scalar_in_linter.R
@@ -15,31 +15,27 @@ test_that("scalar_in_linter skips allowed usages", {
 
 test_that("scalar_in_linter blocks simple disallowed usages", {
   linter <- scalar_in_linter(in_operators = c("%chin%", "%notin%"))
+  lint_msg <- rex::rex("Use comparison operators (e.g. ==) to match length-1 scalars instead of")
 
-  lint_in_msg <- rex::rex("Use == to match length-1 scalars instead of %in%.")
-  lint_chin_msg <- rex::rex("%chin% behaves similar to %in%.")
-  lint_notin_msg <- rex::rex("%notin% behaves similar to %in%.")
-
-  expect_lint("x %in% 1", lint_in_msg, linter)
-  expect_lint("x %chin% 'a'", lint_chin_msg, linter)
-  expect_lint("x %notin% 1", lint_notin_msg, linter)
+  expect_lint("x %in% 1", lint_msg, linter)
+  expect_lint("x %chin% 'a'", lint_msg, linter)
+  expect_lint("x %notin% 1", lint_msg, linter)
 })
 
 test_that("scalar_in_linter blocks or skips based on configuration", {
   linter_default <- scalar_in_linter()
   linter_config <- scalar_in_linter(in_operators = "%notin%")
 
-  lint_in_msg <- rex::rex("Use == to match length-1 scalars instead of %in%.")
-  lint_notin_msg <- rex::rex("%notin% behaves similar to %in%.")
+  lint_msg <- rex::rex("Use comparison operators (e.g. ==) to match length-1 scalars instead of")
 
   # default
-  expect_lint("x %in% 1", lint_in_msg, linter_default)
+  expect_lint("x %in% 1", lint_msg, linter_default)
   expect_lint("x %notin% 1", NULL, linter_default)
   expect_lint("x %notin% y", NULL, linter_default)
 
   # configured
-  expect_lint("x %in% 1", lint_in_msg, linter_config)
-  expect_lint("x %notin% 1", lint_notin_msg, linter_config)
+  expect_lint("x %in% 1", lint_msg, linter_config)
+  expect_lint("x %notin% 1", lint_msg, linter_config)
   expect_lint("x %notin% y", NULL, linter_config)
 })
 

--- a/tests/testthat/test-scalar_in_linter.R
+++ b/tests/testthat/test-scalar_in_linter.R
@@ -3,7 +3,7 @@ test_that("scalar_in_linter skips allowed usages", {
 
   expect_lint("x %in% y", NULL, linter)
   expect_lint("y %in% c('a', 'b')", NULL, linter)
-  expect_lint("c('a', 'b') %chin% x", NULL, linter)
+  expect_lint("c('a', 'b') %in% x", NULL, linter)
   expect_lint("z %in% 1:3", NULL, linter)
   # scalars on LHS are fine (often used as `"col" %in% names(DF)`)
   expect_lint("3L %in% x", NULL, linter)
@@ -15,16 +15,16 @@ test_that("scalar_in_linter skips allowed usages", {
 })
 
 test_that("scalar_in_linter blocks simple disallowed usages", {
-  linter <- scalar_in_linter()
-  lint_in_msg <- rex::rex("Use == to match length-1 scalars, not %in%.")
-  lint_chin_msg <- rex::rex("Use == to match length-1 scalars, not %chin%.")
+  linter <- scalar_in_linter(in_operators = "%chin%")
+  lint_in_msg <- rex::rex("Use == to match length-1 scalars instead of %in%.")
+  lint_chin_msg <- rex::rex("%chin% behaves similar to %in%.")
 
   expect_lint("x %in% 1", lint_in_msg, linter)
   expect_lint("x %chin% 'a'", lint_chin_msg, linter)
 })
 
 test_that("multiple lints are generated correctly", {
-  linter <- scalar_in_linter()
+  linter <- scalar_in_linter(in_operators = "%chin%")
 
   expect_lint(
     trim_some('{

--- a/tests/testthat/test-scalar_in_linter.R
+++ b/tests/testthat/test-scalar_in_linter.R
@@ -15,7 +15,7 @@ test_that("scalar_in_linter skips allowed usages", {
 
 test_that("scalar_in_linter blocks simple disallowed usages", {
   linter <- scalar_in_linter(in_operators = c("%chin%", "%notin%"))
-  lint_msg <- rex::rex("Use comparison operators (e.g. ==) to match length-1 scalars instead of")
+  lint_msg <- rex::rex("Use comparison operators (e.g. ==, !=, etc.) to match length-1 scalars instead of")
 
   expect_lint("x %in% 1", lint_msg, linter)
   expect_lint("x %chin% 'a'", lint_msg, linter)
@@ -26,7 +26,7 @@ test_that("scalar_in_linter blocks or skips based on configuration", {
   linter_default <- scalar_in_linter()
   linter_config <- scalar_in_linter(in_operators = "%notin%")
 
-  lint_msg <- rex::rex("Use comparison operators (e.g. ==) to match length-1 scalars instead of")
+  lint_msg <- rex::rex("Use comparison operators (e.g. ==, !=, etc.) to match length-1 scalars instead of")
 
   # default
   expect_lint("x %in% 1", lint_msg, linter_default)

--- a/tests/testthat/test-scalar_in_linter.R
+++ b/tests/testthat/test-scalar_in_linter.R
@@ -15,12 +15,14 @@ test_that("scalar_in_linter skips allowed usages", {
 })
 
 test_that("scalar_in_linter blocks simple disallowed usages", {
-  linter <- scalar_in_linter(in_operators = "%chin%")
+  linter <- scalar_in_linter(in_operators = c("%chin%", "%notin%"))
   lint_in_msg <- rex::rex("Use == to match length-1 scalars instead of %in%.")
   lint_chin_msg <- rex::rex("%chin% behaves similar to %in%.")
+  lint_notin_msg <- rex::rex("%notin% behaves similar to %in%.")
 
   expect_lint("x %in% 1", lint_in_msg, linter)
   expect_lint("x %chin% 'a'", lint_chin_msg, linter)
+  expect_lint("x %notin% 1", lint_notin_msg, linter)
 })
 
 test_that("multiple lints are generated correctly", {


### PR DESCRIPTION
Make scalar_in_linter configurable to allow projects to define additional %in% style functions like %notin%.