### PR TITLE
Allow that a tag has no associated linters (esp. "deprecated")

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,7 +3,7 @@
 ## Deprecations & breaking changes
 
 * Arguments `allow_cascading_assign=`, `allow_right_assign=`, and `allow_pipe_assign=` to `assignment_linter()` are now defunct.
-* Two linters marked as deprecated with warning in the previous release are now fully deprecated: `extraction_operator_linter()` and `unnecessary_nested_if_linter()`. They will be removed in the next release.
+* Six linters marked as deprecated with warning in the previous release are now fully deprecated: `consecutive_stopifnot_linter()`, `extraction_operator_linter()`, `no_tab_linter()`, `single_quotes_linter()`, `unnecessary_nested_if_linter()`, and `unneeded_concatenation_linter()`. They will be removed in the next release.
 * As previously announced, the following fully-deprecated items are now removed from the package:
    + `with_defaults()`.
    + Passing linters by name or as non-`"linter"`-classed functions.

--- a/R/linter_tags.R
+++ b/R/linter_tags.R
@@ -167,17 +167,17 @@ rd_linters <- function(tag_name) {
   linters <- available_linters(tags = tag_name)
   tagged <- platform_independent_sort(linters[["linter"]])
   if (length(tagged) == 0L) {
-    body <- paste0("There are not currently any linters tagged with '", tag_name, "'.")
+    section_body <- paste0("There are not currently any linters tagged with '", tag_name, "'.")
   } else {
-    body <- c(
+    section_body <- c(
       paste0("The following linters are tagged with '", tag_name, "':"),
       "\\itemize{",
       paste0("  \\item{\\code{\\link{", tagged, "}}}"),
-      "}",
+      "}"
     )
   }
 
-  c("\\section{Linters}{", body, "}")
+  c("\\section{Linters}{", section_body, "}")
 }
 
 #' Generate Rd fragment for the main help page, listing all tags

--- a/R/linter_tags.R
+++ b/R/linter_tags.R
@@ -146,7 +146,7 @@ rd_tags <- function(linter_name) {
   linters <- available_linters(exclude_tags = NULL)
   tags <- platform_independent_sort(linters[["tags"]][[match(linter_name, linters[["linter"]])]])
   if (length(tags) == 0L) {
-    cli_abort("Tags are required, but found none for {.fn linter_name}.")
+    cli_abort("Tags are required, but found none for {.fn {linter_name}}.")
   }
 
   c(
@@ -165,7 +165,7 @@ rd_linters <- function(tag_name) {
   linters <- available_linters(tags = tag_name)
   tagged <- platform_independent_sort(linters[["linter"]])
   if (length(tagged) == 0L) {
-    cli_abort("No linters found associated with tag {.emph tag_name}.")
+    cli_abort("No linters found associated with tag {.emph {tag_name}}.")
   }
 
   c(

--- a/R/linter_tags.R
+++ b/R/linter_tags.R
@@ -167,17 +167,17 @@ rd_linters <- function(tag_name) {
   linters <- available_linters(tags = tag_name)
   tagged <- platform_independent_sort(linters[["linter"]])
   if (length(tagged) == 0L) {
-    return(paste0("There are not currently any linters tagged with '", tag_name, "'."))
+    body <- paste0("There are not currently any linters tagged with '", tag_name, "'.")
+  } else {
+    body <- c(
+      paste0("The following linters are tagged with '", tag_name, "':"),
+      "\\itemize{",
+      paste0("  \\item{\\code{\\link{", tagged, "}}}"),
+      "}",
+    )
   }
 
-  c(
-    "\\section{Linters}{",
-    paste0("The following linters are tagged with '", tag_name, "':"),
-    "\\itemize{",
-    paste0("\\item{\\code{\\link{", tagged, "}}}"),
-    "}", # itemize
-    "}" # section
-  )
+  c("\\section{Linters}{", body, "}")
 }
 
 #' Generate Rd fragment for the main help page, listing all tags

--- a/R/linter_tags.R
+++ b/R/linter_tags.R
@@ -172,7 +172,7 @@ rd_linters <- function(tag_name) {
     section_body <- c(
       paste0("The following linters are tagged with '", tag_name, "':"),
       "\\itemize{",
-      paste0("  \\item{\\code{\\link{", tagged, "}}}"),
+      paste0("\\item{\\code{\\link{", tagged, "}}}"),
       "}"
     )
   }

--- a/R/linter_tags.R
+++ b/R/linter_tags.R
@@ -142,11 +142,13 @@ available_tags <- function(packages = "lintr") {
 #' @param linter_name Name of the linter to generate Rd code for.
 #'
 #' @noRd
-rd_tags <- function(linter_name) {
-  linters <- available_linters(exclude_tags = NULL)
-  tags <- platform_independent_sort(linters[["tags"]][[match(linter_name, linters[["linter"]])]])
-  if (length(tags) == 0L) {
-    cli_abort("Tags are required, but found none for {.fn {linter_name}}.")
+rd_tags <- function(linter_name, tags = NULL) {
+  if (is.null(tags)) {
+    linters <- available_linters(exclude_tags = NULL)
+    tags <- platform_independent_sort(linters[["tags"]][[match(linter_name, linters[["linter"]])]])
+    if (length(tags) == 0L) {
+      cli_abort("Tags are required, but found none for {.fn {linter_name}}.")
+    }
   }
 
   c(
@@ -165,7 +167,7 @@ rd_linters <- function(tag_name) {
   linters <- available_linters(tags = tag_name)
   tagged <- platform_independent_sort(linters[["linter"]])
   if (length(tagged) == 0L) {
-    cli_abort("No linters found associated with tag {.emph {tag_name}}.")
+    return(paste0("There are not currently any linters tagged with '", tag_name, "'."))
   }
 
   c(

--- a/R/linter_tags.R
+++ b/R/linter_tags.R
@@ -142,13 +142,11 @@ available_tags <- function(packages = "lintr") {
 #' @param linter_name Name of the linter to generate Rd code for.
 #'
 #' @noRd
-rd_tags <- function(linter_name, tags = NULL) {
-  if (is.null(tags)) {
-    linters <- available_linters(exclude_tags = NULL)
-    tags <- platform_independent_sort(linters[["tags"]][[match(linter_name, linters[["linter"]])]])
-    if (length(tags) == 0L) {
-      cli_abort("Tags are required, but found none for {.fn {linter_name}}.")
-    }
+rd_tags <- function(linter_name) {
+  linters <- available_linters(exclude_tags = NULL)
+  tags <- platform_independent_sort(linters[["tags"]][[match(linter_name, linters[["linter"]])]])
+  if (length(tags) == 0L) {
+    cli_abort("Tags are required, but found none for {.fn {linter_name}}.")
   }
 
   c(

--- a/R/lintr-deprecated.R
+++ b/R/lintr-deprecated.R
@@ -1,8 +1,9 @@
 #' @name lintr-deprecated
 #' @title Deprecated functions in lintr
 #'
-#' @seealso [linters] for a complete list of linters available in lintr.
-#' @evalRd rd_tags(tags = "deprecated")
+#' @seealso
+#'  - [linters] for a complete list of linters available in lintr.
+#'  - [deprecated_linters] for a list of linters tagged as deprecated.
 #' @keywords internal
 NULL
 

--- a/R/lintr-deprecated.R
+++ b/R/lintr-deprecated.R
@@ -2,7 +2,7 @@
 #' @title Deprecated functions in lintr
 #'
 #' @seealso [linters] for a complete list of linters available in lintr.
-#' @evalRd rd_tags("single_quotes_linter")
+#' @evalRd rd_tags(tags = "deprecated")
 #' @keywords internal
 NULL
 
@@ -14,14 +14,9 @@ unneeded_concatenation_linter <- function(allow_single_expression = TRUE) {
     what = "unneeded_concatenation_linter",
     alternative = "unnecessary_concatenation_linter",
     version = "3.1.0",
-    type = "Linter"
+    type = "Linter",
+    signal = "stop"
   )
-
-  stopifnot(
-    is.logical(allow_single_expression),
-    length(allow_single_expression) == 1L
-  )
-  unnecessary_concatenation_linter(allow_single_expression = allow_single_expression)
 }
 
 #' Single quotes linter
@@ -32,9 +27,9 @@ single_quotes_linter <- function() {
     what = "single_quotes_linter",
     alternative = "quotes_linter",
     version = "3.1.0",
-    type = "Linter"
+    type = "Linter",
+    signal = "stop"
   )
-  quotes_linter()
 }
 
 #' Consecutive stopifnot linter
@@ -45,9 +40,9 @@ consecutive_stopifnot_linter <- function() {
     what = "consecutive_stopifnot_linter",
     alternative = "consecutive_assertion_linter",
     version = "3.1.0",
-    type = "Linter"
+    type = "Linter",
+    signal = "stop"
   )
-  consecutive_assertion_linter()
 }
 
 #' No tabs linter
@@ -58,9 +53,9 @@ no_tab_linter <- function() {
     what = "no_tab_linter",
     alternative = "whitespace_linter",
     version = "3.1.0",
-    type = "Linter"
+    type = "Linter",
+    signal = "stop"
   )
-  whitespace_linter()
 }
 
 #' Extraction operator linter

--- a/inst/lintr/linters.csv
+++ b/inst/lintr/linters.csv
@@ -15,7 +15,7 @@ condition_message_linter,best_practices consistency
 conjunct_test_linter,package_development best_practices readability configurable pkg_testthat
 consecutive_assertion_linter,style readability consistency
 consecutive_mutate_linter,consistency readability configurable efficiency
-consecutive_stopifnot_linter,style readability consistency deprecated
+consecutive_stopifnot_linter,defunct
 cyclocomp_linter,style readability best_practices configurable
 duplicate_argument_linter,correctness common_mistakes configurable
 empty_assignment_linter,readability best_practices
@@ -59,7 +59,7 @@ missing_package_linter,robustness common_mistakes
 namespace_linter,correctness robustness configurable executing
 nested_ifelse_linter,efficiency readability
 nested_pipe_linter,readability consistency configurable
-no_tab_linter,style consistency deprecated
+no_tab_linter,defunct
 nonportable_path_linter,robustness best_practices configurable
 nrow_subset_linter,efficiency consistency best_practices
 numeric_leading_zero_linter,style consistency readability
@@ -90,7 +90,7 @@ sample_int_linter,efficiency readability robustness
 scalar_in_linter,readability consistency best_practices efficiency configurable
 semicolon_linter,style readability default configurable
 seq_linter,robustness efficiency consistency best_practices default
-single_quotes_linter,style consistency readability deprecated
+single_quotes_linter,defunct
 sort_linter,readability best_practices efficiency
 spaces_inside_linter,style readability default
 spaces_left_parentheses_linter,style readability default
@@ -111,7 +111,7 @@ unnecessary_lambda_linter,best_practices efficiency readability configurable
 unnecessary_nested_if_linter,defunct
 unnecessary_nesting_linter,readability consistency configurable best_practices
 unnecessary_placeholder_linter,readability best_practices
-unneeded_concatenation_linter,style readability efficiency configurable deprecated
+unneeded_concatenation_linter,defunct
 unreachable_code_linter,best_practices readability configurable
 unused_import_linter,best_practices common_mistakes configurable executing
 vector_logic_linter,default efficiency best_practices common_mistakes

--- a/man/deprecated_linters.Rd
+++ b/man/deprecated_linters.Rd
@@ -10,4 +10,6 @@ These linters will be excluded from \code{\link[=linters_with_tags]{linters_with
 \seealso{
 \link{linters} for a complete list of linters available in lintr.
 }
+\section{Linters}{
 There are not currently any linters tagged with 'deprecated'.
+}

--- a/man/deprecated_linters.Rd
+++ b/man/deprecated_linters.Rd
@@ -10,12 +10,4 @@ These linters will be excluded from \code{\link[=linters_with_tags]{linters_with
 \seealso{
 \link{linters} for a complete list of linters available in lintr.
 }
-\section{Linters}{
-The following linters are tagged with 'deprecated':
-\itemize{
-\item{\code{\link{consecutive_stopifnot_linter}}}
-\item{\code{\link{no_tab_linter}}}
-\item{\code{\link{single_quotes_linter}}}
-\item{\code{\link{unneeded_concatenation_linter}}}
-}
-}
+There are not currently any linters tagged with 'deprecated'.

--- a/man/linters.Rd
+++ b/man/linters.Rd
@@ -23,7 +23,6 @@ The following tags exist:
 \item{\link[=consistency_linters]{consistency} (32 linters)}
 \item{\link[=correctness_linters]{correctness} (7 linters)}
 \item{\link[=default_linters]{default} (25 linters)}
-\item{\link[=deprecated_linters]{deprecated} (4 linters)}
 \item{\link[=efficiency_linters]{efficiency} (29 linters)}
 \item{\link[=executing_linters]{executing} (6 linters)}
 \item{\link[=package_development_linters]{package_development} (14 linters)}

--- a/man/lintr-deprecated.Rd
+++ b/man/lintr-deprecated.Rd
@@ -38,9 +38,9 @@ Extraction operator linter
 Unnecessary nested if linter
 }
 \seealso{
-\link{linters} for a complete list of linters available in lintr.
+\itemize{
+\item \link{linters} for a complete list of linters available in lintr.
+\item \link{deprecated_linters} for a list of linters tagged as deprecated.
+}
 }
 \keyword{internal}
-\section{Tags}{
-\link[=deprecated_linters]{deprecated}
-}

--- a/man/lintr-deprecated.Rd
+++ b/man/lintr-deprecated.Rd
@@ -42,5 +42,5 @@ Unnecessary nested if linter
 }
 \keyword{internal}
 \section{Tags}{
-\link[=consistency_linters]{consistency}, \link[=deprecated_linters]{deprecated}, \link[=readability_linters]{readability}, \link[=style_linters]{style}
+\link[=deprecated_linters]{deprecated}
 }

--- a/tests/testthat/test-consecutive_assertion_linter.R
+++ b/tests/testthat/test-consecutive_assertion_linter.R
@@ -116,7 +116,7 @@ test_that("lints vectorize", {
   )
 })
 
-test_that("old name consecutive_stopifnot_linter() is funct", {
+test_that("old name consecutive_stopifnot_linter() is defunct", {
   expect_error(consecutive_stopifnot_linter(), "Use consecutive_assertion_linter instead", fixed = TRUE)
 })
 

--- a/tests/testthat/test-consecutive_assertion_linter.R
+++ b/tests/testthat/test-consecutive_assertion_linter.R
@@ -116,16 +116,8 @@ test_that("lints vectorize", {
   )
 })
 
-test_that("old name consecutive_stopifnot_linter() is deprecated", {
-  expect_warning(
-    {
-      old_linter <- consecutive_stopifnot_linter()
-    },
-    "Use consecutive_assertion_linter instead",
-    fixed = TRUE
-  )
-  expect_lint("stopifnot(x); y; stopifnot(z)", NULL, old_linter)
-  expect_lint("stopifnot(x); stopifnot(y)", "Unify consecutive calls", old_linter)
+test_that("old name consecutive_stopifnot_linter() is funct", {
+  expect_warning(consecutive_stopifnot_linter(), "Use consecutive_assertion_linter instead", fixed = TRUE)
 })
 
 test_that("interceding = assignments aren't linted", {

--- a/tests/testthat/test-consecutive_assertion_linter.R
+++ b/tests/testthat/test-consecutive_assertion_linter.R
@@ -117,7 +117,7 @@ test_that("lints vectorize", {
 })
 
 test_that("old name consecutive_stopifnot_linter() is funct", {
-  expect_warning(consecutive_stopifnot_linter(), "Use consecutive_assertion_linter instead", fixed = TRUE)
+  expect_error(consecutive_stopifnot_linter(), "Use consecutive_assertion_linter instead", fixed = TRUE)
 })
 
 test_that("interceding = assignments aren't linted", {

--- a/tests/testthat/test-quotes_linter.R
+++ b/tests/testthat/test-quotes_linter.R
@@ -65,16 +65,8 @@ test_that("handles R>=4.0.0 strings", {
   expect_lint("r'(\")'", NULL, linter)
 })
 
-test_that("single_quotes_linter is deprecated", {
-  expect_warning(
-    {
-      old_linter <- single_quotes_linter()
-    },
-    "Use quotes_linter instead",
-    fixed = TRUE
-  )
-  expect_lint('"blah"', NULL, old_linter)
-  expect_lint("'blah'", "Only use double-quotes", old_linter)
+test_that("single_quotes_linter is defunct", {
+  expect_error(single_quotes_linter(), "Use quotes_linter instead", fixed = TRUE)
 })
 
 test_that("lints vectorize", {

--- a/tests/testthat/test-unneeded_concatenation_linter.R
+++ b/tests/testthat/test-unneeded_concatenation_linter.R
@@ -1,5 +1,5 @@
-test_that("unneeded_concatenation_linter generates deprecation warning", {
-  expect_warning(
+test_that("unneeded_concatenation_linter generates defunct error", {
+  expect_error(
     unneeded_concatenation_linter(),
     rex::rex("Linter unneeded_concatenation_linter was deprecated")
   )

--- a/tests/testthat/test-whitespace_linter.R
+++ b/tests/testthat/test-whitespace_linter.R
@@ -59,14 +59,6 @@ test_that("whitespace_linter blocks disallowed usages with a pipe", {
   )
 })
 
-test_that("no_tab_linter id deprecated", {
-  expect_warning(
-    {
-      old_linter <- no_tab_linter()
-    },
-    "Use whitespace_linter instead",
-    fixed = TRUE
-  )
-  expect_lint("  f(a, b, c)", NULL, old_linter)
-  expect_lint("\tf(a, b, c)", "not tabs", old_linter)
+test_that("no_tab_linter is defunct", {
+  expect_error(no_tab_linter(), "Use whitespace_linter instead", fixed = TRUE)
 })


### PR DESCRIPTION
Another option is to special-case `deprecated`, but I think this approach is OK.

NB: this PR is based against #2744 for now.