### PR TITLE
Add a fifth fuzzer for '='/'<-' equivalency

### DIFF
--- a/.dev/maybe_fuzz_content.R
+++ b/.dev/maybe_fuzz_content.R
@@ -9,7 +9,13 @@ maybe_fuzz_content <- function(file, lines) {
     file.copy(file, new_file, copy.mode = FALSE)
   }
 
-  apply_fuzzers(new_file, list(function_lambda_fuzzer, pipe_fuzzer, dollar_at_fuzzer, comment_injection_fuzzer))
+  apply_fuzzers(new_file, fuzzers = list(
+    function_lambda_fuzzer,
+    pipe_fuzzer,
+    dollar_at_fuzzer,
+    comment_injection_fuzzer,
+    assignment_fuzzer
+  ))
 
   new_file
 }
@@ -57,6 +63,11 @@ pipe_fuzzer <- simple_swap_fuzzer(
 dollar_at_fuzzer <- simple_swap_fuzzer(
   \(pd) pd$token %in% c("'$'", "'@'"),
   replacements = c("$", "@")
+)
+
+assignment_fuzzer <- simple_swap_fuzzer(
+  \(pd) (pd$token == "LEFT_ASSIGN" & pd$text == "<-") | pd$token == "EQ_ASSIGN",
+  replacements = c("<-", "=")
 )
 
 comment_injection_fuzzer <- function(pd, lines) {

--- a/NEWS.md
+++ b/NEWS.md
@@ -16,6 +16,7 @@
 
 * `Lint()`, and thus all linters, ensures that the returned object's `message` attribute is consistently a simple character string (and not, for example, an object of class `"glue"`; #2740, @MichaelChirico).
 * Files with encoding inferred from settings read more robustly under `lint(parse_settings = TRUE)` (#2803, @MichaelChirico).
+* `repeat_linter()` no longer errors when `while` is in a column right of `}` (#2828, @MichaelChirico).
 
 ## New and improved features
 

--- a/R/object_overwrite_linter.R
+++ b/R/object_overwrite_linter.R
@@ -75,9 +75,10 @@ object_overwrite_linter <- function(
 
   # test that the symbol doesn't match an argument name in the function
   # NB: data.table := has parse token LEFT_ASSIGN as well
+  # ancestor::* for '=' assignment
   xpath_assignments <- glue("
     (//SYMBOL | //STR_CONST)[
-      not(text() = ancestor::expr/preceding-sibling::SYMBOL_FORMALS/text())
+      not(text() = ancestor::*/preceding-sibling::SYMBOL_FORMALS/text())
     ]/
       parent::expr[
         count(*) = 1

--- a/R/package_hooks_linter.R
+++ b/R/package_hooks_linter.R
@@ -84,7 +84,8 @@ package_hooks_linter <- function() {
   #   exiting early if not.
   any_hook_xpath <- glue("(//FUNCTION | //OP-LAMBDA)/parent::expr/preceding-sibling::expr/SYMBOL[{ns_calls}]")
 
-  hook_xpath <- sprintf("string(./ancestor::expr/expr/SYMBOL[%s])", ns_calls)
+  # * for '=' assignment
+  hook_xpath <- sprintf("string(./ancestor::*/expr/SYMBOL[%s])", ns_calls)
 
   load_arg_name_xpath <- "
   (//FUNCTION | //OP-LAMBDA)

--- a/R/repeat_linter.R
+++ b/R/repeat_linter.R
@@ -20,7 +20,7 @@
 #' @seealso [linters] for a complete list of linters available in lintr.
 #' @export
 repeat_linter <- function() {
-  xpath <- "//WHILE[following-sibling::expr[1]/NUM_CONST[text() = 'TRUE']]"
+  xpath <- "//WHILE[following-sibling::expr[1]/NUM_CONST[text() = 'TRUE']]/parent::expr"
 
   Linter(linter_level = "expression", function(source_expression) {
     xml <- source_expression$xml_parsed_content
@@ -30,9 +30,7 @@ repeat_linter <- function() {
     xml_nodes_to_lints(
       lints,
       source_expression = source_expression,
-      lint_message = "Use 'repeat' instead of 'while (TRUE)' for infinite loops.",
-      range_start_xpath = "number(./@col1)",
-      range_end_xpath = "number(./following-sibling::*[3]/@col2)"
+      lint_message = "Use 'repeat' instead of 'while (TRUE)' for infinite loops."
     )
   })
 }

--- a/R/unnecessary_nesting_linter.R
+++ b/R/unnecessary_nesting_linter.R
@@ -241,7 +241,10 @@ unnecessary_nesting_linter <- function(
   # "un-walk" from the unnecessary IF to the IF with which it should be combined
   corresponding_if_xpath <- "preceding-sibling::IF | parent::expr/preceding-sibling::IF"
 
-  unnecessary_else_brace_xpath <- "//IF/parent::expr[parent::expr[preceding-sibling::ELSE and count(expr) = 1]]"
+  unnecessary_else_brace_xpath <- "
+  //IF/parent::expr[parent::expr[
+    preceding-sibling::ELSE and count(*) - count(COMMENT) - count(OP-LEFT-BRACE) - count(OP-RIGHT-BRACE) = 1
+  ]]"
 
   Linter(linter_level = "expression", function(source_expression) {
     xml <- source_expression$xml_parsed_content

--- a/R/unnecessary_nesting_linter.R
+++ b/R/unnecessary_nesting_linter.R
@@ -203,7 +203,7 @@ unnecessary_nesting_linter <- function(
   unnecessary_brace_xpath <- glue("
   //OP-LEFT-BRACE
     /parent::expr[
-      count(expr) = 1
+      count(*) - count(COMMENT) - count(OP-LEFT-BRACE) - count(OP-RIGHT-BRACE) = 1
       and not(preceding-sibling::*[
         self::FUNCTION
         or self::OP-LAMBDA

--- a/R/unnecessary_nesting_linter.R
+++ b/R/unnecessary_nesting_linter.R
@@ -183,7 +183,7 @@ unnecessary_nesting_linter <- function(
 
   used_exit_call_xpath <- glue("expr/expr[position() = last()]/{exit_call_expr}")
 
-  assignment_cond <- if (allow_assignment) "expr[LEFT_ASSIGN or RIGHT_ASSIGN]" else "false"
+  assignment_cond <- if (allow_assignment) "*[LEFT_ASSIGN or RIGHT_ASSIGN or EQ_ASSIGN]" else "false"
 
   # several carve-outs of common cases where single-expression braces are OK
   #   - control flow statements: if, for, while, repeat

--- a/tests/testthat/test-assignment_linter.R
+++ b/tests/testthat/test-assignment_linter.R
@@ -1,3 +1,4 @@
+# nofuzz start
 test_that("assignment_linter skips allowed usages", {
   linter <- assignment_linter()
 
@@ -66,7 +67,7 @@ test_that("arguments handle <<- and ->/->> correctly", {
   )
 })
 
-test_that("arguments handle trailing assignment operators correctly", { # nofuzz
+test_that("arguments handle trailing assignment operators correctly", {
   linter_default <- assignment_linter()
   linter_no_trailing <- assignment_linter(allow_trailing = FALSE)
   expect_no_lint("x <- y", linter_no_trailing)
@@ -165,7 +166,7 @@ test_that("arguments handle trailing assignment operators correctly", { # nofuzz
   )
 })
 
-test_that("allow_trailing interacts correctly with comments in braced expressions", { # nofuzz
+test_that("allow_trailing interacts correctly with comments in braced expressions", {
   linter <- assignment_linter(allow_trailing = FALSE)
   expect_no_lint(
     trim_some("
@@ -390,3 +391,4 @@ test_that("implicit '<-' assignments inside calls are ignored where top-level '<
   expect_no_lint("for (i in foo(idx <- is.na(y))) which(idx)", linter)
   expect_no_lint("for (i in foo(bar(idx <- is.na(y)))) which(idx)", linter)
 })
+# nofuzz end

--- a/tests/testthat/test-cache.R
+++ b/tests/testthat/test-cache.R
@@ -420,7 +420,7 @@ test_that("lint with cache uses the provided relative cache directory", { # nofu
   expect_true(dir.exists(path))
 })
 
-test_that("it works outside of a package", {
+test_that("it works outside of a package", { # nofuzz
   linter <- assignment_linter()
 
   local_mocked_bindings(find_package = function(...) NULL)

--- a/tests/testthat/test-cache.R
+++ b/tests/testthat/test-cache.R
@@ -406,7 +406,7 @@ test_that("find_new_line returns the correct line if it is after the current lin
 
 #
 
-test_that("lint with cache uses the provided relative cache directory", {
+test_that("lint with cache uses the provided relative cache directory", { # nofuzz
   path <- withr::local_tempdir("my_cache_dir")
   linter <- assignment_linter()
 

--- a/tests/testthat/test-coalesce_linter.R
+++ b/tests/testthat/test-coalesce_linter.R
@@ -63,7 +63,7 @@ test_that("coalesce_linter blocks usage with implicit assignment", { # nofuzz
   expect_lint("if (!is.null(s <- foo(x))) { s } else { y }", lint_msg_not, linter)
 })
 
-test_that("lints vectorize", {
+test_that("lints vectorize", { # nofuzz
   expect_lint(
     trim_some("{
       if (is.null(x)) y else x

--- a/tests/testthat/test-coalesce_linter.R
+++ b/tests/testthat/test-coalesce_linter.R
@@ -47,7 +47,7 @@ test_that("coalesce_linter blocks simple disallowed usage", {
   )
 })
 
-test_that("coalesce_linter blocks usage with implicit assignment", {
+test_that("coalesce_linter blocks usage with implicit assignment", { # nofuzz
   linter <- coalesce_linter()
   lint_msg <- rex::rex("Use x %||% y instead of if (is.null(x))")
   lint_msg_not <- rex::rex("Use x %||% y instead of if (!is.null(x))")

--- a/tests/testthat/test-exclusions.R
+++ b/tests/testthat/test-exclusions.R
@@ -56,7 +56,7 @@ test_that("it gives the expected error message when there is mismatch between mu
   )
 })
 
-test_that("partial matching works for exclusions but warns if no linter found", {
+test_that("partial matching works for exclusions but warns if no linter found", { # nofuzz
   lintr:::read_settings(NULL)
 
   expect_warning(
@@ -153,7 +153,7 @@ test_that("#1442: is_excluded_files works if no global exclusions are specified"
   expect_length(lint_dir(tmp), 3L)
 })
 
-test_that("next-line exclusion works", {
+test_that("next-line exclusion works", { # nofuzz
   withr::local_options(
     lintr.exclude = "# NL",
     lintr.exclude_next = "# NLN",

--- a/tests/testthat/test-expect_lint.R
+++ b/tests/testthat/test-expect_lint.R
@@ -2,6 +2,7 @@
 # thus less than ideal to test expect_lint(), which can process multiple lints. If you want to test
 # for failure, always put the lint check or lint field that must fail first.
 
+# nofuzz start
 linter <- assignment_linter()
 lint_msg <- "Use one of <-, <<- for assignment, not ="
 
@@ -84,3 +85,4 @@ test_that("execution without testthat gives the right errors", {
   expect_error(expect_no_lint(), lint_msg("expect_no_lint"))
   expect_error(expect_lint_free(), lint_msg("expect_lint_free"))
 })
+# nofuzz end

--- a/tests/testthat/test-function_return_linter.R
+++ b/tests/testthat/test-function_return_linter.R
@@ -1,3 +1,4 @@
+# nofuzz start
 test_that("function_return_linter skips allowed usages", {
   lines_simple <- trim_some("
     foo <- function(x) {
@@ -96,3 +97,4 @@ test_that("lints vectorize", {
     function_return_linter()
   )
 })
+# nofuzz end

--- a/tests/testthat/test-implicit_assignment_linter.R
+++ b/tests/testthat/test-implicit_assignment_linter.R
@@ -1,3 +1,4 @@
+# nofuzz start
 test_that("implicit_assignment_linter skips allowed usages", {
   linter <- implicit_assignment_linter()
 
@@ -503,3 +504,4 @@ test_that("call-less '(' mentions avoiding implicit printing", {
     linter
   )
 })
+# nofuzz end

--- a/tests/testthat/test-lint.R
+++ b/tests/testthat/test-lint.R
@@ -104,7 +104,7 @@ test_that("lint() results do not depend on the position of the .lintr", {
   )
 })
 
-test_that("lint uses linter names", {
+test_that("lint uses linter names", { # nofuzz
   expect_lint(
     "a = 2",
     list(linter = "bla"),

--- a/tests/testthat/test-make_linter_from_regex.R
+++ b/tests/testthat/test-make_linter_from_regex.R
@@ -1,4 +1,4 @@
-test_that("test make_linter_from_regex works", {
+test_that("make_linter_from_regex works", { # nofuzz
   linter <- lintr:::make_linter_from_regex("-", "style", "Silly lint.")()
   expect_lint("a <- 2L", "Silly lint.", linter)
   expect_lint("a = '2-3'", NULL, linter)

--- a/tests/testthat/test-object_overwrite_linter.R
+++ b/tests/testthat/test-object_overwrite_linter.R
@@ -99,9 +99,11 @@ test_that("object_overwrite_linter skips any name assigned at the top level", {
 })
 
 test_that("object_overwrite_linter skips argument names", {
+  
   linter <- object_overwrite_linter()
 
   expect_lint("foo <- function(data) data <- data + 1", NULL, linter)
+  expect_lint("foo <- function(data) data = data + 1", NULL, linter)
 
   expect_lint(
     trim_some("

--- a/tests/testthat/test-package_hooks_linter.R
+++ b/tests/testthat/test-package_hooks_linter.R
@@ -111,7 +111,9 @@ test_that("package_hooks_linter blocks invalid .onLoad() / .onAttach() arguments
   # NB: QC.R allows ... arguments to be passed, but disallow this flexibility in the linter.
   expect_lint(".onLoad <- function() { }", onload_msg, linter)
   expect_lint(".onLoad <- function(lib) { }", onload_msg, linter)
+  expect_lint(".onLoad = function(lib) { }", onload_msg, linter)
   expect_lint(".onLoad <- function(lib, pkg, third) { }", onload_msg, linter)
+  expect_lint(".onLoad = function(lib, pkg, third) { }", onload_msg, linter)
   expect_lint(".onLoad <- function(lib, ...) { }", onload_msg, linter)
 })
 
@@ -149,6 +151,11 @@ test_that("package_hooks_linter blocks attaching namespaces", {
   )
   expect_lint(
     ".onLoad <- function(lib, pkg) { d(e(f(library(foo)))) }",
+    rex::rex("Don't alter the search() path in .onLoad() by calling library()."),
+    linter
+  )
+  expect_lint(
+    ".onLoad = function(lib, pkg) { d(e(f(library(foo)))) }",
     rex::rex("Don't alter the search() path in .onLoad() by calling library()."),
     linter
   )
@@ -208,6 +215,13 @@ test_that("package_hooks_linter detects bad argument names in .onDetach()/.Last.
 
   expect_lint(
     ".onDetach <- function(xxx) { }",
+    rex::rex(".onDetach()", lint_msg_part),
+    linter
+  )
+
+  # assignment operator doesn't matter
+  expect_lint(
+    ".onDetach = function(xxx) { }",
     rex::rex(".onDetach()", lint_msg_part),
     linter
   )

--- a/tests/testthat/test-repeat_linter.R
+++ b/tests/testthat/test-repeat_linter.R
@@ -1,4 +1,4 @@
-test_that("test repeat_linter", {
+test_that("repeat_linter works as expected", {
   linter <- repeat_linter()
   msg <- rex::rex("Use 'repeat' instead of 'while (TRUE)' for infinite loops.")
 
@@ -19,9 +19,19 @@ test_that("test repeat_linter", {
       }
     }"),
     list(
-      list(message = msg, line_number = 2L, column_number = 3L, ranges = list(c(3L, 14L))),
-      list(message = msg, line_number = 4L, column_number = 3L, ranges = list(c(3L, 14L)))
+      list(msg, line_number = 2L, column_number = 3L, ranges = list(c(3L, 16L))),
+      list(msg, line_number = 4L, column_number = 3L, ranges = list(c(3L, 16L)))
     ),
+    linter
+  )
+
+  # fix for bad logic about range start/end
+  expect_lint(
+    trim_some("
+                 while
+      (TRUE) { }
+    "),
+    msg,
     linter
   )
 })

--- a/tests/testthat/test-semicolon_linter.R
+++ b/tests/testthat/test-semicolon_linter.R
@@ -1,3 +1,4 @@
+# nofuzz start
 test_that("semicolon_linter skips allowed usages", {
   linter <- semicolon_linter()
 
@@ -41,7 +42,7 @@ test_that("semicolon_linter handles trailing semicolons", {
   )
 })
 
-test_that("semicolon_linter handles compound semicolons", { # nofuzz
+test_that("semicolon_linter handles compound semicolons", {
   linter <- semicolon_linter()
   lint_msg <- rex::rex("Replace compound semicolons by a newline.")
 
@@ -75,7 +76,7 @@ test_that("semicolon_linter handles compound semicolons", { # nofuzz
   )
 })
 
-test_that("semicolon_linter handles multiple/mixed semicolons", { # nofuzz
+test_that("semicolon_linter handles multiple/mixed semicolons", {
   linter <- semicolon_linter()
   trail_msg <- rex::rex("Remove trailing semicolons.")
   comp_msg <- rex::rex("Replace compound semicolons by a newline.")
@@ -107,7 +108,7 @@ test_that("semicolon_linter handles multiple/mixed semicolons", { # nofuzz
 })
 
 
-test_that("Compound semicolons only", { # nofuzz
+test_that("Compound semicolons only", {
   linter <- semicolon_linter(allow_trailing = TRUE)
   expect_no_lint("a <- 1;", linter)
   expect_no_lint("function(){a <- 1;}", linter)
@@ -144,10 +145,11 @@ test_that("Trailing semicolons only", {
 })
 
 
-test_that("Compound semicolons only", { # nofuzz
+test_that("Compound semicolons only", {
   expect_error(
     semicolon_linter(allow_trailing = TRUE, allow_compound = TRUE),
     "At least one of `allow_compound` or `allow_trailing` must be `FALSE`",
     fixed = TRUE
   )
 })
+# nofuzz end

--- a/tests/testthat/test-undesirable_operator_linter.R
+++ b/tests/testthat/test-undesirable_operator_linter.R
@@ -19,7 +19,7 @@ test_that("linter returns correct linting", {
   expect_no_lint("`%%`(10, 2)", linter)
 })
 
-test_that("undesirable_operator_linter handles '=' consistently", {
+test_that("undesirable_operator_linter handles '=' consistently", { # nofuzz
   linter <- undesirable_operator_linter(op = c("=" = "As an alternative, use '<-'"))
 
   expect_lint("a = 2L", rex::rex("Avoid undesirable operator `=`."), linter)

--- a/tests/testthat/test-unnecessary_nesting_linter.R
+++ b/tests/testthat/test-unnecessary_nesting_linter.R
@@ -68,6 +68,8 @@ test_that("non-terminal expressions are not considered for the logic", {
 })
 
 test_that("parallels in further nesting are skipped", {
+  linter <- unnecessary_nesting_linter()
+
   expect_no_lint(
     trim_some("
       if (length(bucket) > 1) {
@@ -81,7 +83,24 @@ test_that("parallels in further nesting are skipped", {
         }
       }
     "),
-    unnecessary_nesting_linter()
+    linter
+  )
+
+  # same but with '='
+  expect_no_lint(
+    trim_some("
+      if (length(bucket) > 1) {
+        return(age)
+      } else {
+        age = age / 2
+        if (grepl('[0-9]', age)) {
+          return(age)
+        } else {
+          return('unknown')
+        }
+      }
+    "),
+    linter
   )
 })
 

--- a/tests/testthat/test-unnecessary_nesting_linter.R
+++ b/tests/testthat/test-unnecessary_nesting_linter.R
@@ -283,6 +283,7 @@ test_that("unnecessary_nesting_linter passes for multi-line braced expressions",
 })
 
 test_that("unnecessary_nesting_linter skips if unbracing won't reduce nesting", {
+  
   linter <- unnecessary_nesting_linter()
 
   expect_no_lint(
@@ -326,6 +327,20 @@ test_that("unnecessary_nesting_linter skips if unbracing won't reduce nesting", 
         n <- .N - 1
         x[n] < y[n]
       }, j = TRUE, by = x]
+    "),
+    linter
+  )
+
+  # interaction of '=' assignment and 'loose' braces (?)
+  expect_no_lint(
+    trim_some("
+      DT[
+        {
+          n = .N - 1
+          x[n] < y[n]
+        }
+        , j = TRUE, by = x
+      ]
     "),
     linter
   )

--- a/tests/testthat/test-unnecessary_nesting_linter.R
+++ b/tests/testthat/test-unnecessary_nesting_linter.R
@@ -311,7 +311,7 @@ test_that("unnecessary_nesting_linter passes for multi-line braced expressions",
   )
 })
 
-test_that("unnecessary_nesting_linter skips if unbracing won't reduce nesting", {
+test_that("unnecessary_nesting_linter skips if unbracing won't reduce nesting", { # nofuzz
   
   linter <- unnecessary_nesting_linter()
 

--- a/tests/testthat/test-unnecessary_nesting_linter.R
+++ b/tests/testthat/test-unnecessary_nesting_linter.R
@@ -257,13 +257,23 @@ test_that("unnecessary_nesting_linter skips one-expression repeat loops", {
 })
 
 test_that("unnecessary_nesting_linter skips one-expression assignments by default", {
+  linter <- unnecessary_nesting_linter()
+
   expect_no_lint(
     trim_some("
       {
         x <- foo()
       }
     "),
-    unnecessary_nesting_linter()
+    linter
+  )
+  expect_no_lint(
+    trim_some("
+      {
+        x = foo()
+      }
+    "),
+    linter
   )
 })
 

--- a/tests/testthat/test-unreachable_code_linter.R
+++ b/tests/testthat/test-unreachable_code_linter.R
@@ -450,7 +450,7 @@ test_that("unreachable_code_linter ignores terminal nolint end comments", {
     lintr.exclude_end = "#\\s*TestNoLintEnd"
   ))
 
-  expect_no_lint(
+  expect_no_lint( # nofuzz
     trim_some("
       foo <- function() {
         do_something


### PR DESCRIPTION
Closes #2191 -- these are the 5 simple consistency checks I came up with.

Closes #2828 too.

`<-` in implicit assignments is a known issue generating some false positives --> `nofuzz`. Also `assignment_linter()` is used in a lot of places as a "generic simple" linter, those need `nofuzz too`.