### PR TITLE
Support clickable hyperlinks

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -88,7 +88,7 @@
 ## Notes
 
 * All user-facing messages are now prepared using the `{cli}` package (#2418, @IndrajeetPatil). All messages have been reviewed and updated to be more informative and consistent.
-* Error messages and linters contain clickable hyperlinks to improve code navigation (#2645, #2588, @olivroy).
+* File locations in lints and error messages contain clickable hyperlinks to improve code navigation (#2645, #2588, @olivroy).
 * {lintr} now depends on R version 4.0.0. It already does so implicitly due to recursive upstream dependencies requiring this version; we've simply made that dependency explicit and up-front (#2569, @MichaelChirico).
 
 # lintr 3.1.2

--- a/NEWS.md
+++ b/NEWS.md
@@ -88,6 +88,7 @@
 ## Notes
 
 * All user-facing messages are now prepared using the `{cli}` package (#2418, @IndrajeetPatil). All messages have been reviewed and updated to be more informative and consistent.
+* Error messages and linters contain clickable hyperlinks to improve code navigation (#2645, #2588, @olivroy).
 * {lintr} now depends on R version 4.0.0. It already does so implicitly due to recursive upstream dependencies requiring this version; we've simply made that dependency explicit and up-front (#2569, @MichaelChirico).
 
 # lintr 3.1.2

--- a/R/methods.R
+++ b/R/methods.R
@@ -36,12 +36,10 @@ build_line_ref <- function(x) {
     as.character(x$column_number)
   )
 
-  create_clickable_link <- cli::ansi_has_hyperlink_support()
-  if (create_clickable_link) {
-    line_ref <- cli::format_inline("{.path {line_ref}}")
+  if (!cli::ansi_has_hyperlink_support()) {
+    return(line_ref)
   }
-
-  line_ref
+  cli::format_inline("{.path {line_ref}}")
 }
 
 #' @export

--- a/R/methods.R
+++ b/R/methods.R
@@ -8,28 +8,9 @@ format.lint <- function(x, ..., width = getOption("lintr.format_width")) {
   )
   emph <- cli::style_bold
 
-  has_hyperlink_support <- cli::ansi_has_hyperlink_support()
-  if (has_hyperlink_support) {
-    fmt_start <- "{.path "
-    fmt_end <- "}"
-    fmt_f <- cli::format_inline
-  } else {
-    fmt_start <- ""
-    fmt_end <- ""
-    fmt_f <- paste0
-  }
-
+  line_ref <- build_line_ref(x)
   annotated_msg <- paste0(
-    emph(
-      fmt_f(
-        fmt_start,
-        x$filename, ":",
-        as.character(x$line_number), ":",
-        as.character(x$column_number),
-        fmt_end
-      ),
-      ": "
-    ),
+    emph(line_ref, ": "),
     color(x$type, ": ", sep = ""),
     "[", x$linter, "] ",
     emph(x$message)
@@ -46,6 +27,22 @@ format.lint <- function(x, ..., width = getOption("lintr.format_width")) {
     highlight_string(x$message, x$column_number, x$ranges),
     "\n"
   )
+}
+
+build_line_ref <- function(x) {
+  line_ref <- paste0(
+    x$filename, ":",
+    as.character(x$line_number), ":",
+    as.character(x$column_number)
+  )
+
+  create_clickable_link <- cli::ansi_has_hyperlink_support()
+  if (create_clickable_link) {
+    line_ref <- paste0("{.path ", line_ref, "}")
+    line_ref <- cli::format_inline(line_ref)
+  }
+
+  line_ref
 }
 
 #' @export

--- a/R/methods.R
+++ b/R/methods.R
@@ -8,15 +8,26 @@ format.lint <- function(x, ..., width = getOption("lintr.format_width")) {
   )
   emph <- cli::style_bold
 
+  has_hyperlink_support <- cli::ansi_has_hyperlink_support()
+  if (has_hyperlink_support) {
+    start <- "{.path "
+    end   <- "} "
+    f <- cli::format_inline
   } else {
+    start <- ""
+    end   <- ""
+    f <- paste0
   }
 
   annotated_msg <- paste0(
     emph(
+      f(
+      start,
       x$filename, ":",
       as.character(x$line_number), ":",
-      as.character(x$column_number), ": ",
-      sep = ""
+      as.character(x$column_number),
+      end),
+      ": "
     ),
     color(x$type, ": ", sep = ""),
     "[", x$linter, "] ",

--- a/R/methods.R
+++ b/R/methods.R
@@ -11,7 +11,7 @@ format.lint <- function(x, ..., width = getOption("lintr.format_width")) {
   has_hyperlink_support <- cli::ansi_has_hyperlink_support()
   if (has_hyperlink_support) {
     fmt_start <- "{.path "
-    fmt_end <- "} "
+    fmt_end <- "}"
     fmt_f <- cli::format_inline
   } else {
     fmt_start <- ""

--- a/R/methods.R
+++ b/R/methods.R
@@ -1,18 +1,14 @@
 #' @export
 format.lint <- function(x, ..., width = getOption("lintr.format_width")) {
-  if (requireNamespace("cli", quietly = TRUE)) {
-    color <- switch(x$type,
-      warning = cli::col_magenta,
-      error = cli::col_red,
-      style = cli::col_blue,
-      cli::style_bold
-    )
-    emph <- cli::style_bold
+  color <- switch(x$type,
+    warning = cli::col_magenta,
+    error = cli::col_red,
+    style = cli::col_blue,
+    cli::style_bold
+  )
+  emph <- cli::style_bold
+
   } else {
-    # nocov start
-    color <- identity
-    emph <- identity
-    # nocov end
   }
 
   annotated_msg <- paste0(

--- a/R/methods.R
+++ b/R/methods.R
@@ -38,8 +38,7 @@ build_line_ref <- function(x) {
 
   create_clickable_link <- cli::ansi_has_hyperlink_support()
   if (create_clickable_link) {
-    line_ref <- paste0("{.path ", line_ref, "}")
-    line_ref <- cli::format_inline(line_ref)
+    line_ref <- cli::format_inline("{.path {line_ref}}")
   }
 
   line_ref

--- a/R/methods.R
+++ b/R/methods.R
@@ -10,23 +10,24 @@ format.lint <- function(x, ..., width = getOption("lintr.format_width")) {
 
   has_hyperlink_support <- cli::ansi_has_hyperlink_support()
   if (has_hyperlink_support) {
-    start <- "{.path "
-    end   <- "} "
-    f <- cli::format_inline
+    fmt_start <- "{.path "
+    fmt_end <- "} "
+    fmt_f <- cli::format_inline
   } else {
-    start <- ""
-    end   <- ""
-    f <- paste0
+    fmt_start <- ""
+    fmt_end <- ""
+    fmt_f <- paste0
   }
 
   annotated_msg <- paste0(
     emph(
-      f(
-      start,
-      x$filename, ":",
-      as.character(x$line_number), ":",
-      as.character(x$column_number),
-      end),
+      fmt_f(
+        fmt_start,
+        x$filename, ":",
+        as.character(x$line_number), ":",
+        as.character(x$column_number),
+        fmt_end
+      ),
       ": "
     ),
     color(x$type, ": ", sep = ""),


### PR DESCRIPTION
fix #2645 

Basically, this checks for clickable hyperlinks. I also saw that some code was still hidden behind `requireNamespace("cli")` but that is no longer required since cli is imported.

To my great surprise, this works out of the box in Positron ! for `lintr::lint_package()`
![image](https://github.com/user-attachments/assets/53a4e48f-2461-4c43-b87b-da0a98655488)
Before, there were no hyperlinks (lintr 3.1.2)
![image](https://github.com/user-attachments/assets/43140283-b3ff-48dd-abad-ef07783cf4e1)

Lmk if you'd like me to add NEWS for this!
