### PR TITLE
Include `{data.table}` example in `redundant_equals_linter()` docs

### DIFF
--- a/R/redundant_equals_linter.R
+++ b/R/redundant_equals_linter.R
@@ -35,6 +35,7 @@
 #'   linters = redundant_equals_linter()
 #' )
 #'
+#' # in data.table semantics, dt[x] is a join, dt[(x)] is a subset
 #' lint(
 #'   text = "dt[!(x), y]",
 #'   linters = redundant_equals_linter()

--- a/R/redundant_equals_linter.R
+++ b/R/redundant_equals_linter.R
@@ -20,7 +20,7 @@
 #' )
 #'
 #' lint(
-#'   text = "dt[x == FALSE, y]",
+#'   text = "dt[is_tall == FALSE, y]",
 #'   linters = redundant_equals_linter()
 #' )
 #'
@@ -35,9 +35,9 @@
 #'   linters = redundant_equals_linter()
 #' )
 #'
-#' # in data.table semantics, dt[x] is a join, dt[(x)] is a subset
+#' # in `{data.table}` semantics, `dt[x]` is a join, `dt[(x)]` is a subset
 #' lint(
-#'   text = "dt[!(x), y]",
+#'   text = "dt[(!is_tall), y]",
 #'   linters = redundant_equals_linter()
 #' )
 #'

--- a/R/redundant_equals_linter.R
+++ b/R/redundant_equals_linter.R
@@ -19,6 +19,11 @@
 #'   linters = redundant_equals_linter()
 #' )
 #'
+#' lint(
+#'   text = "dt[x == FALSE, y]",
+#'   linters = redundant_equals_linter()
+#' )
+#'
 #' # okay
 #' lint(
 #'   text = "if (any(x)) 1",
@@ -27,6 +32,11 @@
 #'
 #' lint(
 #'   text = "if (!all(x)) 0",
+#'   linters = redundant_equals_linter()
+#' )
+#'
+#' lint(
+#'   text = "dt[!(x), y]",
 #'   linters = redundant_equals_linter()
 #' )
 #'

--- a/man/redundant_equals_linter.Rd
+++ b/man/redundant_equals_linter.Rd
@@ -26,6 +26,11 @@ lint(
   linters = redundant_equals_linter()
 )
 
+lint(
+  text = "dt[x == FALSE, y]",
+  linters = redundant_equals_linter()
+)
+
 # okay
 lint(
   text = "if (any(x)) 1",
@@ -34,6 +39,11 @@ lint(
 
 lint(
   text = "if (!all(x)) 0",
+  linters = redundant_equals_linter()
+)
+
+lint(
+  text = "dt[!(x), y]",
   linters = redundant_equals_linter()
 )
 

--- a/man/redundant_equals_linter.Rd
+++ b/man/redundant_equals_linter.Rd
@@ -27,7 +27,7 @@ lint(
 )
 
 lint(
-  text = "dt[x == FALSE, y]",
+  text = "dt[is_tall == FALSE, y]",
   linters = redundant_equals_linter()
 )
 
@@ -42,8 +42,9 @@ lint(
   linters = redundant_equals_linter()
 )
 
+# in `{data.table}` semantics, `dt[x]` is a join, `dt[(x)]` is a subset
 lint(
-  text = "dt[!(x), y]",
+  text = "dt[(!is_tall), y]",
   linters = redundant_equals_linter()
 )
 


### PR DESCRIPTION
closes #2657