### PR TITLE
Add new section for grouped linters in website reference index

### DIFF
--- a/_pkgdown.yaml
+++ b/_pkgdown.yaml
@@ -26,7 +26,7 @@ reference:
     contents:
       - ends_with("linter")
 
-  - title: Grouped linters
+  - title: Groups of linters
     contents:
       - ends_with("linters")
 

--- a/_pkgdown.yaml
+++ b/_pkgdown.yaml
@@ -26,6 +26,10 @@ reference:
     contents:
       - ends_with("linter")
 
+  - title: Grouped linters
+    contents:
+      - ends_with("linters")
+
   - title: Common default configurations
     contents:
       - all_undesirable_functions
@@ -46,7 +50,6 @@ reference:
 
   - title: Meta-tooling
     contents:
-      - ends_with("linters")
       - Lint
       - checkstyle_output
       - sarif_output


### PR DESCRIPTION
Currently, we are dumping way too many functions in the [meta-tooling section](https://lintr.r-lib.org/dev/reference/index.html#meta-tooling). This increases the possibility of the users missing out on important functions, like `all_linters()` or `default_linters()`. 