### PR TITLE
Rework ?pipe_return_linter to avoid roxygen issue

### DIFF
--- a/R/pipe_return_linter.R
+++ b/R/pipe_return_linter.R
@@ -1,10 +1,19 @@
 #' Block usage of return() in magrittr pipelines
 #'
 #' [return()] inside a magrittr pipeline does not actually execute `return()`
-#'   like you'd expect: `\(x) { x %>% return(); FALSE }` will return `FALSE`!
-#'   It will technically work "as expected" if this is the final statement
-#'   in the function body, but such usage is misleading. Instead, assign
-#'   the pipe outcome to a variable and return that.
+#'   like you'd expect:
+#'
+#'   ```r
+#'   bad_usage <- function(x) {
+#'     x %>%
+#'       return()
+#'     FALSE
+#'   }
+#'   ```
+#'
+#'   `bad_usage(TRUE)` will return `FALSE`! It will technically work "as expected"
+#'   if this is the final statement in the function body, but such usage is misleading.
+#'   Instead, assign the pipe outcome to a variable and return that.
 #'
 #' @examples
 #' # will produce lints

--- a/man/pipe_return_linter.Rd
+++ b/man/pipe_return_linter.Rd
@@ -8,10 +8,19 @@ pipe_return_linter()
 }
 \description{
 \code{\link[=return]{return()}} inside a magrittr pipeline does not actually execute \code{return()}
-like you'd expect: \verb{\\(x) \{ x \%>\% return(); FALSE \}} will return \code{FALSE}!
-It will technically work "as expected" if this is the final statement
-in the function body, but such usage is misleading. Instead, assign
-the pipe outcome to a variable and return that.
+like you'd expect:
+}
+\details{
+\if{html}{\out{<div class="sourceCode r">}}\preformatted{bad_usage <- function(x) \{
+  x \%>\%
+    return()
+  FALSE
+\}
+}\if{html}{\out{</div>}}
+
+\code{bad_usage(TRUE)} will return \code{FALSE}! It will technically work "as expected"
+if this is the final statement in the function body, but such usage is misleading.
+Instead, assign the pipe outcome to a variable and return that.
 }
 \examples{
 # will produce lints


### PR DESCRIPTION
Not sure why this is uncaught till now, AFAICT this has been warning since >2 years ago (?)

https://github.com/r-lib/roxygen2/issues/1492#issuecomment-2701698220

Still the update is an improvement, I think.