### PR TITLE
Leave out some vignette metadata

### DIFF
--- a/vignettes/creating_linters.Rmd
+++ b/vignettes/creating_linters.Rmd
@@ -1,7 +1,5 @@
 ---
 title: "Creating new linters"
-author: "lintr maintainers"
-date: "`r Sys.Date()`"
 output: rmarkdown::html_vignette
 vignette: >
   %\VignetteIndexEntry{Creating new linters}

--- a/vignettes/lintr.Rmd
+++ b/vignettes/lintr.Rmd
@@ -1,6 +1,5 @@
 ---
 title: "Using lintr"
-author: "Alexander Rosenstock"
 output: rmarkdown::html_vignette
 vignette: >
   %\VignetteIndexEntry{Using lintr}


### PR DESCRIPTION
I think this is a good pattern to follow also in our vignettes.

Ref: https://r-pkgs.org/vignettes.html#metadata

<img width="777" alt="Screenshot 2023-09-14 at 10 40 50" src="https://github.com/easystats/easystats/assets/11330453/441c2a76-01e6-4431-9012-5184f0efcfa8">
