### PR TITLE
Use the latest major `{withr}` version

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -45,7 +45,7 @@ Suggests:
     testthat (>= 3.2.1),
     tibble,
     tufte,
-    withr (>= 2.5.0)
+    withr (>= 3.0.0)
 Enhances:
     data.table
 VignetteBuilder: 


### PR DESCRIPTION
To benefit from performance and other enhancements in this release: https://www.tidyverse.org/blog/2024/01/withr-3-0-0/

We have already fixed issues stemming from this version: https://github.com/r-lib/lintr/pull/2519

We didn't bump the version because it was quite new at the time, but we can do so now.