### PR TITLE
Remove duplicate {cli} dependency for development

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -51,7 +51,7 @@ Enhances:
 VignetteBuilder: 
     knitr
 Config/Needs/website: tidyverse/tidytemplate
-Config/Needs/development: pkgload, cli, testthat, patrick
+Config/Needs/development: pkgload, testthat, patrick
 Config/testthat/edition: 3
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)


### PR DESCRIPTION
Since {cli} is in `Imports:` this is redundant (this might have been made obsolete when adding {cli} recently).