### PR TITLE
Ignore a few dependencies for `R 3.6` R CMD check

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -76,6 +76,8 @@ jobs:
           extra-packages: |
             any::rcmdcheck
             knitr=?ignore-before-r=4.0.0
+            rmarkdown=?ignore-before-r=4.0.0
+            testthat=?ignore-before-r=4.0.0
           needs: check
 
       - uses: r-lib/actions/check-r-package@v2

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -75,6 +75,7 @@ jobs:
         with:
           extra-packages: |
             any::rcmdcheck
+            knitr=?ignore-before-r=4.0.0
           needs: check
 
       - uses: r-lib/actions/check-r-package@v2


### PR DESCRIPTION
Because `{evaluate}` now needs R >= 4.0: https://cran.rstudio.com/web/packages/evaluate/index.html