### PR TITLE
Bump minimum backports version to ensure support for ...names()

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -23,7 +23,7 @@ BugReports: https://github.com/r-lib/lintr/issues
 Depends:
     R (>= 4.0)
 Imports:
-    backports (>= 1.1.7),
+    backports (>= 1.4.0),
     cli (>= 3.4.0),
     codetools,
     digest,


### PR DESCRIPTION
lintr uses the `...names()` function via backports on R versions <4.1.0. This function was [added](https://github.com/r-lib/backports/blob/main/NEWS.md#backports-140) to backports in version 1.4.0, so older versions of backports don't work. This PR bumps up the minimum version of backports in the DESCRIPTION.