### PR TITLE
Order author affiliations more sensibly in paper

### DIFF
--- a/paper/paper.Rmd
+++ b/paper/paper.Rmd
@@ -7,38 +7,38 @@ authors:
     affiliation: 1
     orcid: 0000-0002-2739-7082
   - name: Florent Angly
-    affiliation: 6
+    affiliation: 2
     orcid: 0000-0002-8999-0738
   - name: Michael Chirico
-    affiliation: 2
+    affiliation: 3
     orcid: 0000-0003-0787-087X
   - name: Russ Hyde
-    affiliation: 5
+    affiliation: 4
     orcid: ~
   - name: Ren Kun
-    affiliation: 7
+    affiliation: 5
     orcid: ~
   - name: Indrajeet Patil
     orcid: 0000-0003-1995-6531
-    affiliation: 4
+    affiliation: 6
   - name: Alexander Rosenstock
-    affiliation: 3
+    affiliation: 7
     orcid: ~
 affiliations:
   - index: 1
     name: Netflix
   - index: 2
-    name: Google
-  - index: 3
-    name: Mathematisches Institut der Heinrich-Heine-Universität Düsseldorf
-  - index: 4
-    name: Carl Zeiss AG, Germany
-  - index: 5
-    name: Jumping Rivers
-  - index: 6
     name: The University of Queensland
-  - index: 7
+  - index: 3
+    name: Google
+  - index: 4
+    name: Jumping Rivers
+  - index: 5
     name: Unknown
+  - index: 6
+    name: Carl Zeiss AG, Germany
+  - index: 7
+    name: Mathematisches Institut der Heinrich-Heine-Universität Düsseldorf
 output: 
     md_document:
       variant: "markdown"

--- a/paper/paper.md
+++ b/paper/paper.md
@@ -1,44 +1,44 @@
 ---
 title: "Static Code Analysis for R"
-date: "2025-02-01"
+date: "2025-04-01"
 tags: ["R", "linter", "tidyverse"]
 authors:
   - name: Jim Hester
     affiliation: 1
     orcid: 0000-0002-2739-7082
   - name: Florent Angly
-    affiliation: 6
+    affiliation: 2
     orcid: 0000-0002-8999-0738
   - name: Michael Chirico
-    affiliation: 2
+    affiliation: 3
     orcid: 0000-0003-0787-087X
   - name: Russ Hyde
-    affiliation: 5
+    affiliation: 4
     orcid: ~
   - name: Ren Kun
-    affiliation: 7
+    affiliation: 5
     orcid: ~
   - name: Indrajeet Patil
     orcid: 0000-0003-1995-6531
-    affiliation: 4
+    affiliation: 6
   - name: Alexander Rosenstock
-    affiliation: 3
+    affiliation: 7
     orcid: ~
 affiliations:
   - index: 1
     name: Netflix
   - index: 2
-    name: Google
-  - index: 3
-    name: Mathematisches Institut der Heinrich-Heine-Universität Düsseldorf
-  - index: 4
-    name: Carl Zeiss AG, Germany
-  - index: 5
-    name: Jumping Rivers
-  - index: 6
     name: The University of Queensland
-  - index: 7
+  - index: 3
+    name: Google
+  - index: 4
+    name: Jumping Rivers
+  - index: 5
     name: Unknown
+  - index: 6
+    name: Carl Zeiss AG, Germany
+  - index: 7
+    name: Mathematisches Institut der Heinrich-Heine-Universität Düsseldorf
 output: 
     md_document:
       variant: "markdown"


### PR DESCRIPTION
Currently, it's quite difficult to read the affiliation because they are in random order.

<img width="734" alt="Screenshot 2025-04-01 at 21 29 45" src="https://github.com/user-attachments/assets/eb5ac5e9-e7c4-4952-aa9f-f83b177ff863" />
