### PR TITLE
New meta test about defunct linters

### DIFF
--- a/.dev/defunct_linters_test.R
+++ b/.dev/defunct_linters_test.R
@@ -1,0 +1,13 @@
+defunct_linters <- subset(
+  read.csv("inst/lintr/linters.csv"),
+  grepl("\\bdefunct\\b", tags),
+  "linter"
+)
+
+pkgload::load_all()
+found_idx <- defunct_linters %in% getNamespaceExports("lintr")
+if (!all(found_idx)) {
+  stop(
+    "Missing 'defunct'-tagged linters: ", toString(defunct_linters[!found_idx]), "."
+  )
+}

--- a/.dev/defunct_linters_test.R
+++ b/.dev/defunct_linters_test.R
@@ -1,7 +1,8 @@
 defunct_linters <- subset(
   read.csv("inst/lintr/linters.csv"),
   grepl("\\bdefunct\\b", tags),
-  "linter"
+  "linter",
+  drop = TRUE
 )
 
 pkgload::load_all()

--- a/.github/workflows/repo-meta-tests.yaml
+++ b/.github/workflows/repo-meta-tests.yaml
@@ -36,3 +36,8 @@ jobs:
         run: |
           callr::rscript(".dev/roxygen_test.R")
         shell: Rscript {0}
+
+      - name: Ensure defunct linters exist
+        run: |
+          callr::rscript(".dev/defunct_linters_test.R")
+        shell: Rscript {0}


### PR DESCRIPTION
Closes #2734.

Pretty simple. I think maybe eventually we'll move the tests about "tags in linters.csv match man/*" here too. But this is enough for now.