### PR TITLE
Exempt OP-LAMBDA the same as FUNCTION in unnecessary_nesting_linter

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -10,6 +10,12 @@
    + Linters `closed_curly_linter()`, `open_curly_linter()`, `paren_brace_linter()`, and `semicolon_terminator_linter()`.
    + `linter=` argument of `Lint()`.
 
+## New and improved features
+
+### Lint accuracy fixes: removing false positives
+
+* `unnecessary_nesting_linter()` treats function bodies under the shorthand lambda (`\()`) the same as normal function bodies (#2748, @MichaelChirico).
+
 ## Notes
 
 * `expect_lint_free()` and other functions that rely on the {testthat} framework now have a consistent error message. (#2585, @F-Noelle).

--- a/R/unnecessary_nesting_linter.R
+++ b/R/unnecessary_nesting_linter.R
@@ -206,6 +206,7 @@ unnecessary_nesting_linter <- function(
       count(expr) = 1
       and not(preceding-sibling::*[
         self::FUNCTION
+        or self::OP-LAMBDA
         or self::FOR
         or self::IF
         or self::WHILE

--- a/tests/testthat/test-unnecessary_nesting_linter.R
+++ b/tests/testthat/test-unnecessary_nesting_linter.R
@@ -180,6 +180,18 @@ test_that("unnecessary_nesting_linter skips one-line functions", {
     NULL,
     linter
   )
+
+  # ditto short-hand lambda
+  skip_if_not_r_version("4.1.0")
+  expect_lint(
+    trim_some("
+      foo <- \\(x) {
+        return(x)
+      }
+    "),
+    NULL,
+    linter
+  )
 })
 
 test_that("unnecessary_nesting_linter skips one-expression for loops", {


### PR DESCRIPTION
Closes #2748 