### PR TITLE
Don't package testthat-problems.rds

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -23,6 +23,7 @@
 ^bench$
 ^tests/testthat/dummy_packages/package/[.]Rbuildignore$
 ^tests/testthat/dummy_packages/cp1252/[.]Rbuildignore$
+testthat-problems[.]rds$
 ^_pkgdown\.yaml$
 ^docs$
 ^pkgdown$


### PR DESCRIPTION
Just noticed this wound up on CRAN:

https://github.com/cran/lintr/blob/945dc7b6e6f8cbfcdeafa93fe2acc0eaa0645da5/tests/testthat/testthat-problems.rds