### PR TITLE
Remove linter= argument of Lint()

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,10 @@
 # lintr (development version)
 
+## Deprecations & breaking changes
+
+* As previously announced, the following fully-deprecated items are now removed from the package:
+   + `linter=` argument of `Lint()`.
+
 # lintr 3.2.0
 
 ## Deprecations & breaking changes

--- a/R/lint.R
+++ b/R/lint.R
@@ -397,22 +397,12 @@ reorder_lints <- function(lints) {
 #' @param message message used to describe the lint error
 #' @param line code source where the lint occurred
 #' @param ranges a list of ranges on the line that should be emphasized.
-#' @param linter deprecated. No longer used.
 #' @return an object of class `c("lint", "list")`.
 #' @name lint-s3
 #' @export
 Lint <- function(filename, line_number = 1L, column_number = 1L, # nolint: object_name.
                  type = c("style", "warning", "error"),
-                 message = "", line = "", ranges = NULL, linter = "") {
-  if (!missing(linter)) {
-    lintr_deprecated(
-      what = "Using the `linter` argument of `Lint()`",
-      version = "3.0.0",
-      type = "",
-      signal = "stop"
-    )
-  }
-
+                 message = "", line = "", ranges = NULL) {
   if (length(line) != 1L || !is.character(line)) {
     cli_abort("{.arg line} must be a string.", call. = FALSE)
   }

--- a/man/lint-s3.Rd
+++ b/man/lint-s3.Rd
@@ -12,8 +12,7 @@ Lint(
   type = c("style", "warning", "error"),
   message = "",
   line = "",
-  ranges = NULL,
-  linter = ""
+  ranges = NULL
 )
 }
 \arguments{
@@ -30,8 +29,6 @@ Lint(
 \item{line}{code source where the lint occurred}
 
 \item{ranges}{a list of ranges on the line that should be emphasized.}
-
-\item{linter}{deprecated. No longer used.}
 }
 \value{
 an object of class \code{c("lint", "list")}.


### PR DESCRIPTION
Another post-release progression of deprecation