### PR TITLE
Two typos: Github->GitHub, unneccessary->unnecessary

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1016,7 +1016,7 @@ lintr 2.0.0 is a major release, and incorporates development changes since the l
 * Make spaces_left_parentheses_linter more robust when determining `(` type (#128, @saurfang)
 * commented_code_linter (#83, @jackwasey)
 * Now trims long comments (#55, reported by @paulstaab)
-* Automatic commenting of Github commits and pull requests when linting on Travis-CI
+* Automatic commenting of GitHub commits and pull requests when linting on Travis-CI
 * expect_lint_free expectation can be added to testthat unit tests.
 * Robust configuration system and exclusion logic
 * Emacs and Sublime Text 3 plugins now available from their respective package repositories.

--- a/R/is_lint_level.R
+++ b/R/is_lint_level.R
@@ -28,7 +28,7 @@ is_lint_level <- function(source_expression, level = c("expression", "file")) {
 
 #' Determine whether a linter needs to run for a given source_expression level
 #'
-#' Used by [lint()] to avoid unneccessary calls to linters.
+#' Used by [lint()] to avoid unnecessary calls to linters.
 #'
 #' @param linter A linter.
 #' @param level Which level of expression is being tested? `"expression"`


### PR DESCRIPTION
Found by our internal typo linter