### PR TITLE
Capture emitted output as a test

### DIFF
--- a/tests/testthat/test-methods.R
+++ b/tests/testthat/test-methods.R
@@ -134,7 +134,7 @@ test_that("print.lints works", {
 
   tmp <- withr::local_tempfile()
   stopifnot(file.create(tmp))
-  expect_invisible(print(lint(tmp)))
+  expect_message(print(lint(tmp)), "No lints found")
 })
 
 test_that("split.lint works as intended", {

--- a/tests/testthat/test-methods.R
+++ b/tests/testthat/test-methods.R
@@ -134,7 +134,7 @@ test_that("print.lints works", {
 
   tmp <- withr::local_tempfile()
   stopifnot(file.create(tmp))
-  expect_message(print(lint(tmp)), "No lints found")
+  expect_message(expect_invisible(print(lint(tmp))), "No lints found")
 })
 
 test_that("split.lint works as intended", {

--- a/tests/testthat/test-rstudio_markers.R
+++ b/tests/testthat/test-rstudio_markers.R
@@ -114,5 +114,5 @@ test_that("rstudio_source_markers apply to print within rstudio", {
   expect_output(print(l), "matched", fixed = TRUE)
 
   l <- lint(empty, seq_linter())
-  expect_output(print(l), "matched", fixed = TRUE)
+  expect_message(expect_output(print(l), "matched", fixed = TRUE), "No lints found")
 })


### PR DESCRIPTION
These tests have been omitting uncaught output for some time (probably since #2643):

![see link](https://github.com/user-attachments/assets/2293422a-1972-4a24-9fcb-37ad11234770)

https://github.com/r-lib/lintr/actions/runs/13335295688/job/37249044522

Better to capture this output intentionally, vs. let it bubble up.