### PR TITLE
Move the cyclocomp namespace check into the factory

### DIFF
--- a/R/cyclocomp_linter.R
+++ b/R/cyclocomp_linter.R
@@ -28,7 +28,7 @@ cyclocomp_linter <- function(complexity_limit = 15L) {
       "Cyclocomp complexity is computed using {.fn cyclocomp::cyclocomp}.",
       i = "Please install the needed {.pkg cyclocomp} package."
     ))
-    return(Linter(function(.) cli_abort("cyclocomp_linter is disabled due to lack of {.pkg cyclocomp} package")))
+    return(Linter(function(.) cli_abort("cyclocomp_linter is disabled due to lack of the {.pkg cyclocomp} package")))
   }
   # nocov end
   Linter(linter_level = "expression", function(source_expression) {

--- a/R/cyclocomp_linter.R
+++ b/R/cyclocomp_linter.R
@@ -24,10 +24,11 @@
 cyclocomp_linter <- function(complexity_limit = 15L) {
   # nocov start
   if (!requireNamespace("cyclocomp", quietly = TRUE)) {
-    cli::cli_abort(c(
-      "Cyclocomp complexity is computed using {.fn cyclocomp::cyclocomp}.",
+    cli::cli_warn(c(
+      "Cyclocomp complexity is computed using {.fn cyclocomp::cyclocomp}. Returning a null linter.",
       i = "Please install the needed {.pkg cyclocomp} package."
     ))
+    return(Linter(function(.) NULL))
   }
   # nocov end
   Linter(linter_level = "expression", function(source_expression) {

--- a/R/cyclocomp_linter.R
+++ b/R/cyclocomp_linter.R
@@ -25,7 +25,7 @@ cyclocomp_linter <- function(complexity_limit = 15L) {
   # nocov start
   if (!requireNamespace("cyclocomp", quietly = TRUE)) {
     cli::cli_warn(c(
-      "Cyclocomp complexity is computed using {.fn cyclocomp::cyclocomp}. Returning a null linter.",
+      "Cyclocomp complexity is computed using {.fn cyclocomp::cyclocomp}.",
       i = "Please install the needed {.pkg cyclocomp} package."
     ))
     return(Linter(function(.) cli_abort("cyclocomp_linter is disabled due to lack of {.pkg cyclocomp} package")))

--- a/R/cyclocomp_linter.R
+++ b/R/cyclocomp_linter.R
@@ -28,7 +28,7 @@ cyclocomp_linter <- function(complexity_limit = 15L) {
       "Cyclocomp complexity is computed using {.fn cyclocomp::cyclocomp}. Returning a null linter.",
       i = "Please install the needed {.pkg cyclocomp} package."
     ))
-    return(Linter(function(.) NULL))
+    return(Linter(function(.) cli_abort("cyclocomp_linter is disabled due to lack of {.pkg cyclocomp} package"))
   }
   # nocov end
   Linter(linter_level = "expression", function(source_expression) {

--- a/R/cyclocomp_linter.R
+++ b/R/cyclocomp_linter.R
@@ -22,16 +22,15 @@
 #' @seealso [linters] for a complete list of linters available in lintr.
 #' @export
 cyclocomp_linter <- function(complexity_limit = 15L) {
+  # nocov start
+  if (!requireNamespace("cyclocomp", quietly = TRUE)) {
+    cli::cli_abort(c(
+      "Cyclocomp complexity is computed using {.fn cyclocomp::cyclocomp}.",
+      i = "Please install the needed {.pkg cyclocomp} package."
+    ))
+  }
+  # nocov end
   Linter(linter_level = "expression", function(source_expression) {
-    # nocov start
-    if (!requireNamespace("cyclocomp", quietly = TRUE)) {
-      cli::cli_abort(c(
-        "Cyclocomp complexity is computed using {.fn cyclocomp::cyclocomp}.",
-        i = "Please install the needed {.pkg cyclocomp} package."
-      ))
-    }
-    # nocov end
-
     complexity <- try_silently(
       cyclocomp::cyclocomp(parse(text = source_expression$content))
     )

--- a/R/cyclocomp_linter.R
+++ b/R/cyclocomp_linter.R
@@ -28,7 +28,7 @@ cyclocomp_linter <- function(complexity_limit = 15L) {
       "Cyclocomp complexity is computed using {.fn cyclocomp::cyclocomp}. Returning a null linter.",
       i = "Please install the needed {.pkg cyclocomp} package."
     ))
-    return(Linter(function(.) cli_abort("cyclocomp_linter is disabled due to lack of {.pkg cyclocomp} package"))
+    return(Linter(function(.) cli_abort("cyclocomp_linter is disabled due to lack of {.pkg cyclocomp} package")))
   }
   # nocov end
   Linter(linter_level = "expression", function(source_expression) {

--- a/R/settings.R
+++ b/R/settings.R
@@ -157,7 +157,7 @@ read_config_file <- function(config_file, call = parent.frame()) {
       error = malformed
     ),
     warning = function(w) {
-      cli::cli_warn(
+      cli_warn(
         "Warning encountered while loading config:",
         parent = w
       )

--- a/R/with.R
+++ b/R/with.R
@@ -187,11 +187,10 @@ call_linter_factory <- function(linter_factory, linter_name, package) {
   linter <- tryCatch(
     linter_factory(),
     error = function(e) {
-      cli_warn(
-        "Could not create linter with {.fun {package}::{linter_name}}. Returning a null linter.",
+      cli_abort(
+        "Could not create linter with {.fun {package}::{linter_name}}.",
         parent = e
       )
-      Linter(function(.) list())
     }
   )
   # Otherwise, all linters would be called "linter_factory".

--- a/R/with.R
+++ b/R/with.R
@@ -187,10 +187,11 @@ call_linter_factory <- function(linter_factory, linter_name, package) {
   linter <- tryCatch(
     linter_factory(),
     error = function(e) {
-      cli_abort(
-        "Could not create linter with {.fun {package}::{linter_name}}.",
+      cli_warn(
+        "Could not create linter with {.fun {package}::{linter_name}}. Returning a null linter.",
         parent = e
       )
+      Linter(function(.) list())
     }
   )
   # Otherwise, all linters would be called "linter_factory".

--- a/tests/testthat/test-cyclocomp_linter.R
+++ b/tests/testthat/test-cyclocomp_linter.R
@@ -69,6 +69,5 @@ test_that("a null linter is returned, with warning, if cyclocomp is unavailable"
     linter <- cyclocomp_linter(1L)
   })
 
-  # linted above
-  expect_no_lint("if (TRUE) 1 else 2", linter)
+  expect_error(lint(text = "if (TRUE) 1 else 2"), linters = linter), "disabled", fixed = TRUE)
 })

--- a/tests/testthat/test-cyclocomp_linter.R
+++ b/tests/testthat/test-cyclocomp_linter.R
@@ -69,5 +69,5 @@ test_that("a null linter is returned, with warning, if cyclocomp is unavailable"
     linter <- cyclocomp_linter(1L)
   })
 
-  expect_error(lint(text = "if (TRUE) 1 else 2"), linters = linter), "disabled", fixed = TRUE)
+  expect_error(lint(text = "if (TRUE) 1 else 2", linters = linter), "disabled", fixed = TRUE)
 })

--- a/tests/testthat/test-cyclocomp_linter.R
+++ b/tests/testthat/test-cyclocomp_linter.R
@@ -59,3 +59,16 @@ test_that("returns the correct linting", {
     cyclocomp_linter(5L)
   )
 })
+
+test_that("a null linter is returned, with warning, if cyclocomp is unavailable", {
+  # simple requireNamspace->FALSE won't work since expect_no_lint checks for testthat
+  local_mocked_bindings(
+    requireNamespace = function(pkg, ...) pkg != "cyclocomp" && base::requireNamespace(pkg, ...)
+  )
+  expect_warning(regexp = "Please install", fixed = TRUE, {
+    linter <- cyclocomp_linter(1L)
+  })
+
+  # linted above
+  expect_no_lint("if (TRUE) 1 else 2", linter)
+})

--- a/tests/testthat/test-get_source_expressions.R
+++ b/tests/testthat/test-get_source_expressions.R
@@ -104,6 +104,7 @@ test_that("Multi-byte character truncated by parser is ignored", {
 })
 
 test_that("Can read non UTF-8 file", {
+  withr::local_options(lintr.linter_file = tempfile())
   file <- test_path("dummy_projects", "project", "cp1252.R")
   lintr:::read_settings(file)
   expect_null(get_source_expressions(file)$error)

--- a/tests/testthat/test-linter_tags.R
+++ b/tests/testthat/test-linter_tags.R
@@ -53,6 +53,8 @@ test_that("default_linters and default tag match up", {
 })
 
 test_that("warnings occur only for deprecated linters", {
+  skip_if_not_installed("cyclocomp") # actually we expect a warning there
+
   expect_silent(linters_with_tags(tags = NULL))
   num_deprecated_linters <- nrow(available_linters(tags = "deprecated", exclude_tags = NULL))
   deprecation_warns_seen <- 0L

--- a/tests/testthat/test-settings.R
+++ b/tests/testthat/test-settings.R
@@ -110,6 +110,8 @@ test_that("linters_with_defaults doesn't break on very long input", {
 })
 
 test_that("it has a smart default for encodings", {
+  withr::local_options(list(lintr.linter_file = tempfile()))
+
   lintr:::read_settings(NULL)
   expect_identical(settings$encoding, "UTF-8")
 

--- a/tests/testthat/test-use_lintr.R
+++ b/tests/testthat/test-use_lintr.R
@@ -32,6 +32,7 @@ test_that("use_lintr with type = full also works", {
     file.path(normalize_path(tmp), ".lintr")
   )
 
+  skip_if_not_installed("cyclocomp") # avoid warning
   lints <- lint_dir(tmp)
   expect_length(lints, 0L)
 })

--- a/tests/testthat/test-with.R
+++ b/tests/testthat/test-with.R
@@ -64,6 +64,8 @@ test_that("all default linters are tagged default", {
 })
 
 test_that("can instantiate all linters without arguments", {
+  skip_if_not_installed("cyclocomp") # avoid warning
+
   all_linters <- linters_with_tags(tags = NULL)
 
   expect_type(all_linters, "list")
@@ -100,6 +102,8 @@ test_that("linters_with_defaults(default = .) is supported with a deprecation wa
 })
 
 test_that("all_linters contains all available linters", {
+  skip_if_not_installed("cyclocomp") # avoid warning
+
   all_linters <- all_linters(packages = "lintr")
 
   expect_identical(linters_with_tags(NULL, packages = "lintr"), all_linters)
@@ -107,6 +111,8 @@ test_that("all_linters contains all available linters", {
 })
 
 test_that("all_linters respects ellipsis argument", {
+  skip_if_not_installed("cyclocomp") # avoid warning
+
   expect_identical(
     linters_with_tags(tags = NULL, implicit_integer_linter = NULL),
     all_linters(packages = "lintr", implicit_integer_linter = NULL)


### PR DESCRIPTION
Closes #2777

Two notable changes accompany this:

 - Rather than _error_ up-front if {cyclocomp} is unavailable, we _warn_ & return a "dumb" linter that just always & immediately finds no lints.
 - `linters_with_tags()` (_via_ `call_linter_factory()`) _warns_ instead of _errors_ when a linter fails to build. Again we return the "dumb" linter in this case. This is not strictly needed thanks to only warning from the factory, but I think it's a better design anyway.

Mostly in tests I've opted anyway for `skip()`s, rather than an awkward construct where we optionally `expect_warning()`, or swap between `expect_warning()`/`expect_no_warning()`, or ...

This exercise also flushed out some more tests that are implicitly reading our main project .lintr file, fixing which increases their hermeticity. 