### PR TITLE
Make `backport_linter(r_version = )` default and options more explicit

### DIFF
--- a/R/backport_linter.R
+++ b/R/backport_linter.R
@@ -21,6 +21,11 @@
 #'   linters = backport_linter("3.2.0")
 #' )
 #'
+#' lint(
+#'   text = "deparse1(expr)",
+#'   linters = backport_linter("3.6.0")
+#' )
+#'
 #' # okay
 #' lint(
 #'   text = "trimws(x)",
@@ -29,24 +34,12 @@
 #'
 #' lint(
 #'   text = "str2lang(x)",
-#'   linters = backport_linter("4.0.0")
-#' )
-#'
-#' lint(
-#'   text = "str2lang(x)",
 #'   linters = backport_linter("3.2.0", except = "str2lang")
 #' )
 #'
 #' # Version aliases instead of numbers can also be passed to `r_version`
-#' # lints
 #' lint(
-#'   text = "str2lang('x')",
-#'   linters = backport_linter("3.5.0")
-#' )
-#'
-#' # ok
-#' lint(
-#'   text = "str2lang('x')",
+#'   text = "deparse1(expr)",
 #'   linters = backport_linter("release")
 #' )
 #'

--- a/R/backport_linter.R
+++ b/R/backport_linter.R
@@ -3,7 +3,8 @@
 #' Check for usage of unavailable functions. Not reliable for testing r-devel dependencies.
 #'
 #' @param r_version Minimum R version to test for compatibility. Defaults to
-#'  the R version currently in use.
+#'  the R version currently in use. The version can be specified as a version
+#'  number, or as a version alias (such as `"devel"`, `"oldrel"`, `"oldrel-1"`).
 #' @param except Character vector of functions to be excluded from linting.
 #'  Use this to list explicitly defined backports, e.g. those imported from the `{backports}` package or manually
 #'  defined in your package.
@@ -34,6 +35,11 @@
 #' lint(
 #'   text = "str2lang(x)",
 #'   linters = backport_linter("3.2.0", except = "str2lang")
+#' )
+#'
+#' lint(
+#'   text = "mean(x)",
+#'   linters = backport_linter("release")
 #' )
 #'
 #' @evalRd rd_tags("backport_linter")

--- a/R/backport_linter.R
+++ b/R/backport_linter.R
@@ -2,7 +2,8 @@
 #'
 #' Check for usage of unavailable functions. Not reliable for testing r-devel dependencies.
 #'
-#' @param r_version Minimum R version to test for compatibility
+#' @param r_version Minimum R version to test for compatibility. Defaults to
+#'  the R version currently in use.
 #' @param except Character vector of functions to be excluded from linting.
 #'  Use this to list explicitly defined backports, e.g. those imported from the `{backports}` package or manually
 #'  defined in your package.

--- a/R/backport_linter.R
+++ b/R/backport_linter.R
@@ -37,8 +37,16 @@
 #'   linters = backport_linter("3.2.0", except = "str2lang")
 #' )
 #'
+#' # Version aliases instead of numbers can also be passed to `r_version`
+#' # lints
 #' lint(
-#'   text = "mean(x)",
+#'   text = "str2lang('x')",
+#'   linters = backport_linter("3.5.0")
+#' )
+#'
+#' # ok
+#' lint(
+#'   text = "str2lang('x')",
 #'   linters = backport_linter("release")
 #' )
 #'

--- a/man/backport_linter.Rd
+++ b/man/backport_linter.Rd
@@ -30,6 +30,11 @@ lint(
   linters = backport_linter("3.2.0")
 )
 
+lint(
+  text = "deparse1(expr)",
+  linters = backport_linter("3.6.0")
+)
+
 # okay
 lint(
   text = "trimws(x)",
@@ -38,24 +43,12 @@ lint(
 
 lint(
   text = "str2lang(x)",
-  linters = backport_linter("4.0.0")
-)
-
-lint(
-  text = "str2lang(x)",
   linters = backport_linter("3.2.0", except = "str2lang")
 )
 
 # Version aliases instead of numbers can also be passed to `r_version`
-# lints
 lint(
-  text = "str2lang('x')",
-  linters = backport_linter("3.5.0")
-)
-
-# ok
-lint(
-  text = "str2lang('x')",
+  text = "deparse1(expr)",
   linters = backport_linter("release")
 )
 

--- a/man/backport_linter.Rd
+++ b/man/backport_linter.Rd
@@ -8,7 +8,8 @@ backport_linter(r_version = getRversion(), except = character())
 }
 \arguments{
 \item{r_version}{Minimum R version to test for compatibility. Defaults to
-the R version currently in use.}
+the R version currently in use. The version can be specified as a version
+number, or as a version alias (such as \code{"devel"}, \code{"oldrel"}, \code{"oldrel-1"}).}
 
 \item{except}{Character vector of functions to be excluded from linting.
 Use this to list explicitly defined backports, e.g. those imported from the \code{{backports}} package or manually
@@ -43,6 +44,11 @@ lint(
 lint(
   text = "str2lang(x)",
   linters = backport_linter("3.2.0", except = "str2lang")
+)
+
+lint(
+  text = "mean(x)",
+  linters = backport_linter("release")
 )
 
 }

--- a/man/backport_linter.Rd
+++ b/man/backport_linter.Rd
@@ -46,8 +46,16 @@ lint(
   linters = backport_linter("3.2.0", except = "str2lang")
 )
 
+# Version aliases instead of numbers can also be passed to `r_version`
+# lints
 lint(
-  text = "mean(x)",
+  text = "str2lang('x')",
+  linters = backport_linter("3.5.0")
+)
+
+# ok
+lint(
+  text = "str2lang('x')",
   linters = backport_linter("release")
 )
 

--- a/man/backport_linter.Rd
+++ b/man/backport_linter.Rd
@@ -7,7 +7,8 @@
 backport_linter(r_version = getRversion(), except = character())
 }
 \arguments{
-\item{r_version}{Minimum R version to test for compatibility}
+\item{r_version}{Minimum R version to test for compatibility. Defaults to
+the R version currently in use.}
 
 \item{except}{Character vector of functions to be excluded from linting.
 Use this to list explicitly defined backports, e.g. those imported from the \code{{backports}} package or manually


### PR DESCRIPTION
While thinking about #1974, I noticed some features of `backport_linter()` were not explicitly documented. This minor PR aims to help discoverability of this useful feature.