### PR TITLE
Include =-assigned generics when checking object name/length

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -35,6 +35,7 @@
 * `implicit_integer_linter(allow_colon = TRUE)` is OK with negative literals, e.g. `-1:1` or `1:-1` (#2673, @MichaelChirico).
 * `missing_argument_linter()` allows empty calls like `foo()` even if there are comments between `(` and `)` (#2741, @MichaelChirico).
 * `return_linter()` works on functions that happen to use braced expressions in their formals (#2616, @MichaelChirico).
+* `object_name_linter()` and `object_length_linter()` account for S3 class correctly when the generic is assigned with `=` (#2507, @MichaelChirico).
 
 ## Notes
 

--- a/R/declared_functions.R
+++ b/R/declared_functions.R
@@ -1,19 +1,16 @@
 declared_s3_generics <- function(x) {
-  xpath <- paste0(
-    # Top level expression which
-    "/exprlist/expr",
+  # Top level expression which assigns to a symbol
+  #   and is an S3 Generic (contains call to UseMethod)
+  # Retrieve assigned name of the function
+  xpath <- "/exprlist
+    /*[
+      (LEFT_ASSIGN or EQ_ASSIGN)
+      and expr[FUNCTION or OP-LAMBDA]
+      and .//SYMBOL_FUNCTION_CALL[text() = 'UseMethod']
+    ]
+    /expr
+    /SYMBOL
+  "
 
-    # Assigns to a symbol
-    "[./LEFT_ASSIGN|EQ_ASSIGN]",
-    "[./expr[FUNCTION or OP-LAMBDA]]",
-    "[./expr/SYMBOL]",
-
-    # Is a S3 Generic (contains call to UseMethod)
-    "[.//SYMBOL_FUNCTION_CALL[text()='UseMethod']]",
-
-    # Retrieve assigned name of the function
-    "/expr/SYMBOL/text()"
-  )
-
-  as.character(xml_find_all(x, xpath))
+  xml_text(xml_find_all(x, xpath))
 }

--- a/tests/testthat/test-object_name_linter.R
+++ b/tests/testthat/test-object_name_linter.R
@@ -309,3 +309,21 @@ test_that("literals in assign() and setGeneric() are checked", {
   expect_lint("assign(envir = 'good_env_name', 'badName', 2)", lint_msg, linter)
   expect_lint("assign(envir = 'good_env_name', x = 'badName', 2)", lint_msg, linter)
 })
+
+test_that("generics assigned with '=' or <<- are registered", {
+  linter <- object_name_linter()
+
+  expect_no_lint(
+    trim_some("
+      f = function(x) {
+        UseMethod('f')
+      }
+      g <<- function(x) {
+        UseMethod('f')
+      }
+      f.default <- function(x) {}
+      g.default <- function(x) {}
+    "),
+    linter
+  )
+})


### PR DESCRIPTION
Closes #2507.

Ignoring `->`-assigned generics because it's very awkward to write them:

```r
(function(x) UseMethod('foo')) -> foo
```