### PR TITLE
Fix missing DCF code block on website

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -55,7 +55,7 @@ Config/Needs/development: pkgload, cli, testthat, patrick
 Config/testthat/edition: 3
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.3.1
+RoxygenNote: 7.3.2
 Collate:
     'make_linter_from_xpath.R'
     'xp_utils.R'

--- a/R/settings.R
+++ b/R/settings.R
@@ -12,7 +12,7 @@
 #' This file is a DCF file, see [base::read.dcf()] for details.
 #' Here is an example of a `.lintr` file:
 #'
-#'  ```dcf
+#'  ```
 #'  linters: linters_with_defaults(
 #'      any_duplicated_linter(),
 #'      any_is_na_linter(),

--- a/man/read_settings.Rd
+++ b/man/read_settings.Rd
@@ -27,7 +27,7 @@ or the environment variable \code{R_LINTR_LINTER_FILE}
 This file is a DCF file, see \code{\link[base:dcf]{base::read.dcf()}} for details.
 Here is an example of a \code{.lintr} file:
 
-\if{html}{\out{<div class="sourceCode dcf">}}\preformatted{linters: linters_with_defaults(
+\if{html}{\out{<div class="sourceCode">}}\preformatted{linters: linters_with_defaults(
     any_duplicated_linter(),
     any_is_na_linter(),
     backport_linter("oldrel-4", except = c("R_user_dir", "str2lang")),


### PR DESCRIPTION
My guess is since knitr doesn't support DCF code blocks (cf. `names(knitr::knit_engines$get())`), pkgdown doesn't either.

- Current status:

https://lintr.r-lib.org/dev/reference/read_settings.html

<img width="811" alt="Screenshot 2024-07-24 at 07 31 33" src="https://github.com/user-attachments/assets/9e489d99-14f6-4968-9dca-f394a5c8d639">

- With this PR (locally)

<img width="810" alt="Screenshot 2024-07-24 at 07 31 51" src="https://github.com/user-attachments/assets/6f5a6547-4c80-44e5-b0b3-19f255c83ddb">


