### PR TITLE
add a test of available_linters(packages=)

### DIFF
--- a/R/lintr-package.R
+++ b/R/lintr-package.R
@@ -23,6 +23,7 @@ NULL
 # ref: https://testthat.r-lib.org/dev/reference/local_mocked_bindings.html#base-functions
 # nolint start: object_name_linter. These will be copied from base style.
 requireNamespace <- NULL
+system.file <- NULL
 unlink <- NULL
 quit <- NULL
 # nolint end: object_name_linter.

--- a/tests/testthat/test-linter_tags.R
+++ b/tests/testthat/test-linter_tags.R
@@ -263,9 +263,9 @@ test_that("other packages' linters can be included", {
   )
 
   # edge case
-  write_csv(custom_db[0, c("linter", "tags")], file.path(custom_loc, "linters.csv"))
+  write_csv(custom_db[0L, c("linter", "tags")], file.path(custom_loc, "linters.csv"))
   expect_identical(
     available_linters(packages = "myPkg"),
-    custom_db[0, ]
+    custom_db[0L, ]
   )
 })

--- a/tests/testthat/test-linter_tags.R
+++ b/tests/testthat/test-linter_tags.R
@@ -248,19 +248,24 @@ test_that("other packages' linters can be included", {
   custom_db$tags <- strsplit(custom_db$tags, " ", fixed = TRUE)
   custom_loc <- file.path(db_loc, "myPkg", "lintr")
   dir.create(custom_loc, recursive = TRUE)
-  write.csv(
+  write_csv <- function(x, file) write.csv(x, file, row.names = FALSE, quote = FALSE)
+  write_csv(
     within(custom_db, {
       tags <- vapply(tags, paste, collapse = " ", FUN.VALUE = character(1L))
       rm(package)
     }),
-    file.path(custom_loc, "linters.csv"),
-    row.names = FALSE,
-    quote = FALSE
+    file.path(custom_loc, "linters.csv")
   )
-
 
   expect_identical(
     available_linters(packages = "myPkg"),
     custom_db
+  )
+
+  # edge case
+  write_csv(custom_db[0, c("linter", "tags")], file.path(custom_loc, "linters.csv"))
+  expect_identical(
+    available_linters(packages = "myPkg"),
+    custom_db[0, ]
   )
 })

--- a/tests/testthat/test-linter_tags.R
+++ b/tests/testthat/test-linter_tags.R
@@ -246,7 +246,6 @@ test_that("other packages' linters can be included", {
     tags = c("tag1 tag2", "tag1 tag3")
   )
   custom_db$tags <- strsplit(custom_db$tags, " ", fixed = TRUE)
-      
   custom_loc <- file.path(db_loc, "myPkg", "lintr")
   dir.create(custom_loc, recursive = TRUE)
   write.csv(


### PR DESCRIPTION
Closes #933.

I wrote a few different approaches for constructing the difference between the csv on disk & the expected output, nothing seemed particularly clean, but feel free to chime in if you've got a preference. Fundamentally it's challenging that `write.csv()`/`read.csv()` don't support list columns, hence a need to massage a bit.