### PR TITLE
lint(text=) finds local settings again

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -16,7 +16,7 @@
 ## Bug fixes
 
 * `Lint()`, and thus all linters, ensures that the returned object's `message` attribute is consistently a simple character string (and not, for example, an object of class `"glue"`; #2740, @MichaelChirico).
-* Files with encoding inferred from settings read more robustly under `lint(parse_settings = TRUE)` (#2803, @MichaelChirico).
+* Files with encoding inferred from settings read more robustly under `lint(parse_settings = TRUE)` (#2803, @MichaelChirico). Thanks also to @bastistician for detecting a regression caused by the initial change for users of Emacs (#2847).
 
 ## Changes to default linters
 

--- a/R/lint.R
+++ b/R/lint.R
@@ -45,9 +45,8 @@ lint <- function(filename, linters = NULL, ..., cache = FALSE, parse_settings = 
 
   needs_tempfile <- missing(filename) || re_matches(filename, rex(newline))
   inline_data <- !is.null(text) || needs_tempfile
-  parse_settings <- !inline_data && isTRUE(parse_settings)
 
-  if (parse_settings) {
+  if (isTRUE(parse_settings)) {
     read_settings(filename)
     on.exit(reset_settings(), add = TRUE)
   }

--- a/R/settings.R
+++ b/R/settings.R
@@ -65,6 +65,7 @@
 read_settings <- function(filename, call = parent.frame()) {
   reset_settings()
 
+  # doing lint(text=) should read settings from the current directory, required e.g. for Emacs
   if (missing(filename)) filename <- "./any_local_file"
   config_file <- find_config(filename)
   default_encoding <- find_default_encoding(filename)

--- a/R/settings.R
+++ b/R/settings.R
@@ -65,6 +65,7 @@
 read_settings <- function(filename, call = parent.frame()) {
   reset_settings()
 
+  if (missing(filename)) filename <- "./any_local_file"
   config_file <- find_config(filename)
   default_encoding <- find_default_encoding(filename)
   if (!is.null(default_encoding)) {

--- a/tests/testthat/test-lint.R
+++ b/tests/testthat/test-lint.R
@@ -233,3 +233,11 @@ test_that("Linter() input is validated", {
 test_that("typo in argument name gives helpful error", {
   expect_error(lint("xxx", litners = identity), "Found unknown arguments in `...`: `litners`")
 })
+
+test_that("settings are picked up under lint(text=)", {
+  .lintr <- withr::local_tempfile(lines = "linters: list(assignment_linter())")
+  withr::local_options(lintr.linter_file = .lintr)
+
+  # lint '=', but not the operator spacing
+  expect_length(lint(text = "a=1"), 1L)
+})


### PR DESCRIPTION
Closes #2847, cc @bastistician

PS, I originally pushed this directly to `main` by mistake as b548c789f23efaf6404a50c57bf29a2c29b3a5cd; reverted as dc7a612bb44da150e0e1ef4f6b9a48b23a61210b to put this through normal review