### PR TITLE
Improve the nofuzz system to allow specific exclusions

### DIFF
--- a/.dev/ast_fuzz_test.R
+++ b/.dev/ast_fuzz_test.R
@@ -177,5 +177,3 @@ if (length(invalid_failures) > 0L) {
   print(invalid_failures)
   stop("Fix any bugs, or use '# nofuzz'/'# fuzzer [dis|en]able' to mark false positives.")
 }
-
-browser()

--- a/.dev/ast_fuzz_test.R
+++ b/.dev/ast_fuzz_test.R
@@ -92,7 +92,7 @@ for (test_file in list.files("tests/testthat", pattern = "^test-", full.names = 
       stop("Unable to parse any expression starting from line ", one_line)
     }
     comment_txt <- subset(pd, line1 == one_line & token == "COMMENT", select = "text", drop = TRUE)
-    deactivated <- get_str(comment_text)
+    deactivated <- get_str(comment_txt)
     test_lines <- c(
       head(test_lines, one_line - 1L),
       sprintf("deactivate_fuzzers('%s')", deactivated),
@@ -171,3 +171,5 @@ if (length(invalid_failures) > 0L) {
   print(invalid_failures)
   stop("Fix any bugs, or use '# nofuzz'/'# fuzzer [dis|en]able' to mark false positives.")
 }
+
+browser()

--- a/.dev/ast_fuzz_test.R
+++ b/.dev/ast_fuzz_test.R
@@ -169,5 +169,5 @@ if (length(invalid_failures) > 0L) {
   )
   cat(sprintf("%d fuzzed tests failed unexpectedly!\n", length(invalid_failures)))
   print(invalid_failures)
-  stop("Use # nofuzz [start|end] to mark false positives or fix any bugs.")
+  stop("Fix any bugs, or use '# nofuzz'/'# fuzzer [dis|en]able' to mark false positives.")
 }

--- a/.dev/maybe_fuzz_content.R
+++ b/.dev/maybe_fuzz_content.R
@@ -1,4 +1,11 @@
 maybe_fuzz_content <- function(file, lines) {
+  # some tests (esp. involving encoding) have to be skipped entirely
+  #   since the logic here is not able to copy over relevant configs/settings
+  active_fuzzers <- .fuzzers$active
+  if (length(active_fuzzers) == 0L) {
+    return(file)
+  }
+
   if (is.null(file)) {
     new_file <- tempfile()
     con <- file(new_file, encoding = "UTF-8")
@@ -9,7 +16,7 @@ maybe_fuzz_content <- function(file, lines) {
     file.copy(file, new_file, copy.mode = FALSE)
   }
 
-  apply_fuzzers(new_file, fuzzers = .fuzzers$active)
+  apply_fuzzers(new_file, fuzzers = active_fuzzers)
 
   new_file
 }

--- a/R/keyword_quote_linter.R
+++ b/R/keyword_quote_linter.R
@@ -136,7 +136,7 @@ keyword_quote_linter <- function() {
     )
 
     extraction_expr <- extraction_expr[invalid_extraction_quoting]
-    extractor <- xml_find_chr(extraction_expr, "string(preceding-sibling::*[1])")
+    extractor <- xml_find_chr(extraction_expr, "string(preceding-sibling::*[not(self::COMMENT)][1])")
     gen_extractor <- ifelse(extractor == "$", "[[", "slot()")
 
     extraction_lints <- xml_nodes_to_lints(

--- a/tests/testthat/test-any_duplicated_linter.R
+++ b/tests/testthat/test-any_duplicated_linter.R
@@ -1,4 +1,4 @@
-# nofuzz start
+# fuzzer disable: dollar_at
 test_that("any_duplicated_linter skips allowed usages", {
   linter <- any_duplicated_linter()
 
@@ -81,4 +81,4 @@ test_that("any_duplicated_linter catches expression with two types of lint", {
     linter
   )
 })
-# nofuzz end
+# fuzzer enable: dollar_at

--- a/tests/testthat/test-assignment_linter.R
+++ b/tests/testthat/test-assignment_linter.R
@@ -1,4 +1,4 @@
-# nofuzz start
+# fuzzer disable: assignment
 test_that("assignment_linter skips allowed usages", {
   linter <- assignment_linter()
 
@@ -67,7 +67,7 @@ test_that("arguments handle <<- and ->/->> correctly", {
   )
 })
 
-test_that("arguments handle trailing assignment operators correctly", {
+test_that("arguments handle trailing assignment operators correctly", { # nofuzz: comment_injection
   linter_default <- assignment_linter()
   linter_no_trailing <- assignment_linter(allow_trailing = FALSE)
   expect_no_lint("x <- y", linter_no_trailing)
@@ -391,4 +391,4 @@ test_that("implicit '<-' assignments inside calls are ignored where top-level '<
   expect_no_lint("for (i in foo(idx <- is.na(y))) which(idx)", linter)
   expect_no_lint("for (i in foo(bar(idx <- is.na(y)))) which(idx)", linter)
 })
-# nofuzz end
+# fuzzer enable: assignment

--- a/tests/testthat/test-assignment_linter.R
+++ b/tests/testthat/test-assignment_linter.R
@@ -67,7 +67,8 @@ test_that("arguments handle <<- and ->/->> correctly", {
   )
 })
 
-test_that("arguments handle trailing assignment operators correctly", { # nofuzz: comment_injection
+# fuzzer disable: comment_injection
+test_that("arguments handle trailing assignment operators correctly", {
   linter_default <- assignment_linter()
   linter_no_trailing <- assignment_linter(allow_trailing = FALSE)
   expect_no_lint("x <- y", linter_no_trailing)
@@ -213,6 +214,7 @@ test_that("allow_trailing interacts correctly with comments in braced expression
     linter
   )
 })
+# fuzzer enable: comment_injection
 
 test_that("%<>% throws a lint", {
   expect_lint("x %<>% sum()", "Avoid the assignment pipe %<>%", assignment_linter())

--- a/tests/testthat/test-brace_linter.R
+++ b/tests/testthat/test-brace_linter.R
@@ -1,4 +1,4 @@
-# nofuzz start
+# fuzzer disable: comment_injection
 test_that("brace_linter lints braces correctly", {
   open_curly_msg <- rex::rex(
     "Opening curly braces should never go on their own line"
@@ -634,4 +634,4 @@ test_that("function shorthand is treated like 'full' function", {
     linter
   )
 })
-# nofuzz end
+# fuzzer enable: comment_injection

--- a/tests/testthat/test-cache.R
+++ b/tests/testthat/test-cache.R
@@ -406,7 +406,7 @@ test_that("find_new_line returns the correct line if it is after the current lin
 
 #
 
-test_that("lint with cache uses the provided relative cache directory", { # nofuzz
+test_that("lint with cache uses the provided relative cache directory", { # nofuzz: assignment
   path <- withr::local_tempdir("my_cache_dir")
   linter <- assignment_linter()
 
@@ -420,7 +420,7 @@ test_that("lint with cache uses the provided relative cache directory", { # nofu
   expect_true(dir.exists(path))
 })
 
-test_that("it works outside of a package", { # nofuzz
+test_that("it works outside of a package", { # nofuzz: assignment
   linter <- assignment_linter()
 
   local_mocked_bindings(find_package = function(...) NULL)

--- a/tests/testthat/test-cache.R
+++ b/tests/testthat/test-cache.R
@@ -404,8 +404,6 @@ test_that("find_new_line returns the correct line if it is after the current lin
   expect_identical(lintr:::find_new_line(3L, "foobar3", t1), 3L)
 })
 
-#
-
 test_that("lint with cache uses the provided relative cache directory", { # nofuzz: assignment
   path <- withr::local_tempdir("my_cache_dir")
   linter <- assignment_linter()

--- a/tests/testthat/test-coalesce_linter.R
+++ b/tests/testthat/test-coalesce_linter.R
@@ -47,7 +47,7 @@ test_that("coalesce_linter blocks simple disallowed usage", {
   )
 })
 
-test_that("coalesce_linter blocks usage with implicit assignment", { # nofuzz
+test_that("coalesce_linter blocks usage with implicit assignment", { # nofuzz: assignment
   linter <- coalesce_linter()
   lint_msg <- rex::rex("Use x %||% y instead of if (is.null(x))")
   lint_msg_not <- rex::rex("Use x %||% y instead of if (!is.null(x))")
@@ -63,7 +63,7 @@ test_that("coalesce_linter blocks usage with implicit assignment", { # nofuzz
   expect_lint("if (!is.null(s <- foo(x))) { s } else { y }", lint_msg_not, linter)
 })
 
-test_that("lints vectorize", { # nofuzz
+test_that("lints vectorize", { # nofuzz: assignment
   expect_lint(
     trim_some("{
       if (is.null(x)) y else x

--- a/tests/testthat/test-commas_linter.R
+++ b/tests/testthat/test-commas_linter.R
@@ -1,4 +1,4 @@
-# nofuzz start
+# fuzzer disable: comment_injection
 test_that("returns the correct linting (with default parameters)", {
   linter <- commas_linter()
   msg_after <- rex::rex("Put a space after a comma.")
@@ -114,4 +114,4 @@ test_that("returns the correct linting (with 'allow_trailing' set)", {
     linter
   )
 })
-# nofuzz end
+# fuzzer enable: comment_injection

--- a/tests/testthat/test-exclusions.R
+++ b/tests/testthat/test-exclusions.R
@@ -56,7 +56,7 @@ test_that("it gives the expected error message when there is mismatch between mu
   )
 })
 
-test_that("partial matching works for exclusions but warns if no linter found", { # nofuzz
+test_that("partial matching works for exclusions but warns if no linter found", { # nofuzz: assignment
   lintr:::read_settings(NULL)
 
   expect_warning(
@@ -110,7 +110,7 @@ test_that("#1413: lint_dir properly excludes files", {
   expect_length(lint_dir(tmp), 0L)
 })
 
-test_that("#1442: is_excluded_files works if no global exclusions are specified", {
+test_that("#1442: is_excluded_files works if no global exclusions are specified", { # nofuzz: assignment
   withr::local_options(lintr.linter_file = "lintr_test_config")
   tmp <- withr::local_tempdir()
 
@@ -142,7 +142,7 @@ test_that("#1442: is_excluded_files works if no global exclusions are specified"
   )
 
   # 3 lints: assignment_linter(), quotes_linter() and line_length_linter()
-  expect_lint( # nofuzz
+  expect_lint(
     file = file.path(tmp, "bad.R"),
     checks = list(
       list(linter = "assignment_linter", line_number = 1L),
@@ -153,7 +153,7 @@ test_that("#1442: is_excluded_files works if no global exclusions are specified"
   expect_length(lint_dir(tmp), 3L)
 })
 
-test_that("next-line exclusion works", { # nofuzz
+test_that("next-line exclusion works", { # nofuzz: assignment
   withr::local_options(
     lintr.exclude = "# NL",
     lintr.exclude_next = "# NLN",

--- a/tests/testthat/test-exclusions.R
+++ b/tests/testthat/test-exclusions.R
@@ -110,7 +110,7 @@ test_that("#1413: lint_dir properly excludes files", {
   expect_length(lint_dir(tmp), 0L)
 })
 
-test_that("#1442: is_excluded_files works if no global exclusions are specified", { # nofuzz: assignment
+test_that("#1442: is_excluded_files works if no global exclusions are specified", { # nofuzz
   withr::local_options(lintr.linter_file = "lintr_test_config")
   withr::local_dir(withr::local_tempdir())
 

--- a/tests/testthat/test-exclusions.R
+++ b/tests/testthat/test-exclusions.R
@@ -112,7 +112,7 @@ test_that("#1413: lint_dir properly excludes files", {
 
 test_that("#1442: is_excluded_files works if no global exclusions are specified", { # nofuzz: assignment
   withr::local_options(lintr.linter_file = "lintr_test_config")
-  tmp <- withr::local_tempdir()
+  withr::local_dir(withr::local_tempdir())
 
   writeLines(
     trim_some("
@@ -125,7 +125,7 @@ test_that("#1442: is_excluded_files works if no global exclusions are specified"
           )
         )
     "),
-    file.path(tmp, "lintr_test_config")
+    "lintr_test_config"
   )
 
   writeLines(
@@ -138,19 +138,19 @@ test_that("#1442: is_excluded_files works if no global exclusions are specified"
       # long comment
       # comment
     "),
-    file.path(tmp, "bad.R")
+    "bad.R"
   )
 
   # 3 lints: assignment_linter(), quotes_linter() and line_length_linter()
   expect_lint(
-    file = file.path(tmp, "bad.R"),
+    file = "bad.R",
     checks = list(
       list(linter = "assignment_linter", line_number = 1L),
       list(linter = "quotes_linter", line_number = 1L),
       list(linter = "line_length_linter", line_number = 1L)
     )
   )
-  expect_length(lint_dir(tmp), 3L)
+  expect_length(lint_dir(), 3L)
 })
 
 test_that("next-line exclusion works", { # nofuzz: assignment

--- a/tests/testthat/test-expect_lint.R
+++ b/tests/testthat/test-expect_lint.R
@@ -2,7 +2,7 @@
 # thus less than ideal to test expect_lint(), which can process multiple lints. If you want to test
 # for failure, always put the lint check or lint field that must fail first.
 
-# nofuzz start
+# fuzzer disable: assignment
 linter <- assignment_linter()
 lint_msg <- "Use one of <-, <<- for assignment, not ="
 
@@ -85,4 +85,4 @@ test_that("execution without testthat gives the right errors", {
   expect_error(expect_no_lint(), lint_msg("expect_no_lint"))
   expect_error(expect_lint_free(), lint_msg("expect_lint_free"))
 })
-# nofuzz end
+# fuzzer enable: assignment

--- a/tests/testthat/test-function_left_parentheses_linter.R
+++ b/tests/testthat/test-function_left_parentheses_linter.R
@@ -7,7 +7,7 @@ test_that("function_left_parentheses_linter skips allowed usages", {
   expect_no_lint("base::print(blah)", linter)
   expect_no_lint('base::"print"(blah)', linter)
   expect_no_lint("base::print(blah, fun(1))", linter)
-  expect_no_lint("blah <- function(blah) { }", linter) # nofuzz
+  expect_no_lint("blah <- function(blah) { }", linter) # nofuzz: comment_injection
   expect_no_lint("(1 + 1)", linter)
   expect_no_lint("( (1 + 1) )", linter)
   expect_no_lint("if (blah) { }", linter)
@@ -18,9 +18,9 @@ test_that("function_left_parentheses_linter skips allowed usages", {
   expect_no_lint("c(1, 2, 3)[(2 - 1)]", linter)
   expect_no_lint("list(1, 2, 3)[[(2 - 1)]]", linter)
   expect_no_lint("range(10)[(2 - 1):(10 - 1)]", linter)
-  expect_no_lint("function(){function(){}}()()", linter) # nofuzz
-  expect_no_lint("c(function(){})[1]()", linter) # nofuzz
-  expect_no_lint("function(x) (mean(x) + 3)", linter) # nofuzz
+  expect_no_lint("function(){function(){}}()()", linter) # nofuzz: comment_injection
+  expect_no_lint("c(function(){})[1]()", linter) # nofuzz: comment_injection
+  expect_no_lint("function(x) (mean(x) + 3)", linter) # nofuzz: comment_injection
   expect_no_lint('"blah (1)"', linter)
 })
 
@@ -197,7 +197,7 @@ test_that("newline in character string doesn't trigger false positive (#1963)", 
   )
 })
 
-test_that("shorthand functions are handled", { # nofuzz
+test_that("shorthand functions are handled", { # nofuzz: comment_injection
   skip_if_not_r_version("4.1.0")
   linter <- function_left_parentheses_linter()
   fun_lint_msg <- rex::rex("Remove spaces before the left parenthesis in a function definition.")

--- a/tests/testthat/test-function_return_linter.R
+++ b/tests/testthat/test-function_return_linter.R
@@ -1,4 +1,4 @@
-# nofuzz start
+# fuzzer disable: assignment
 test_that("function_return_linter skips allowed usages", {
   lines_simple <- trim_some("
     foo <- function(x) {
@@ -97,4 +97,4 @@ test_that("lints vectorize", {
     function_return_linter()
   )
 })
-# nofuzz end
+# fuzzer enable: assignment

--- a/tests/testthat/test-get_source_expressions.R
+++ b/tests/testthat/test-get_source_expressions.R
@@ -108,7 +108,7 @@ test_that("Can read non UTF-8 file", {
   withr::local_options(list(lintr.linter_file = tempfile()))
   proj_dir <- test_path("dummy_projects", "project")
   withr::local_dir(proj_dir)
-  expect_no_lint( # nofuzz: assignment
+  expect_no_lint( # nofuzz: assignment comment_injection
     file = "cp1252.R",
     linters = list()
   )

--- a/tests/testthat/test-get_source_expressions.R
+++ b/tests/testthat/test-get_source_expressions.R
@@ -104,11 +104,11 @@ test_that("Multi-byte character truncated by parser is ignored", {
   })
 })
 
-test_that("Can read non UTF-8 file", {
+test_that("Can read non UTF-8 file", { # nofuzz
   withr::local_options(list(lintr.linter_file = tempfile()))
   proj_dir <- test_path("dummy_projects", "project")
   withr::local_dir(proj_dir)
-  expect_no_lint( # nofuzz
+  expect_no_lint(
     file = "cp1252.R",
     linters = list()
   )

--- a/tests/testthat/test-get_source_expressions.R
+++ b/tests/testthat/test-get_source_expressions.R
@@ -108,7 +108,7 @@ test_that("Can read non UTF-8 file", {
   withr::local_options(list(lintr.linter_file = tempfile()))
   proj_dir <- test_path("dummy_projects", "project")
   withr::local_dir(proj_dir)
-  expect_no_lint( # nofuzz
+  expect_no_lint( # nofuzz: assignment
     file = "cp1252.R",
     linters = list()
   )

--- a/tests/testthat/test-get_source_expressions.R
+++ b/tests/testthat/test-get_source_expressions.R
@@ -108,7 +108,7 @@ test_that("Can read non UTF-8 file", {
   withr::local_options(list(lintr.linter_file = tempfile()))
   proj_dir <- test_path("dummy_projects", "project")
   withr::local_dir(proj_dir)
-  expect_no_lint( # nofuzz: assignment comment_injection
+  expect_no_lint( # nofuzz
     file = "cp1252.R",
     linters = list()
   )

--- a/tests/testthat/test-if_switch_linter.R
+++ b/tests/testthat/test-if_switch_linter.R
@@ -86,7 +86,8 @@ test_that("multiple lints have right metadata", {
   )
 })
 
-test_that("max_branch_lines= and max_branch_expressions= arguments work", { # nofuzz
+# fuzzer disable: comment_injection
+test_that("max_branch_lines= and max_branch_expressions= arguments work", {
   max_lines2_linter <- if_switch_linter(max_branch_lines = 2L)
   max_lines4_linter <- if_switch_linter(max_branch_lines = 4L)
   max_expr2_linter <- if_switch_linter(max_branch_expressions = 2L)
@@ -225,7 +226,7 @@ test_that("max_branch_lines= and max_branch_expressions= arguments work", { # no
   expect_no_lint(five_expr_three_lines_lines, max_expr4_linter)
 })
 
-test_that("max_branch_lines= and max_branch_expressions= block over-complex switch() too", { # nofuzz
+test_that("max_branch_lines= and max_branch_expressions= block over-complex switch() too", {
   max_lines2_linter <- if_switch_linter(max_branch_lines = 2L)
   max_lines4_linter <- if_switch_linter(max_branch_lines = 4L)
   max_expr2_linter <- if_switch_linter(max_branch_expressions = 2L)
@@ -388,7 +389,7 @@ test_that("max_branch_lines= and max_branch_expressions= block over-complex swit
   expect_lint(five_expr_three_lines_lines, lint_msg, max_expr4_linter)
 })
 
-test_that("max_branch_lines= and max_branch_expressions= interact correctly", { # nofuzz
+test_that("max_branch_lines= and max_branch_expressions= interact correctly", {
   linter <- if_switch_linter(max_branch_lines = 5L, max_branch_expressions = 3L)
   lint_msg <- rex::rex("Prefer switch() statements over repeated if/else equality tests")
 
@@ -438,7 +439,7 @@ test_that("max_branch_lines= and max_branch_expressions= interact correctly", { 
   )
 })
 
-test_that("max_branch_lines= and max_branch_expressions= work for a terminal 'else' branch", { # nofuzz
+test_that("max_branch_lines= and max_branch_expressions= work for a terminal 'else' branch", {
   max_lines2_linter <- if_switch_linter(max_branch_lines = 2L)
   max_expr2_linter <- if_switch_linter(max_branch_expressions = 2L)
   lint_msg <- rex::rex("Prefer repeated if/else statements over overly-complicated switch() statements.")
@@ -481,7 +482,7 @@ test_that("max_branch_lines= and max_branch_expressions= work for a terminal 'el
   expect_lint(default_long_lines, lint_msg, max_expr2_linter)
 })
 
-test_that("max_branch_lines= and max_branch_expressions= are guided by the most complex branch", { # nofuzz
+test_that("max_branch_lines= and max_branch_expressions= are guided by the most complex branch", {
   max_lines2_linter <- if_switch_linter(max_branch_lines = 2L)
   max_expr2_linter <- if_switch_linter(max_branch_expressions = 2L)
   lint_msg <- rex::rex("Prefer repeated if/else statements over overly-complicated switch() statements.")
@@ -520,3 +521,4 @@ test_that("max_branch_lines= and max_branch_expressions= are guided by the most 
   expect_lint(switch_one_branch_lines, lint_msg, max_lines2_linter)
   expect_lint(switch_one_branch_lines, lint_msg, max_expr2_linter)
 })
+# fuzzer enable: comment_injection

--- a/tests/testthat/test-implicit_assignment_linter.R
+++ b/tests/testthat/test-implicit_assignment_linter.R
@@ -1,4 +1,4 @@
-# nofuzz start
+# fuzzer disable: assignment
 test_that("implicit_assignment_linter skips allowed usages", {
   linter <- implicit_assignment_linter()
 
@@ -504,4 +504,4 @@ test_that("call-less '(' mentions avoiding implicit printing", {
     linter
   )
 })
-# nofuzz end
+# fuzzer enable: assignment

--- a/tests/testthat/test-indentation_linter.R
+++ b/tests/testthat/test-indentation_linter.R
@@ -1,4 +1,4 @@
-# nofuzz start
+# fuzzer disable: comment_injection
 test_that("indentation linter flags unindented expressions", {
   linter <- indentation_linter(indent = 2L)
 
@@ -153,7 +153,6 @@ test_that("indentation linter flags improper closing curly braces", {
   )
 })
 
-# nofuzz start
 test_that("function argument indentation works in tidyverse-style", {
   linter <- indentation_linter()
   expect_no_lint(
@@ -263,7 +262,7 @@ test_that("function argument indentation works in tidyverse-style", {
   )
 })
 
-test_that("function argument indentation works in always-hanging-style", {
+test_that("function argument indentation works in always-hanging-style", { # nofuzz: function_lambda
   linter <- indentation_linter(hanging_indent_style = "always")
   expect_no_lint(
     trim_some("
@@ -357,7 +356,6 @@ test_that("function argument indentation works in always-hanging-style", {
     linter
   )
 })
-# nofuzz end
 
 test_that("indentation with operators works", {
   linter <- indentation_linter()
@@ -913,4 +911,4 @@ test_that("for loop gets correct linting", {
     linter
   )
 })
-# nofuzz end
+# fuzzer enable: comment_injection

--- a/tests/testthat/test-indentation_linter.R
+++ b/tests/testthat/test-indentation_linter.R
@@ -228,7 +228,7 @@ test_that("function argument indentation works in tidyverse-style", { # nofuzz: 
   )
 
   # anchor is correctly found with assignments as well
-  expect_no_lint(
+  expect_no_lint( # nofuzz: assignment
     trim_some("
       test <- function(a = 1L,
                        b = 2L) {
@@ -323,7 +323,7 @@ test_that("function argument indentation works in always-hanging-style", { # nof
   )
 
   # anchor is correctly found with assignments as well
-  expect_no_lint(
+  expect_no_lint( # nofuzz: assignment
     trim_some("
       test <- function(a = 1L,
                        b = 2L) {

--- a/tests/testthat/test-indentation_linter.R
+++ b/tests/testthat/test-indentation_linter.R
@@ -153,7 +153,7 @@ test_that("indentation linter flags improper closing curly braces", {
   )
 })
 
-test_that("function argument indentation works in tidyverse-style", {
+test_that("function argument indentation works in tidyverse-style", { # nofuzz: function_lambda
   linter <- indentation_linter()
   expect_no_lint(
     trim_some("

--- a/tests/testthat/test-infix_spaces_linter.R
+++ b/tests/testthat/test-infix_spaces_linter.R
@@ -1,4 +1,4 @@
-# nofuzz start
+# fuzzer disable: comment_injection
 test_that("returns the correct linting", {
   ops <- c(
     "+",
@@ -236,4 +236,4 @@ test_that("lints vectorize", {
     infix_spaces_linter()
   )
 })
-# nofuzz end
+# fuzzer enable: comment_injection

--- a/tests/testthat/test-infix_spaces_linter.R
+++ b/tests/testthat/test-infix_spaces_linter.R
@@ -191,7 +191,7 @@ test_that("mixed unary & binary operators aren't mis-lint", {
   )
 })
 
-test_that("parse tags are accepted by exclude_operators", {
+test_that("parse tags are accepted by exclude_operators", { # nofuzz: assignment
   expect_no_lint("sum(x, na.rm=TRUE)", infix_spaces_linter(exclude_operators = "EQ_SUB"))
   expect_no_lint("function(x, na.rm=TRUE) { }", infix_spaces_linter(exclude_operators = "EQ_FORMALS"))
   expect_no_lint("x=1", infix_spaces_linter(exclude_operators = "EQ_ASSIGN"))

--- a/tests/testthat/test-is_numeric_linter.R
+++ b/tests/testthat/test-is_numeric_linter.R
@@ -28,7 +28,7 @@ test_that("is_numeric_linter blocks disallowed usages involving ||", {
   expect_lint("is.integer(x) || is.numeric(x)", lint_msg, linter)
 
   # identical expressions match too
-  expect_lint( # fuzzer disable: dollar_at
+  expect_lint( # nofuzz: dollar_at
     "is.integer(DT$x) || is.numeric(DT$x)",
     lint_msg, 
     linter

--- a/tests/testthat/test-is_numeric_linter.R
+++ b/tests/testthat/test-is_numeric_linter.R
@@ -28,7 +28,7 @@ test_that("is_numeric_linter blocks disallowed usages involving ||", {
   expect_lint("is.integer(x) || is.numeric(x)", lint_msg, linter)
 
   # identical expressions match too
-  expect_lint( # nofuzz
+  expect_lint( # fuzzer disable: dollar_at
     "is.integer(DT$x) || is.numeric(DT$x)",
     lint_msg, 
     linter

--- a/tests/testthat/test-keyword_quote_linter.R
+++ b/tests/testthat/test-keyword_quote_linter.R
@@ -129,6 +129,16 @@ test_that("keyword_quote_linter blocks quoted $, @ extractions", { # nofuzz: dol
   expect_lint("x@'foo' = 1", at_msg, linter)
   expect_lint("x@`foo` <- 1", at_msg, linter)
   expect_lint("x@`foo` = 1", at_msg, linter)
+
+  # comment torture
+  expect_lint(
+    trim_some("
+      x@ # comment
+      `foo` <- 1
+    "),
+    at_msg,
+    linter
+  )
 })
 
 test_that("multiple lints are generated correctly", { # nofuzz: dollar_at

--- a/tests/testthat/test-keyword_quote_linter.R
+++ b/tests/testthat/test-keyword_quote_linter.R
@@ -109,7 +109,7 @@ test_that("keyword_quote_linter blocks quoted assignment targets", {
   expect_lint('1 -> "a b"', backtick_msg, linter)
 })
 
-test_that("keyword_quote_linter blocks quoted $, @ extractions", { # nofuzz
+test_that("keyword_quote_linter blocks quoted $, @ extractions", { # nofuzz: dollar_at
   linter <- keyword_quote_linter()
   backtick_msg <- rex::rex("Use backticks to create non-syntactic names, not quotes.")
   dollar_msg <- rex::rex("Only quote targets of extraction with $ if necessary")
@@ -131,7 +131,7 @@ test_that("keyword_quote_linter blocks quoted $, @ extractions", { # nofuzz
   expect_lint("x@`foo` = 1", at_msg, linter)
 })
 
-test_that("multiple lints are generated correctly", { # nofuzz
+test_that("multiple lints are generated correctly", { # nofuzz: dollar_at
   linter <- keyword_quote_linter()
 
   expect_lint(

--- a/tests/testthat/test-knitr_formats.R
+++ b/tests/testthat/test-knitr_formats.R
@@ -120,7 +120,7 @@ test_that("it handles asciidoc", {
   )
 })
 
-test_that("it does _not_ handle brew", { # nofuzz
+test_that("it does _not_ handle brew", { # nofuzz: comment_injection
   expect_lint("'<% a %>'\n",
     checks = list(
       regexes[["quotes"]],

--- a/tests/testthat/test-line_length_linter.R
+++ b/tests/testthat/test-line_length_linter.R
@@ -1,4 +1,4 @@
-# nofuzz start
+# fuzzer disable: comment_injection
 test_that("line_length_linter skips allowed usages", {
   linter <- line_length_linter(80L)
 
@@ -72,4 +72,4 @@ test_that("Multiple lints give custom messages", {
     line_length_linter(5L)
   )
 })
-# nofuzz end
+# fuzzer enable: comment_injection

--- a/tests/testthat/test-lint.R
+++ b/tests/testthat/test-lint.R
@@ -104,7 +104,7 @@ test_that("lint() results do not depend on the position of the .lintr", {
   )
 })
 
-test_that("lint uses linter names", { # nofuzz
+test_that("lint uses linter names", { # nofuzz: assignment
   expect_lint(
     "a = 2",
     list(linter = "bla"),
@@ -146,7 +146,7 @@ test_that("lint() results from file or text should be consistent", {
   expect_identical(lint_from_file, lint_from_text)
 })
 
-test_that("exclusions work with custom linter names", { # nofuzz
+test_that("exclusions work with custom linter names", { # nofuzz: assignment
   expect_no_lint(
     "a = 2 # nolint: bla.",
     linters = list(bla = assignment_linter()),

--- a/tests/testthat/test-make_linter_from_regex.R
+++ b/tests/testthat/test-make_linter_from_regex.R
@@ -1,4 +1,4 @@
-test_that("make_linter_from_regex works", { # nofuzz
+test_that("make_linter_from_regex works", { # nofuzz: assignment
   linter <- lintr:::make_linter_from_regex("-", "style", "Silly lint.")()
   expect_lint("a <- 2L", "Silly lint.", linter)
   expect_no_lint("a = '2-3'", linter)

--- a/tests/testthat/test-nested_pipe_linter.R
+++ b/tests/testthat/test-nested_pipe_linter.R
@@ -14,7 +14,7 @@ test_that("nested_pipe_linter skips allowed usages", {
   )
 
   # pipes fitting on one line can be ignored
-  expect_no_lint( # nofuzz
+  expect_no_lint( # nofuzz: comment_injection
     "bind_rows(a %>% select(b), c %>% select(b))",
     linter
   )
@@ -25,7 +25,7 @@ test_that("nested_pipe_linter skips allowed usages", {
   expect_no_lint("switch(x, a = x, x %>% foo())", linter)
 
   # inline switch inputs are not linted
-  expect_no_lint( # nofuzz
+  expect_no_lint( # nofuzz: comment_injection
     trim_some("
       switch(
         x %>% foo(),
@@ -128,7 +128,7 @@ test_that("Native pipes are handled as well", {
   linter_inline <- nested_pipe_linter(allow_inline = FALSE)
   lint_msg <- rex::rex("Don't nest pipes inside other calls.")
 
-  expect_no_lint( # nofuzz
+  expect_no_lint( # nofuzz: comment_injection
     "bind_rows(a |> select(b), c |> select(b))",
     linter
   )
@@ -150,7 +150,7 @@ test_that("Native pipes are handled as well", {
   )
 })
 
-test_that("lints vectorize", { # nofuzz
+test_that("lints vectorize", { # nofuzz: comment_injection
   lint_msg <- rex::rex("Don't nest pipes inside other calls.")
 
   lines <- trim_some("{

--- a/tests/testthat/test-object_usage_linter.R
+++ b/tests/testthat/test-object_usage_linter.R
@@ -883,7 +883,7 @@ test_that("dplyr's .env-specified objects are marked as 'used'", {
   skip_if_not_installed("rlang")
   linter <- object_usage_linter()
 
-  expect_lint( # nofuzz
+  expect_lint( # nofuzz: dollar_at
     trim_some("
       foo <- function(df) {
         source <- 1

--- a/tests/testthat/test-one_call_pipe_linter.R
+++ b/tests/testthat/test-one_call_pipe_linter.R
@@ -12,7 +12,7 @@ test_that("one_call_pipe_linter skips allowed usages", {
   expect_no_lint("x %<>% as.character()", linter)
 })
 
-# nofuzz start
+# fuzzer disable: pipe
 test_that("one_call_pipe_linter blocks simple disallowed usages", {
   linter <- one_call_pipe_linter()
   lint_msg <- rex::rex("Avoid pipe %>% for expressions with only a single call.")
@@ -25,7 +25,7 @@ test_that("one_call_pipe_linter blocks simple disallowed usages", {
   # nested case
   expect_lint("x %>% inner_join(y %>% filter(is_treatment))", lint_msg, linter)
 })
-# nofuzz end
+# fuzzer enable: pipe
 
 test_that("one_call_pipe_linter skips data.table chains", {
   linter <- one_call_pipe_linter()
@@ -52,7 +52,7 @@ test_that("one_call_pipe_linter treats all pipes equally", {
   expect_no_lint('data %>% filter(type == "console") %$% obscured_id %>% unique()', linter)
 })
 
-test_that("multiple lints are generated correctly", { # nofuzz
+test_that("multiple lints are generated correctly", { # nofuzz: pipe
   expect_lint(
     trim_some("{
       a %>% b()
@@ -74,7 +74,7 @@ test_that("Native pipes are handled as well", {
 
   linter <- one_call_pipe_linter()
 
-  expect_lint( # nofuzz
+  expect_lint( # nofuzz: pipe
     "x |> foo()",
     rex::rex("Avoid pipe |> for expressions with only a single call."),
     linter
@@ -84,7 +84,7 @@ test_that("Native pipes are handled as well", {
   expect_no_lint("x |> foo() %>% bar()", linter)
   expect_no_lint("x %>% foo() |> bar()", linter)
 
-  expect_lint( # nofuzz
+  expect_lint( # nofuzz: pipe
     trim_some("{
       a %>% b()
       c |> d()

--- a/tests/testthat/test-paren_body_linter.R
+++ b/tests/testthat/test-paren_body_linter.R
@@ -1,4 +1,4 @@
-# nofuzz start
+# fuzzer disable: comment_injection
 testthat::test_that("paren_body_linter returns correct lints", {
   linter <- paren_body_linter()
   lint_msg <- rex::rex("Put a space between a right parenthesis and a body expression.")
@@ -96,4 +96,4 @@ test_that("function shorthand is handled", {
 
   expect_lint("\\()test", lint_msg, linter)
 })
-# nofuzz end
+# fuzzer enable: comment_injection

--- a/tests/testthat/test-pipe_consistency_linter.R
+++ b/tests/testthat/test-pipe_consistency_linter.R
@@ -1,4 +1,4 @@
-# nofuzz start
+# fuzzer disable: pipe
 test_that("pipe_consistency skips allowed usage", {
   skip_if_not_r_version("4.1.0")
   linter <- pipe_consistency_linter()
@@ -161,4 +161,4 @@ test_that("pipe_consistency_linter works with other magrittr pipes", {
     linter
   )
 })
-# nofuzz end
+# fuzzer enable: pipe

--- a/tests/testthat/test-pipe_continuation_linter.R
+++ b/tests/testthat/test-pipe_continuation_linter.R
@@ -1,4 +1,4 @@
-# nofuzz start
+# fuzzer disable: comment_injection
 test_that("pipe-continuation correctly handles stand-alone expressions", {
   linter <- pipe_continuation_linter()
   lint_msg <- rex::rex("Put a space before `%>%` and a new line after it,")
@@ -202,4 +202,4 @@ local({
     .cases = cases
   )
 })
-# nofuzz end
+# fuzzer enable: comment_injection

--- a/tests/testthat/test-return_linter.R
+++ b/tests/testthat/test-return_linter.R
@@ -704,7 +704,7 @@ test_that("except= and except_regex= combination works", {
   )
 })
 
-test_that("return_linter skips brace-wrapped inline functions", { # nofuzz
+test_that("return_linter skips brace-wrapped inline functions", { # nofuzz: comment_injection
   expect_no_lint("function(x) { sum(x) }", return_linter(return_style = "explicit"))
 })
 

--- a/tests/testthat/test-semicolon_linter.R
+++ b/tests/testthat/test-semicolon_linter.R
@@ -1,4 +1,4 @@
-# nofuzz start
+# fuzzer disable: comment_injection
 test_that("semicolon_linter skips allowed usages", {
   linter <- semicolon_linter()
 
@@ -152,4 +152,4 @@ test_that("Compound semicolons only", {
     fixed = TRUE
   )
 })
-# nofuzz end
+# fuzzer enable: comment_injection

--- a/tests/testthat/test-spaces_inside_linter.R
+++ b/tests/testthat/test-spaces_inside_linter.R
@@ -1,4 +1,4 @@
-# nofuzz start
+# fuzzer disable: comment_injection
 test_that("spaces_inside_linter skips allowed usages", {
   linter <- spaces_inside_linter()
 
@@ -244,4 +244,4 @@ test_that("spaces_inside_linter blocks disallowed usages with a pipe", {
 test_that("terminal missing keyword arguments are OK", {
   expect_no_lint("alist(missing_arg = )", spaces_inside_linter())
 })
-# nofuzz end
+# fuzzer enable: comment_injection

--- a/tests/testthat/test-spaces_left_parentheses_linter.R
+++ b/tests/testthat/test-spaces_left_parentheses_linter.R
@@ -1,4 +1,4 @@
-# nofuzz start
+# fuzzer disable: comment_injection
 test_that("spaces_left_parentheses_linter skips allowed usages", {
   linter <- spaces_left_parentheses_linter()
 
@@ -112,4 +112,4 @@ test_that("lints vectorize", {
     spaces_left_parentheses_linter()
   )
 })
-# nofuzz end
+# fuzzer enable: comment_injection

--- a/tests/testthat/test-trailing_blank_lines_linter.R
+++ b/tests/testthat/test-trailing_blank_lines_linter.R
@@ -1,4 +1,4 @@
-# nofuzz start
+# fuzzer disable: comment_injection
 test_that("trailing_blank_lines_linter doesn't block allowed usages", {
   linter <- trailing_blank_lines_linter()
 
@@ -159,4 +159,4 @@ test_that("blank lines in knitr chunks produce lints", {
     linters = linter
   )
 })
-# nofuzz end
+# fuzzer enable: comment_injection

--- a/tests/testthat/test-trailing_whitespace_linter.R
+++ b/tests/testthat/test-trailing_whitespace_linter.R
@@ -1,4 +1,4 @@
-# nofuzz start
+# fuzzer disable: comment_injection
 test_that("returns the correct linting", {
   linter <- trailing_whitespace_linter()
   lint_msg <- rex::rex("Remove trailing whitespace.")
@@ -68,4 +68,4 @@ test_that("also handles trailing whitespace in string constants", {
     trailing_whitespace_linter(allow_in_strings = FALSE)
   )
 })
-# nofuzz end
+# fuzzer enable: comment_injection

--- a/tests/testthat/test-undesirable_operator_linter.R
+++ b/tests/testthat/test-undesirable_operator_linter.R
@@ -7,19 +7,19 @@ test_that("linter returns correct linting", {
   expect_no_lint("cat(\"10$\")", linter)
   expect_lint(
     "a <<- log(10)",
-    list(message = msg_assign, line_number = 1L, column_number = 3L),
+    list(msg_assign, line_number = 1L, column_number = 3L),
     linter
   )
-  expect_lint( # nofuzz
+  expect_lint( # nofuzz: dollar_at
     "data$parsed == c(1, 2)",
-    list(message = msg_dollar, line_number = 1L, column_number = 5L),
+    list(msg_dollar, line_number = 1L, column_number = 5L),
     linter
   )
 
   expect_no_lint("`%%`(10, 2)", linter)
 })
 
-test_that("undesirable_operator_linter handles '=' consistently", { # nofuzz
+test_that("undesirable_operator_linter handles '=' consistently", { # nofuzz: assignment
   linter <- undesirable_operator_linter(op = c("=" = "As an alternative, use '<-'"))
 
   expect_lint("a = 2L", rex::rex("Avoid undesirable operator `=`."), linter)

--- a/tests/testthat/test-unnecessary_nesting_linter.R
+++ b/tests/testthat/test-unnecessary_nesting_linter.R
@@ -311,7 +311,7 @@ test_that("unnecessary_nesting_linter passes for multi-line braced expressions",
   )
 })
 
-test_that("unnecessary_nesting_linter skips if unbracing won't reduce nesting", { # nofuzz
+test_that("unnecessary_nesting_linter skips if unbracing won't reduce nesting", {
   
   linter <- unnecessary_nesting_linter()
 
@@ -817,7 +817,7 @@ patrick::with_parameters_test_that(
   )
 )
 
-test_that("allow_functions= works", { # nofuzz '})' break-up by comment
+test_that("allow_functions= works", { # nofuzz: comment_injection
   linter_default <- unnecessary_nesting_linter()
   linter_foo <- unnecessary_nesting_linter(allow_functions = "foo")
   expect_lint("foo(x, {y}, z)", "Reduce the nesting of this statement", linter_default)

--- a/tests/testthat/test-unnecessary_placeholder_linter.R
+++ b/tests/testthat/test-unnecessary_placeholder_linter.R
@@ -19,7 +19,7 @@ patrick::with_parameters_test_that(
   pipe = pipes
 )
 
-patrick::with_parameters_test_that( # nofuzz
+patrick::with_parameters_test_that( # nofuzz: pipe
   "unnecessary_placeholder_linter blocks simple disallowed usages",
   {
     expect_lint(
@@ -38,7 +38,7 @@ patrick::with_parameters_test_that( # nofuzz
   pipe = pipes
 )
 
-test_that("lints vectorize", { # nofuzz
+test_that("lints vectorize", { # nofuzz: pipe
   lint_msg <- rex::rex("Don't use the placeholder (`.`) when it's not needed")
 
   expect_lint(

--- a/tests/testthat/test-unreachable_code_linter.R
+++ b/tests/testthat/test-unreachable_code_linter.R
@@ -55,7 +55,7 @@ test_that("unreachable_code_linter works in sub expressions", {
     linter
   )
 
-  expect_no_lint( # nofuzz
+  expect_no_lint( # nofuzz: comment_injection
     trim_some("
       foo <- function(bar) {
         if (bar) {
@@ -177,7 +177,7 @@ test_that("unreachable_code_linter works with next and break in sub expressions"
     linter
   )
 
-  expect_no_lint( # nofuzz
+  expect_no_lint( # nofuzz: comment_injection
     trim_some("
       foo <- function(bar) {
         if (bar) {
@@ -282,7 +282,7 @@ test_that("unreachable_code_linter passes on multi-line functions", {
   expect_no_lint(lines, unreachable_code_linter())
 })
 
-test_that("unreachable_code_linter ignores comments on the same expression", { # nofuzz
+test_that("unreachable_code_linter ignores comments on the same expression", { # nofuzz: comment_injection
   linter <- unreachable_code_linter()
 
   expect_no_lint(
@@ -297,7 +297,7 @@ test_that("unreachable_code_linter ignores comments on the same expression", { #
   )
 })
 
-test_that("unreachable_code_linter ignores comments on the same line", { # nofuzz
+test_that("unreachable_code_linter ignores comments on the same line", { # nofuzz: comment_injection
   lines <- trim_some("
     foo <- function(x) {
       return(y^2) # y^3
@@ -339,7 +339,7 @@ test_that("unreachable_code_linter finds unreachable comments", {
   )
 })
 
-test_that("unreachable_code_linter finds expressions in the same line", { # nofuzz
+test_that("unreachable_code_linter finds expressions in the same line", { # nofuzz: comment_injection
   msg <- rex::rex("Remove code and comments coming after return() or stop()")
   linter <- unreachable_code_linter()
 
@@ -450,7 +450,7 @@ test_that("unreachable_code_linter ignores terminal nolint end comments", {
     lintr.exclude_end = "#\\s*TestNoLintEnd"
   ))
 
-  expect_no_lint( # nofuzz
+  expect_no_lint( # nofuzz: comment_injection
     trim_some("
       foo <- function() {
         do_something

--- a/tests/testthat/test-unused_import_linter.R
+++ b/tests/testthat/test-unused_import_linter.R
@@ -7,7 +7,7 @@ test_that("unused_import_linter lints as expected", {
   # SYMBOL usage is detected
   expect_no_lint("library(dplyr)\ndo.call(tibble, args = list(a = 1))", linter)
   # SPECIAL usage is detected
-  expect_no_lint( # nofuzz
+  expect_no_lint( # nofuzz: pipe
     trim_some("
       library(magrittr)
       1:3 %>% mean()


### PR DESCRIPTION
Continues the chain from #2818 to #2829 (the last of which this is currently based against).

I wasn't satisfied with the approach to just comment out & ignore large swaths of the test suite needed to implement `# nofuzz` through now, especially after the `comment_injection_fuzzer` turned out to require such large `# nofuzz` regions, but I was stuck on how to proceed with specific exclusions.

I think the approach taken here is pretty satisfactory: as a preprocessing step, we convert the `# nofuzz` markup into new code in the suite that signals activated/deactivated fuzzers for each execution of `expect_lint()`.

The approach could be improved -- it can be a bit of a pain to debug, e.g. when `expect_lint(file = .)` was erroring due to encoding issues, the error causes the test to exit and thus fails to run the `activate_fuzzers()` step, leading to cascading confusing errors it's hard to pin down. And there's no simple workaround here, as e.g. using a `withr::defer()` approach to ensure the `activate_fuzzers()` step is run is not straightforward.

But I think there's enough good progress here (and it turned up a few more true positive fixes!) that it is ready for review.