### PR TITLE
Remove ':::' as exempted

### DIFF
--- a/.lintr
+++ b/.lintr
@@ -34,7 +34,6 @@ linters: all_linters(
     ),
     undesirable_operator_linter(modify_defaults(
       defaults = default_undesirable_operators,
-      `:::` = NULL,
       `<<-` = NULL
     )),
     unnecessary_concatenation_linter(allow_single_expression = FALSE),


### PR DESCRIPTION
#2801 cleared out remaining `:::` usage, h/t @AshesITR. Part of #2878 