### PR TITLE
Register Enhances S3 methods more selectively

### DIFF
--- a/R/zzz.R
+++ b/R/zzz.R
@@ -341,7 +341,7 @@ enhances_method_registration <- function(generic, s3class, implementation, owner
 
   reset_settings()
 
-  enhances_method_registration(    "as_tibble", "lints",     as_tibble.lints,     "tibble")
+  enhances_method_registration("as_tibble"    , "lints",     as_tibble.lints,     "tibble")
   enhances_method_registration("as.data.table", "lints", as.data.table.lints, "data.table")
 }
 # nocov end


### PR DESCRIPTION
Cribbing this from https://github.com/Rdatatable/data.table/pull/6589 -- our current approach always tries `requireNamespace()`. IMO it's better to avoid that for the very-weak `Enhances` dependency if we can.