### PR TITLE
Fix description of paste_linter(allow_file_path=)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -36,6 +36,7 @@
 
 * `expect_lint_free()` and other functions that rely on the {testthat} framework now have a consistent error message. (#2585, @F-Noelle).
 * `unnecessary_nesting_linter()` gives a more specific lint message, identifying the unmatched "exit call" that prompts the recommendation to reduce nesting (#2316, @MichaelChirico).
+* The description in `?paste_linter` of `allow_file_path=` has been corrected (#2675, @MichaelChirico). In particular, `allow_file_path="never"` is the most strict form, `allow_file_path="always"` is the most lax form.
 
 # lintr 3.2.0
 

--- a/R/paste_linter.R
+++ b/R/paste_linter.R
@@ -24,10 +24,10 @@
 #' @param allow_to_string Logical, default `FALSE`. If `TRUE`, usage of
 #'   `paste()` and `paste0()` with `collapse = ", "` is not linted.
 #' @param allow_file_path String, one of `"never"`, `"double_slash"`, or `"always"`; `"double_slash"` by default.
-#'   If `"never"`, usage of `paste()` and `paste0()` to construct file paths is not linted. If `"double_slash"`,
+#'   If `"always"`, usage of `paste()` and `paste0()` to construct file paths is not linted. If `"double_slash"`,
 #'   strings containing consecutive forward slashes will not lint. The main use case here is for URLs -- "paths" like
 #'   `"https://"` will not induce lints, since constructing them with `file.path()` might be deemed unnatural.
-#'   Lastly, if `"always"`, strings with consecutive forward slashes will also lint. Note that `"//"` is never linted
+#'   Lastly, if `"never"`, strings with consecutive forward slashes will also lint. Note that `"//"` is never linted
 #'   when it comes at the beginning or end of the input, to avoid requiring empty inputs like
 #'  `file.path("", ...)` or `file.path(..., "")`.
 #'

--- a/man/paste_linter.Rd
+++ b/man/paste_linter.Rd
@@ -18,10 +18,10 @@ paste_linter(
 \code{paste()} and \code{paste0()} with \code{collapse = ", "} is not linted.}
 
 \item{allow_file_path}{String, one of \code{"never"}, \code{"double_slash"}, or \code{"always"}; \code{"double_slash"} by default.
-If \code{"never"}, usage of \code{paste()} and \code{paste0()} to construct file paths is not linted. If \code{"double_slash"},
+If \code{"always"}, usage of \code{paste()} and \code{paste0()} to construct file paths is not linted. If \code{"double_slash"},
 strings containing consecutive forward slashes will not lint. The main use case here is for URLs -- "paths" like
 \code{"https://"} will not induce lints, since constructing them with \code{file.path()} might be deemed unnatural.
-Lastly, if \code{"always"}, strings with consecutive forward slashes will also lint. Note that \code{"//"} is never linted
+Lastly, if \code{"never"}, strings with consecutive forward slashes will also lint. Note that \code{"//"} is never linted
 when it comes at the beginning or end of the input, to avoid requiring empty inputs like
 \code{file.path("", ...)} or \code{file.path(..., "")}.}
 }


### PR DESCRIPTION
Closes #2675.

First I confirmed the linter is working in the intuitive way:

```
lint(text = "paste('a', 'b', sep = '/')", linters = paste_linter(allow_file_path="never"))
# <text>:1:1: warning: [paste_linter] Construct file paths with file.path(...) instead of paste(..., sep = "/"). If you are using paste(sep = "/") to construct a date, consider using format() or lubridate helpers instead. Note that paste() converts empty inputs to "", whereas file.path() leaves it empty.
# paste('a', 'b', sep = '/')
# ^~~~~~~~~~~~~~~~~~~~~~~~~~
lint(text = "paste('a', 'b', sep = '/')", linters = paste_linter(allow_file_path="always"))
# ℹ No lints found.
lint(text = "paste('a', 'b', sep = '/')", linters = paste_linter(allow_file_path="double_slash"))
# <text>:1:1: warning: [paste_linter] Construct file paths with file.path(...) instead of paste(..., sep = "/"). If you are using paste(sep = "/") to construct a date, consider using format() or lubridate helpers instead. Note that paste() converts empty inputs to "", whereas file.path() leaves it empty.
# paste('a', 'b', sep = '/')
# ^~~~~~~~~~~~~~~~~~~~~~~~~~
lint(text = "paste0('a//b/', 'c')", linters = paste_linter(allow_file_path="never"))
# <text>:1:1: warning: [paste_linter] Construct file paths with file.path(...) instead of paste0(x, "/", y, "/", z). Note that paste() converts empty inputs to "", whereas file.path() leaves it empty.
# paste0('a//b/', 'c')
# ^~~~~~~~~~~~~~~~~~~~
```