### PR TITLE
Don't include GHA log output in pkgdown website

### DIFF
--- a/R/actions.R
+++ b/R/actions.R
@@ -2,6 +2,10 @@ in_github_actions <- function() {
   identical(Sys.getenv("GITHUB_ACTIONS"), "true")
 }
 
+in_pkgdown <- function() {
+  identical(Sys.getenv("IN_PKGDOWN"), "true")
+}
+
 # Output logging commands for any lints found
 github_actions_log_lints <- function(lints, project_dir = "") {
   for (x in lints) {

--- a/R/methods.R
+++ b/R/methods.R
@@ -92,7 +92,7 @@ print.lints <- function(x, ...) {
     inline_data <- x[[1L]][["filename"]] == "<text>"
     if (!inline_data && use_rstudio_source_markers) {
       rstudio_source_markers(x)
-    } else if (in_github_actions()) {
+    } else if (in_github_actions() && !in_pkgdown()) {
       github_actions_log_lints(x, project_dir = github_annotation_project_dir)
     } else {
       lapply(x, print, ...)

--- a/tests/testthat/test-ci.R
+++ b/tests/testthat/test-ci.R
@@ -52,7 +52,6 @@ patrick::with_parameters_test_that(
   env_var_value = list("", "F", NA, NULL)
 )
 
-
 test_that("GitHub Actions log is skipped in pkgdown websites", {
   withr::local_envvar(list(GITHUB_ACTIONS = "true", IN_PKGDOWN = "true"))
   withr::local_options(lintr.rstudio_source_markers = FALSE)

--- a/tests/testthat/test-ci.R
+++ b/tests/testthat/test-ci.R
@@ -1,5 +1,5 @@
 test_that("GitHub Actions functionality works", {
-  withr::local_envvar(list(GITHUB_ACTIONS = "true"))
+  withr::local_envvar(list(GITHUB_ACTIONS = "true", IN_PKGDOWN = "false"))
   withr::local_options(lintr.rstudio_source_markers = FALSE)
   tmp <- withr::local_tempfile(lines = "x <- 1:nrow(y)")
 
@@ -26,7 +26,7 @@ test_that("GitHub Actions functionality works in a subdirectory", {
 patrick::with_parameters_test_that(
   "GitHub Actions - error on lint works",
   {
-    withr::local_envvar(list(GITHUB_ACTIONS = "true", LINTR_ERROR_ON_LINT = env_var_value))
+    withr::local_envvar(list(GITHUB_ACTIONS = "true", IN_PKGDOWN = "", LINTR_ERROR_ON_LINT = env_var_value))
     withr::local_options(lintr.rstudio_source_markers = FALSE)
     tmp <- withr::local_tempfile(lines = "x <- 1:nrow(y)")
 
@@ -51,3 +51,13 @@ patrick::with_parameters_test_that(
   },
   env_var_value = list("", "F", NA, NULL)
 )
+
+
+test_that("GitHub Actions log is skipped in pkgdown websites", {
+  withr::local_envvar(list(GITHUB_ACTIONS = "true", IN_PKGDOWN = "true"))
+  withr::local_options(lintr.rstudio_source_markers = FALSE)
+  tmp <- withr::local_tempfile(lines = "x <- 1:nrow(y)")
+
+  l <- lint(tmp)
+  expect_output(print(l), "warning: [seq_linter]", fixed = TRUE)
+})

--- a/tests/testthat/test-ci.R
+++ b/tests/testthat/test-ci.R
@@ -57,6 +57,6 @@ test_that("GitHub Actions log is skipped in pkgdown websites", {
   withr::local_options(lintr.rstudio_source_markers = FALSE)
   tmp <- withr::local_tempfile(lines = "x <- 1:nrow(y)")
 
-  l <- lint(tmp)
+  l <- lint(tmp, linters = seq_linter())
   expect_output(print(l), "warning: [seq_linter]", fixed = TRUE)
 })


### PR DESCRIPTION
If I locally render the site, I see:

<img width="835" alt="Screenshot 2024-07-18 at 17 36 48" src="https://github.com/user-attachments/assets/d7406eca-8b98-4fce-8397-c031d3ced47c">

## Minimal reprex:

``` r
library(lintr)

withr::local_options(lintr.rstudio_source_markers = FALSE)
withr::local_envvar(list(GITHUB_ACTIONS = "true"))

tmp <- withr::local_tempfile(lines = "x <- 1:nrow(y)")

withr::local_envvar(list(IN_PKGDOWN = "true"))
lint(tmp)
#> /private/var/folders/xr/v_vddzvs33q5wg7jv9mr__4h0000gn/T/RtmpwfSzjb/filedd1064e6f6e8:1:6: warning: [seq_linter] Use seq_len(nrow(...)) instead of 1:nrow(...), which is likely to be wrong in the empty edge case.
#> x <- 1:nrow(y)
#>      ^~~~~~~~~

withr::local_envvar(list(IN_PKGDOWN = "false"))
lint(tmp)
#> ::warning file=/private/var/folders/xr/v_vddzvs33q5wg7jv9mr__4h0000gn/T/RtmpwfSzjb/filedd1064e6f6e8,line=1,col=6::file=/private/var/folders/xr/v_vddzvs33q5wg7jv9mr__4h0000gn/T/RtmpwfSzjb/filedd1064e6f6e8,line=1,col=6,[seq_linter] Use seq_len(nrow(...)) instead of 1:nrow(...), which is likely to be wrong in the empty edge case.

withr::local_envvar(list(IN_PKGDOWN = ""))
lint(tmp)
#> ::warning file=/private/var/folders/xr/v_vddzvs33q5wg7jv9mr__4h0000gn/T/RtmpwfSzjb/filedd1064e6f6e8,line=1,col=6::file=/private/var/folders/xr/v_vddzvs33q5wg7jv9mr__4h0000gn/T/RtmpwfSzjb/filedd1064e6f6e8,line=1,col=6,[seq_linter] Use seq_len(nrow(...)) instead of 1:nrow(...), which is likely to be wrong in the empty edge case.
```

<sup>Created on 2024-07-18 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>