### PR TITLE
Fix matrix_apply_linter() with interweaved comments

### DIFF
--- a/R/matrix_apply_linter.R
+++ b/R/matrix_apply_linter.R
@@ -114,7 +114,7 @@ matrix_apply_linter <- function() {
     xml_nodes_to_lints(
       bad_expr,
       source_expression = source_expression,
-      lint_message = sprintf("Use %1$s rather than %2$s", recos, get_r_string(bad_expr)),
+      lint_message = sprintf("Use %1$s rather than %2$s", recos, xml_text(bad_expr)),
       type = "warning"
     )
   })

--- a/R/matrix_apply_linter.R
+++ b/R/matrix_apply_linter.R
@@ -101,7 +101,6 @@ matrix_apply_linter <- function() {
     variable <- xml_text(xml_find_all(bad_expr, variable_xpath))
 
     fun <- xml_text(xml_find_all(bad_expr, fun_xpath))
-    fun <- tools::toTitleCase(fun)
 
     margin <- xml_find_all(bad_expr, margin_xpath)
 
@@ -109,12 +108,10 @@ matrix_apply_linter <- function() {
       xml_find_first(bad_expr, "SYMBOL_SUB[text() = 'na.rm']/following-sibling::expr")
     )
 
-    recos <- Map(craft_colsums_rowsums_msg, variable, margin, fun, narm_val)
-
     xml_nodes_to_lints(
       bad_expr,
       source_expression = source_expression,
-      lint_message = sprintf("Use %1$s rather than %2$s", recos, xml_text(bad_expr)),
+      lint_message = Map(craft_colsums_rowsums_msg, variable, margin, fun, narm_val),
       type = "warning"
     )
   })
@@ -147,6 +144,9 @@ craft_colsums_rowsums_msg <- function(variable, margin, fun, narm_val) {
   } else {
     narm <- ""
   }
+  current <- glue("apply({variable}, {xml_text(margin)}, {fun}{narm})")
+
+  fun <- tools::toTitleCase(fun)
 
   if (identical(l1, 1L)) {
     reco <- glue("row{fun}s({variable}{narm}, dims = {l2})")
@@ -159,7 +159,7 @@ craft_colsums_rowsums_msg <- function(variable, margin, fun, narm_val) {
   }
 
   # It's easier to remove this after the fact, rather than having never ending if/elses
-  reco <- gsub(", dims = 1", "", reco, fixed = TRUE)
+  recommended <- gsub(", dims = 1", "", reco, fixed = TRUE)
 
-  reco
+  sprintf("Use %1$s rather than %2$s", recommended, current)
 }

--- a/tests/testthat/test-matrix_apply_linter.R
+++ b/tests/testthat/test-matrix_apply_linter.R
@@ -61,6 +61,15 @@ test_that("matrix_apply_linter simple disallowed usages", {
 
   expect_lint("apply(x, 2:4, mean)", lint_message, linter)
 
+  expect_lint(
+    trim_some("
+      apply(x, 2, #comment
+      mean)
+    "),
+    lint_message,
+    linter
+  )
+
 })
 
 test_that("matrix_apply_linter recommendation includes na.rm if present in original call", {


### PR DESCRIPTION
Fix #2825

- 313c04e34c895bc09bd83ef91538ce63813b2b87 downgrades the bug to a metadata error (as in #2826) but there is no crash
- bc2a56015e88865ed604ce9690f5ab62ddc4f27f also fixes the metadata but might make the code slightly more complex

Should we merge both commits or only 313c04e34c895bc09bd83ef91538ce63813b2b87 and leave the metadata issue for a more global solution to #2826?