### PR TITLE
Skip quarto installation in CI

### DIFF
--- a/.github/workflows/ast-fuzz.yaml
+++ b/.github/workflows/ast-fuzz.yaml
@@ -23,6 +23,8 @@ jobs:
           use-public-rspm: true
 
       - uses: r-lib/actions/setup-r-dependencies@v2
+        with:
+          install-quarto: false
 
       - name: Ensure equivalent code generates equivalent lints
         run: |

--- a/.github/workflows/check-all-examples.yaml
+++ b/.github/workflows/check-all-examples.yaml
@@ -30,6 +30,7 @@ jobs:
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
+          install-quarto: false
           pak-version: devel
           extra-packages: |
             any::pkgload

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -20,6 +20,7 @@ jobs:
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
+          install-quarto: false
           extra-packages: |
             any::cyclocomp
             r-lib/lintr

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -30,6 +30,7 @@ jobs:
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
+          install-quarto: false
           extra-packages: any::pkgdown, local::.
           needs: website
 

--- a/.github/workflows/repo-meta-tests.yaml
+++ b/.github/workflows/repo-meta-tests.yaml
@@ -23,6 +23,7 @@ jobs:
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
+          install-quarto: false
           extra-packages: |
             any::roxygen2
 

--- a/.github/workflows/test-coverage-examples.yaml
+++ b/.github/workflows/test-coverage-examples.yaml
@@ -21,6 +21,7 @@ jobs:
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
+          install-quarto: false
           extra-packages: |
             any::covr
             local::.

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -24,6 +24,7 @@ jobs:
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
+          install-quarto: false
           extra-packages: any::covr, any::xml2
           needs: coverage
 

--- a/.github/workflows/test-package-vigilant.yaml
+++ b/.github/workflows/test-package-vigilant.yaml
@@ -22,6 +22,7 @@ jobs:
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
+          install-quarto: false
           extra-packages: local::.
 
       - name: Run Tests


### PR DESCRIPTION
Explicitly set to `false` because the GHA is finding our test.qmd file and assuming we need Quarto:

https://github.com/r-lib/actions/blob/v2-branch/setup-r-dependencies/action.yaml#L50-L55