### PR TITLE
Remove outputs from roxygen examples

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -226,8 +226,8 @@ platform_independent_sort <- function(x) x[platform_independent_order(x)]
 #' writeLines("c('a', 'b')", tmp)
 #' expr_as_xml <- get_source_expressions(tmp)$expressions[[1L]]$xml_parsed_content
 #' writeLines(as.character(expr_as_xml))
-#' get_r_string(expr_as_xml, "expr[2]") # "a"
-#' get_r_string(expr_as_xml, "expr[3]") # "b"
+#' get_r_string(expr_as_xml, "expr[2]")
+#' get_r_string(expr_as_xml, "expr[3]")
 #' unlink(tmp)
 #'
 #' # more importantly, extract strings under R>=4 raw strings
@@ -236,8 +236,8 @@ platform_independent_sort <- function(x) x[platform_independent_order(x)]
 #' writeLines("c(R'(a\\b)', R'--[a\\\"\'\"\\b]--')", tmp4.0)
 #' expr_as_xml4.0 <- get_source_expressions(tmp4.0)$expressions[[1L]]$xml_parsed_content
 #' writeLines(as.character(expr_as_xml4.0))
-#' get_r_string(expr_as_xml4.0, "expr[2]") # "a\\b"
-#' get_r_string(expr_as_xml4.0, "expr[3]") # "a\\\"'\"\\b"
+#' get_r_string(expr_as_xml4.0, "expr[2]")
+#' get_r_string(expr_as_xml4.0, "expr[3]")
 #' unlink(tmp4.0)
 #'
 #' @export

--- a/man/get_r_string.Rd
+++ b/man/get_r_string.Rd
@@ -27,8 +27,8 @@ tmp <- tempfile()
 writeLines("c('a', 'b')", tmp)
 expr_as_xml <- get_source_expressions(tmp)$expressions[[1L]]$xml_parsed_content
 writeLines(as.character(expr_as_xml))
-get_r_string(expr_as_xml, "expr[2]") # "a"
-get_r_string(expr_as_xml, "expr[3]") # "b"
+get_r_string(expr_as_xml, "expr[2]")
+get_r_string(expr_as_xml, "expr[3]")
 unlink(tmp)
 
 # more importantly, extract strings under R>=4 raw strings
@@ -37,8 +37,8 @@ tmp4.0 <- tempfile()
 writeLines("c(R'(a\\\\b)', R'--[a\\\\\"\'\"\\\\b]--')", tmp4.0)
 expr_as_xml4.0 <- get_source_expressions(tmp4.0)$expressions[[1L]]$xml_parsed_content
 writeLines(as.character(expr_as_xml4.0))
-get_r_string(expr_as_xml4.0, "expr[2]") # "a\\b"
-get_r_string(expr_as_xml4.0, "expr[3]") # "a\\\"'\"\\b"
+get_r_string(expr_as_xml4.0, "expr[2]")
+get_r_string(expr_as_xml4.0, "expr[3]")
 unlink(tmp4.0)
 \dontshow{\}) # examplesIf}
 }


### PR DESCRIPTION
In pkgdown, this output is right below the code.
In RStudio IDE, users can just click on "Run examples", and it will show the output.
Everywhere else, the users can execute the code and see the outputs. I don't think we need to embed the outputs here.

---

Another issue is that styler keeps restyling this code, which needs to be reverted:

```r
styler::style_text('get_r_string(expr_as_xml4.0, "expr[2]") # "a\\b"')
#> get_r_string(expr_as_xml4.0, "expr[2]") # "a\b"
```