### PR TITLE
Emphasize S3-S4 difference in recommendation for how to fix class_equals_linter()

### DIFF
--- a/R/class_equals_linter.R
+++ b/R/class_equals_linter.R
@@ -48,9 +48,10 @@ class_equals_linter <- function() {
     bad_expr <- xml_find_all(xml_calls, xpath)
 
     operator <- xml_find_chr(bad_expr, "string(*[2])")
-    lint_message <- sprintf(
-      "Use inherits(x, 'class-name'), is.<class> or is(x, 'class') instead of comparing class(x) with %s.",
-      operator
+    lint_message <- paste0(
+      "Use inherits(x, 'class-name'), is.<class> for S3 classes, ",
+      "or is(x, 'S4Class') for S4 classes, ",
+      "instead of comparing class(x) with ", operator, "."
     )
     xml_nodes_to_lints(
       bad_expr,

--- a/tests/testthat/test-class_equals_linter.R
+++ b/tests/testthat/test-class_equals_linter.R
@@ -29,7 +29,7 @@ test_that("class_equals_linter blocks usage of %in% for checking class", {
 test_that("class_equals_linter blocks class(x) != 'klass'", {
   expect_lint(
     "if (class(x) != 'character') TRUE",
-    rex::rex("Use inherits(x, 'class-name'), is.<class> or is(x, 'class')"),
+    rex::rex("Use inherits(x, 'class-name'), is.<class> for S3 classes, or is(x, 'S4Class') for S4 classes"),
     class_equals_linter()
   )
 })

--- a/tests/testthat/test-class_equals_linter.R
+++ b/tests/testthat/test-class_equals_linter.R
@@ -11,7 +11,7 @@ test_that("class_equals_linter skips allowed usages", {
 
 test_that("class_equals_linter blocks simple disallowed usages", {
   linter <- class_equals_linter()
-  lint_msg <- rex::rex("Use inherits(x, 'class-name'), is.<class> or is(x, 'class')")
+  lint_msg <- rex::rex("Use inherits(x, 'class-name'), is.<class> for S3 classes, or is(x, 'S4Class') for S4 classes")
 
   expect_lint("if (class(x) == 'character') stop('no')", lint_msg, linter)
   expect_lint("is_regression <- class(x) == 'lm'", lint_msg, linter)
@@ -20,7 +20,7 @@ test_that("class_equals_linter blocks simple disallowed usages", {
 
 test_that("class_equals_linter blocks usage of %in% for checking class", {
   linter <- class_equals_linter()
-  lint_msg <- rex::rex("Use inherits(x, 'class-name'), is.<class> or is(x, 'class')")
+  lint_msg <- rex::rex("Use inherits(x, 'class-name'), is.<class> for S3 classes, or is(x, 'S4Class') for S4 classes")
 
   expect_lint("if ('character' %in% class(x)) stop('no')", lint_msg, linter)
   expect_lint("if (class(x) %in% 'character') stop('no')", lint_msg, linter)
@@ -43,13 +43,13 @@ test_that("class_equals_linter skips usage for subsetting", {
   # but not further nesting
   expect_lint(
     "x[if (class(x) == 'foo') 1 else 2]",
-    rex::rex("Use inherits(x, 'class-name'), is.<class> or is(x, 'class')"),
+    rex::rex("Use inherits(x, 'class-name'), is.<class> for S3 classes, or is(x, 'S4Class') for S4 classes"),
     linter
   )
 })
 
 test_that("lints vectorize", {
-  lint_msg <- rex::rex("Use inherits(x, 'class-name'), is.<class> or is(x, 'class')")
+  lint_msg <- rex::rex("Use inherits(x, 'class-name'), is.<class> for S3 classes, or is(x, 'S4Class') for S4 classes")
 
   expect_lint(
     trim_some("{


### PR DESCRIPTION
Per experience here:

https://github.com/Rdatatable/data.table/pull/6603#discussion_r1854842225

I think it's good to more strongly recommend `is()` only for S4 classes.