### PR TITLE
Apply condition_call_linter() only on string literals

### DIFF
--- a/R/condition_call_linter.R
+++ b/R/condition_call_linter.R
@@ -57,11 +57,15 @@
 #' @export
 condition_call_linter <- function(display_call = FALSE) {
   call_xpath <- glue::glue("
-    following-sibling::SYMBOL_SUB[text() = 'call.']
+    following-sibling::expr/STR_CONST
+    and following-sibling::SYMBOL_SUB[text() = 'call.']
       /following-sibling::expr[1]
       /NUM_CONST[text() = '{!display_call}']
   ")
-  no_call_xpath <- "parent::expr[not(SYMBOL_SUB[text() = 'call.'])]"
+  no_call_xpath <- "
+    following-sibling::expr/STR_CONST
+    and parent::expr[not(SYMBOL_SUB[text() = 'call.'])]
+  "
 
   if (is.na(display_call)) {
     call_cond <- no_call_xpath
@@ -81,6 +85,7 @@ condition_call_linter <- function(display_call = FALSE) {
 
   Linter(linter_level = "expression", function(source_expression) {
     xml_calls <- source_expression$xml_find_function_calls(c("stop", "warning"))
+
     bad_expr <- xml_find_all(xml_calls, xpath)
 
     xml_nodes_to_lints(

--- a/tests/testthat/test-condition_call_linter.R
+++ b/tests/testthat/test-condition_call_linter.R
@@ -1,19 +1,19 @@
 test_that("condition_call_linter skips allowed usages", {
   linter <- condition_call_linter()
 
-  expect_lint("stop('test', call. = FALSE)", NULL, linter)
+  expect_no_lint("stop('test', call. = FALSE)", linter)
 
   # works even with multiple arguments
-  expect_lint("stop('this is a', 'test', call. = FALSE)", NULL, linter)
+  expect_no_lint("stop('this is a', 'test', call. = FALSE)", linter)
 
   linter <- condition_call_linter(display_call = TRUE)
 
-  expect_lint("stop('test', call. = TRUE)", NULL, linter)
+  expect_no_lint("stop('test', call. = TRUE)", linter)
 
   linter <- condition_call_linter(display_call = NA)
 
-  expect_lint("stop('test', call. = TRUE)", NULL, linter)
-  expect_lint("stop('test', call. = FALSE)", NULL, linter)
+  expect_no_lint("stop('test', call. = TRUE)", linter)
+  expect_no_lint("stop('test', call. = FALSE)", linter)
 })
 
 patrick::with_parameters_test_that(

--- a/tests/testthat/test-condition_call_linter.R
+++ b/tests/testthat/test-condition_call_linter.R
@@ -2,6 +2,8 @@ test_that("condition_call_linter skips allowed usages", {
   linter <- condition_call_linter()
 
   expect_no_lint("stop('test', call. = FALSE)", linter)
+  expect_no_lint("stop(test)", linter)
+  expect_no_lint("stop(errorCondition('test'))", linter)
 
   # works even with multiple arguments
   expect_no_lint("stop('this is a', 'test', call. = FALSE)", linter)
@@ -9,11 +11,13 @@ test_that("condition_call_linter skips allowed usages", {
   linter <- condition_call_linter(display_call = TRUE)
 
   expect_no_lint("stop('test', call. = TRUE)", linter)
+  expect_no_lint("stop(test)", linter)
 
   linter <- condition_call_linter(display_call = NA)
 
   expect_no_lint("stop('test', call. = TRUE)", linter)
   expect_no_lint("stop('test', call. = FALSE)", linter)
+  expect_no_lint("stop(test)", linter)
 })
 
 patrick::with_parameters_test_that(
@@ -41,8 +45,8 @@ patrick::with_parameters_test_that(
 test_that("lints vectorize", {
   expect_lint(
     trim_some("{
-      stop(e)
-      warning(w)
+      stop('e')
+      warning('w')
     }"),
     list(
       list("stop", line_number = 2L),


### PR DESCRIPTION
Fix #2647 