### PR TITLE
Specific advice in unnecessary_nesting_linter metadata

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -33,7 +33,7 @@
 ## Notes
 
 * `expect_lint_free()` and other functions that rely on the {testthat} framework now have a consistent error message. (#2585, @F-Noelle).
-* `unnecessary_nesting_linter()` gives a more specific lint message identifying which "exit call" is unmatched & thus leading to the recommendation to reduce nesting (#2316, @MichaelChirico).
+* `unnecessary_nesting_linter()` gives a more specific lint message, identifying the unmatched "exit call" that prompts the recommendation to reduce nesting (#2316, @MichaelChirico).
 
 # lintr 3.2.0
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -33,6 +33,7 @@
 ## Notes
 
 * `expect_lint_free()` and other functions that rely on the {testthat} framework now have a consistent error message. (#2585, @F-Noelle).
+* `unnecessary_nesting_linter()` gives a more specific lint message identifying which "exit call" is unmatched & thus leading to the recommendation to reduce nesting (#2316, @MichaelChirico).
 
 # lintr 3.2.0
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -239,6 +239,9 @@ re_matches_logical <- function(x, regex, ...) {
 #'
 #' @export
 get_r_string <- function(s, xpath = NULL) {
+  if (length(s) == 0L) {
+    return(character())
+  }
   if (is_node(s) || is_nodeset(s)) {
     if (is.null(xpath)) {
       s <- xml_text(s)

--- a/tests/testthat/test-unnecessary_nesting_linter.R
+++ b/tests/testthat/test-unnecessary_nesting_linter.R
@@ -87,6 +87,7 @@ test_that("parallels in further nesting are skipped", {
 
 test_that("unnecessary_nesting_linter blocks if/else with one exit branch", {
   linter <- unnecessary_nesting_linter()
+  linter_warning <- unnecessary_nesting_linter(branch_exit_calls = "warning")
   lint_msg <- function(exit) rex::rex("Reduce the nesting of this if/else statement", anything, exit, "()")
 
   expect_lint(
@@ -138,6 +139,18 @@ test_that("unnecessary_nesting_linter blocks if/else with one exit branch", {
     linter
   )
 
+  expect_lint(
+    trim_some("
+      if (A) {
+        B
+      } else {
+        warning()
+      }
+    "),
+    lint_msg("warning"),
+    linter_warning
+  )
+
   stop_warning_lines <- trim_some("
     if (A) {
       stop('An error')
@@ -148,7 +161,7 @@ test_that("unnecessary_nesting_linter blocks if/else with one exit branch", {
   expect_lint(stop_warning_lines, lint_msg("stop"), linter)
 
   # Optionally consider 'warning' as an exit call --> no lint
-  expect_no_lint(stop_warning_lines, unnecessary_nesting_linter(branch_exit_calls = "warning"))
+  expect_no_lint(stop_warning_lines, linter_warning)
 })
 
 test_that("unnecessary_nesting_linter skips one-line functions", {

--- a/tests/testthat/test-unnecessary_nesting_linter.R
+++ b/tests/testthat/test-unnecessary_nesting_linter.R
@@ -87,7 +87,7 @@ test_that("parallels in further nesting are skipped", {
 
 test_that("unnecessary_nesting_linter blocks if/else with one exit branch", {
   linter <- unnecessary_nesting_linter()
-  lint_msg <- rex::rex("Reduce the nesting of this if/else statement by unnesting the portion")
+  lint_msg <- function(exit) rex::rex("Reduce the nesting of this if/else statement", anything, exit, "()")
 
   expect_lint(
     trim_some("
@@ -97,7 +97,7 @@ test_that("unnecessary_nesting_linter blocks if/else with one exit branch", {
         B
       }
     "),
-    lint_msg,
+    lint_msg("stop"),
     linter
   )
 
@@ -109,7 +109,7 @@ test_that("unnecessary_nesting_linter blocks if/else with one exit branch", {
         B
       }
     "),
-    lint_msg,
+    lint_msg("return"),
     linter
   )
 
@@ -122,7 +122,7 @@ test_that("unnecessary_nesting_linter blocks if/else with one exit branch", {
         stop()
       }
     "),
-    lint_msg,
+    lint_msg("stop"),
     linter
   )
 
@@ -134,7 +134,7 @@ test_that("unnecessary_nesting_linter blocks if/else with one exit branch", {
         return()
       }
     "),
-    lint_msg,
+    lint_msg("return"),
     linter
   )
 
@@ -145,7 +145,7 @@ test_that("unnecessary_nesting_linter blocks if/else with one exit branch", {
       warning('A warning')
     }
   ")
-  expect_lint(stop_warning_lines, lint_msg, linter)
+  expect_lint(stop_warning_lines, lint_msg("stop"), linter)
 
   # Optionally consider 'warning' as an exit call --> no lint
   expect_no_lint(stop_warning_lines, unnecessary_nesting_linter(branch_exit_calls = "warning"))

--- a/tests/testthat/test-unnecessary_nesting_linter.R
+++ b/tests/testthat/test-unnecessary_nesting_linter.R
@@ -356,7 +356,7 @@ test_that("unnecessary_nesting_linter allow_assignment= argument works", {
 })
 
 test_that("lints vectorize", {
-  lint_msg <- rex::rex("Reduce the nesting of this if/else")
+  lint_msg <- function(exit) rex::rex("Reduce the nesting of this if/else", anything, exit, "()")
 
   expect_lint(
     trim_some("{
@@ -366,14 +366,14 @@ test_that("lints vectorize", {
         0
       }
       if (B) {
-        stop('really no')
+        q('really no')
       } else {
         1
       }
     }"),
     list(
-      list(lint_msg, line_number = 2L),
-      list(lint_msg, line_number = 7L)
+      list(lint_msg("stop"), line_number = 2L),
+      list(lint_msg("q"), line_number = 7L)
     ),
     unnecessary_nesting_linter()
   )


### PR DESCRIPTION
Closes #2316.

Also

 - Add an early return to `get_r_string()`, which might get called many times with empty inputs
 - Avoid `//expr` XPath