### PR TITLE
Remove pipe on end of commented code prior to checking parsability

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -29,6 +29,7 @@
 * `.lintr` configs set by option `lintr.linter_file` or environment variable `R_LINTR_LINTER_FILE` can point to subdirectories (#2512, @MichaelChirico).
 * `indentation_linter()` returns `ranges[1L]==1L` when the offending line has 0 spaces (#2550, @MichaelChirico).
 * `literal_coercion_linter()` doesn't surface a warning about NAs during coercion for code like `as.integer("a")` (#2566, @MichaelChirico).
+* `commented_code_linter()` can detect commented out code ending with a pipe (#2671, @jcken95)
 
 ## Changes to default linters
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -29,7 +29,7 @@
 * `.lintr` configs set by option `lintr.linter_file` or environment variable `R_LINTR_LINTER_FILE` can point to subdirectories (#2512, @MichaelChirico).
 * `indentation_linter()` returns `ranges[1L]==1L` when the offending line has 0 spaces (#2550, @MichaelChirico).
 * `literal_coercion_linter()` doesn't surface a warning about NAs during coercion for code like `as.integer("a")` (#2566, @MichaelChirico).
-* `commented_code_linter()` can detect commented out code ending with a pipe (#2671, @jcken95)
+* `commented_code_linter()` can detect commented code that ends with a pipe (#2671, @jcken95)
 
 ## Changes to default linters
 

--- a/R/commented_code_linter.R
+++ b/R/commented_code_linter.R
@@ -86,6 +86,9 @@ commented_code_linter <- function() {
     # ignore trailing ',' when testing for parsability
     extracted_code <- re_substitutes(extracted_code, rex(",", any_spaces, end), "")
     extracted_code <- re_substitutes(extracted_code, rex(start, any_spaces, ","), "")
+    # ignore a trailing pipe (|>) when testing parsability
+    extracted_code <- re_substitutes(extracted_code, rex("|>", any_spaces, end), "")
+
     is_parsable <- which(vapply(extracted_code, parsable, logical(1L)))
 
     lint_list <- xml_nodes_to_lints(

--- a/R/commented_code_linter.R
+++ b/R/commented_code_linter.R
@@ -86,8 +86,9 @@ commented_code_linter <- function() {
     # ignore trailing ',' when testing for parsability
     extracted_code <- re_substitutes(extracted_code, rex(",", any_spaces, end), "")
     extracted_code <- re_substitutes(extracted_code, rex(start, any_spaces, ","), "")
-    # ignore a trailing pipe (|>) when testing parsability
+    # ignore a trailing pipe (|> or %>%) when testing parsability
     extracted_code <- re_substitutes(extracted_code, rex("|>", any_spaces, end), "")
+    extracted_code <- re_substitutes(extracted_code, rex("%>%", any_spaces, end), "")
 
     is_parsable <- which(vapply(extracted_code, parsable, logical(1L)))
 

--- a/R/commented_code_linter.R
+++ b/R/commented_code_linter.R
@@ -83,12 +83,9 @@ commented_code_linter <- function() {
     all_comments <- xml_text(all_comment_nodes)
     code_candidates <- re_matches(all_comments, code_candidate_regex, global = FALSE, locations = TRUE)
     extracted_code <- code_candidates[, "code"]
-    # ignore trailing ',' when testing for parsability
-    extracted_code <- re_substitutes(extracted_code, rex(",", any_spaces, end), "")
+    # ignore trailing ',' or pipes ('|>', '%>%') when testing for parsability
+    extracted_code <- re_substitutes(extracted_code, rex(or(",", "|>", "%>%"), any_spaces, end), "")
     extracted_code <- re_substitutes(extracted_code, rex(start, any_spaces, ","), "")
-    # ignore a trailing pipe (|> or %>%) when testing parsability
-    extracted_code <- re_substitutes(extracted_code, rex("|>", any_spaces, end), "")
-    extracted_code <- re_substitutes(extracted_code, rex("%>%", any_spaces, end), "")
 
     is_parsable <- which(vapply(extracted_code, parsable, logical(1L)))
 

--- a/tests/testthat/test-commented_code_linter.R
+++ b/tests/testthat/test-commented_code_linter.R
@@ -103,3 +103,19 @@ test_that("commented_code_linter can detect operators in comments and lint corre
     commented_code_linter()
   )
 })
+
+test_that("commented_code_linter can detect commented code ending with a pipe", {
+  skip_if_not_r_version("4.1.0")
+
+  expect_lint(
+    "# f() |>",
+    rex::rex("Remove commented code."),
+    commented_code_linter()
+  )
+
+  expect_lint(
+    "# f() %>%",
+    rex::rex("Remove commented code."),
+    commented_code_linter()
+  )
+})

--- a/tests/testthat/test-commented_code_linter.R
+++ b/tests/testthat/test-commented_code_linter.R
@@ -104,20 +104,12 @@ test_that("commented_code_linter can detect operators in comments and lint corre
   )
 })
 
-test_that("commented_code_linter can detect commented code ending with a base pipe", {
+test_that("commented_code_linter can detect commented code ending with pipes", {
+  linter <- commented_code_linter()
+  lint_msg <- rex::rex("Remove commented code.")
+
+  expect_lint("# f() %>%", lint_msg, linter)
+
   skip_if_not_r_version("4.1.0")
-
-  expect_lint(
-    "# f() |>",
-    rex::rex("Remove commented code."),
-    commented_code_linter()
-  )
-})
-
-test_that("commented_code_linter can detect commented code ending with a {magrittr} pipe", {
-  expect_lint(
-    "# f() %>%",
-    rex::rex("Remove commented code."),
-    commented_code_linter()
-  )
+  expect_lint("# f() |>", lint_msg, linter)
 })

--- a/tests/testthat/test-commented_code_linter.R
+++ b/tests/testthat/test-commented_code_linter.R
@@ -104,27 +104,20 @@ test_that("commented_code_linter can detect operators in comments and lint corre
   )
 })
 
-test_that(
-  "commented_code_linter can detect commented code ending with a base pipe",
-  {
-    skip_if_not_r_version("4.1.0")
+test_that("commented_code_linter can detect commented code ending with a base pipe", {
+  skip_if_not_r_version("4.1.0")
 
-    expect_lint(
-      "# f() |>",
-      rex::rex("Remove commented code."),
-      commented_code_linter()
-    )
-  }
-)
+  expect_lint(
+    "# f() |>",
+    rex::rex("Remove commented code."),
+    commented_code_linter()
+  )
+})
 
-
-test_that(
-  "commented_code_linter can detect commented code ending with a {magrittr} pipe",
-  {
-    expect_lint(
-      "# f() %>%",
-      rex::rex("Remove commented code."),
-      commented_code_linter()
-    )
-  }
-)
+test_that("commented_code_linter can detect commented code ending with a {magrittr} pipe", {
+  expect_lint(
+    "# f() %>%",
+    rex::rex("Remove commented code."),
+    commented_code_linter()
+  )
+})

--- a/tests/testthat/test-commented_code_linter.R
+++ b/tests/testthat/test-commented_code_linter.R
@@ -104,18 +104,27 @@ test_that("commented_code_linter can detect operators in comments and lint corre
   )
 })
 
-test_that("commented_code_linter can detect commented code ending with a pipe", {
-  skip_if_not_r_version("4.1.0")
+test_that(
+  "commented_code_linter can detect commented code ending with a base pipe",
+  {
+    skip_if_not_r_version("4.1.0")
 
-  expect_lint(
-    "# f() |>",
-    rex::rex("Remove commented code."),
-    commented_code_linter()
-  )
+    expect_lint(
+      "# f() |>",
+      rex::rex("Remove commented code."),
+      commented_code_linter()
+    )
+  }
+)
 
-  expect_lint(
-    "# f() %>%",
-    rex::rex("Remove commented code."),
-    commented_code_linter()
-  )
-})
+
+test_that(
+  "commented_code_linter can detect commented code ending with a {magrittr} pipe",
+  {
+    expect_lint(
+      "# f() %>%",
+      rex::rex("Remove commented code."),
+      commented_code_linter()
+    )
+  }
+)


### PR DESCRIPTION
Closes #2671

The PR removes pipes from the end of `extracted_code` when checking parsability of code. A test to check that a lint is detected on commented lines ending with a pipe (which are otherwise parsable) are indeed detected.

This solves a common false negative occurrence in, for example, data wrangling

``` r
mtcars |>
# dplyr::filter(cyl > 4) |>
   dplyr::summarise(m = mean(wt))
```

The above snippet detect no commented code lints, but changes in this PR would lead to a commented code linter being detected