### PR TITLE
Add missing nested '{}' in cli evaluation

### DIFF
--- a/R/linter_tags.R
+++ b/R/linter_tags.R
@@ -146,7 +146,7 @@ rd_tags <- function(linter_name) {
   linters <- available_linters(exclude_tags = NULL)
   tags <- platform_independent_sort(linters[["tags"]][[match(linter_name, linters[["linter"]])]])
   if (length(tags) == 0L) {
-    cli_abort("Tags are required, but found none for {.fn linter_name}.")
+    cli_abort("Tags are required, but found none for {.fn {linter_name}}.")
   }
 
   c(
@@ -165,7 +165,7 @@ rd_linters <- function(tag_name) {
   linters <- available_linters(tags = tag_name)
   tagged <- platform_independent_sort(linters[["linter"]])
   if (length(tagged) == 0L) {
-    cli_abort("No linters found associated with tag {.emph tag_name}.")
+    cli_abort("No linters found associated with tag {.emph {tag_name}}.")
   }
 
   c(


### PR DESCRIPTION
The outer `{` covers the tag, we still need the inner `{` to get "glue evaluation" of that variable, otherwise we get these errors:

```
✖ linter_tag_docs.R:89: @evalRd failed to evaluate.
Caused by error in `rd_linters()`:
! No linters found associated with tag tag_name.
✖ lintr-deprecated.R:5: @evalRd failed to evaluate.
Caused by error in `rd_tags()`:
! Tags are required, but found none for `linter_name()`.
```