### PR TITLE
Adjust to "no lints found" output in lintr vignette exposition

### DIFF
--- a/vignettes/lintr.Rmd
+++ b/vignettes/lintr.Rmd
@@ -321,7 +321,7 @@ lint("X = 42L # nolint ------ this comment overflows the default 80 chars line l
 )
 ```
 
-Observe how all lints were suppressed and no output is shown.
+Observe how all lints were suppressed.
 Sometimes, only a specific linter needs to be excluded.
 In this case, the *name* of the linter can be appended to the `# nolint` comment preceded by a colon and terminated by a dot.
 
@@ -412,8 +412,6 @@ lint("# nolint start: commented_code_linter.\n# x <- 42L\n# print(x)\n# nolint e
   parse_settings = FALSE
 )
 ```
-
-(No lints)
 
 ### Excluding lines via the config file
 


### PR DESCRIPTION
The exposition is slightly off now that printing empty lint objects gives a message "No lints found".

![Screenshot of the rendered vignette, first diff](https://github.com/user-attachments/assets/7d257148-ae3f-422c-ac13-2ab592d09f8e)
![Screenshot of the rendered vignette, second diff](https://github.com/user-attachments/assets/9d1d0198-8c53-4e8b-8c64-b243478aa26f)
