### PR TITLE
Don't warn if cyclocomp is missing but it's explicitly excluded

### DIFF
--- a/R/with.R
+++ b/R/with.R
@@ -97,10 +97,16 @@ linters_with_tags <- function(tags, ..., packages = "lintr", exclude_tags = "dep
   }
   tagged_linters <- list()
 
+  dots <- list(...)
+  exclude_idx <- vapply(dots, is.null, logical(1L))
+  excluded_linters <- names(dots)[exclude_idx]
+  dots <- dots[!exclude_idx]
+
   for (package in packages) {
     pkg_ns <- loadNamespace(package)
     ns_exports <- getNamespaceExports(pkg_ns)
     available <- available_linters(packages = package, tags = tags, exclude_tags = exclude_tags)
+    available <- available[!available$linter %in% excluded_linters, ]
     if (nrow(available) > 0L) {
       if (!all(available$linter %in% ns_exports)) {
         missing_linters <- setdiff(available$linter, ns_exports) # nolint: object_usage_linter. TODO(#2252).
@@ -120,7 +126,7 @@ linters_with_tags <- function(tags, ..., packages = "lintr", exclude_tags = "dep
     }
   }
 
-  modify_defaults(..., defaults = tagged_linters)
+  do.call(modify_defaults, c(list(defaults = tagged_linters), dots))
 }
 
 #' Create a linter configuration based on all available linters

--- a/tests/testthat/test-with.R
+++ b/tests/testthat/test-with.R
@@ -118,3 +118,12 @@ test_that("all_linters respects ellipsis argument", {
     all_linters(packages = "lintr", implicit_integer_linter = NULL)
   )
 })
+
+test_that("Excluding cyclocomp linter avoids a warning", {
+  local_mocked_bindings(
+    requireNamespace = function(pkg, ...) pkg != "cyclocomp" || base::requireNamespace(pkg, ...)
+  )
+
+  expect_silent(all_linters(cyclocomp_linter = NULL))
+  expect_silent(linters_with_tags("configurable", cyclocomp_linter = NULL))
+})


### PR DESCRIPTION
Closes #2909. A bit ugly, not super satisfied with the fix.

It may be possible to defer the `call_linter_factory` step until `modify_defaults()`, but that would change the behavior of both `linters_with_tags()` and `modify_defaults()`.