### PR TITLE
Lint `identical(x, sort(x))` in `sort_linter()`

### DIFF
--- a/R/sort_linter.R
+++ b/R/sort_linter.R
@@ -85,11 +85,10 @@ sort_linter <- function() {
   sorted_xpath <- "
   parent::expr[not(SYMBOL_SUB)]
     /parent::expr[
-      (EQ or NE)
+      (EQ or NE or expr/SYMBOL_FUNCTION_CALL/text() = 'identical')
       and expr/expr = expr
     ]
   "
-
 
   arguments_xpath <-
     ".//SYMBOL_SUB[text() = 'method' or text() = 'decreasing' or text() = 'na.last']"

--- a/tests/testthat/test-sort_linter.R
+++ b/tests/testthat/test-sort_linter.R
@@ -120,7 +120,7 @@ test_that("sort_linter blocks simple disallowed usages", {
 
   # expression matching
   expect_lint("sort(foo(x)) == foo(x)", sorted_msg, linter)
-  expect_lint("identical(foo(x), sort(foo(x))", sorted_msg, linter)
+  expect_lint("identical(foo(x), sort(foo(x)))", sorted_msg, linter)
 })
 
 test_that("lints vectorize", {

--- a/tests/testthat/test-sort_linter.R
+++ b/tests/testthat/test-sort_linter.R
@@ -108,15 +108,19 @@ test_that("sort_linter blocks simple disallowed usages", {
   sorted_msg <- rex::rex("Use !is.unsorted(x) to test the sortedness of a vector.")
 
   expect_lint("sort(x) == x", sorted_msg, linter)
+  expect_lint("identical(x, sort(x))", sorted_msg, linter)
 
   # argument order doesn't matter
   expect_lint("x == sort(x)", sorted_msg, linter)
+  expect_lint("identical(sort(x), x)", sorted_msg, linter)
 
   # inverted version
   expect_lint("sort(x) != x", unsorted_msg, linter)
+  expect_lint("!identical(x, sort(x))", unsorted_msg, linter)
 
   # expression matching
   expect_lint("sort(foo(x)) == foo(x)", sorted_msg, linter)
+  expect_lint("identical(foo(x), sort(foo(x))", sorted_msg, linter)
 })
 
 test_that("lints vectorize", {


### PR DESCRIPTION
I initially tried to re-use the existing `sorted_xpath` but I think customizing the error message was then too messy and unclear.

Fix #2908