### PR TITLE
Fix false positive for null coalescing without else clause

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -56,7 +56,7 @@
 * `download_file_linter()` encourages the use of `mode = "wb"` (or `mode = "ab"`) when using `download.file()`, rather than `mode = "w"` or `mode = "a"`, as the latter can produce broken
 files in Windows (#2882, @Bisaloo).
 * `lint2df_linter()` encourages the use of the `list2DF()` function, or the `data.frame()` function when recycling is required, over the slower and less readable `do.call(cbind.data.frame, )` alternative (#2834, @Bisaloo).
-* `coalesce_linter()` encourages the use of the infix operator `x %||% y`, which is equivalent to `if (is.null(x)) y else x` (#2246, @MichaelChirico). While this has long been used in many tidyverse packages (it was added to {ggplot2} in 2008), it became part of every R installation from R 4.4.0.
+* `coalesce_linter()` encourages the use of the infix operator `x %||% y`, which is equivalent to `if (is.null(x)) y else x` (#2246, @MichaelChirico). While this has long been used in many tidyverse packages (it was added to {ggplot2} in 2008), it became part of every R installation from R 4.4.0. Thanks also to @emmanuel-ferdman for fixing a false positive before release.
 
 ### Lint accuracy fixes: removing false positives
 

--- a/R/coalesce_linter.R
+++ b/R/coalesce_linter.R
@@ -60,6 +60,7 @@ coalesce_linter <- function() {
   parent::expr[
     preceding-sibling::OP-EXCLAMATION
     and parent::expr/preceding-sibling::IF
+    and parent::expr/following-sibling::ELSE
     and (
       expr[2] = parent::expr/following-sibling::expr[1]
       or expr[2] = parent::expr/following-sibling::{braced_expr_cond}

--- a/tests/testthat/test-coalesce_linter.R
+++ b/tests/testthat/test-coalesce_linter.R
@@ -3,6 +3,9 @@ test_that("coalesce_linter skips allowed usage", {
 
   expect_no_lint("if (is.null(x)) y", linter)
   expect_no_lint("if (!is.null(x)) y", linter)
+  expect_no_lint("if (!is.null(x)) x", linter)
+  expect_no_lint("if (is.null(x)) x", linter)
+  expect_no_lint("c(if (!is.null(E)) E)", linter)
   expect_no_lint("if (is.null(x)) y else z", linter)
   expect_no_lint("if (!is.null(x)) x[1] else y", linter)
   expect_no_lint("if (is.null(x[1])) y else x[2]", linter)


### PR DESCRIPTION
## PR Summary
This PR fixes a bug where `coalesce_linter()` incorrectly warned for if statements without else clauses:
```r
# Before: incorrectly warned
if (!is.null(x)) x
#> Use x %||% y instead of if (!is.null(x)) x else y.
#                                            ^^^^^^^^ (doesn't exist!)

# After: correctly ignores
if (!is.null(x)) x  # no warning
```
The XPath query had two branches for detecting coalesce patterns. The first branch (for `is.null` patterns) correctly checked for an ELSE node, but the second branch (for `!is.null` patterns) was missing this check, causing false positives. Added one line (`and parent::expr/following-sibling::ELSE`) to ensure both branches only match if-else statements, not plain if statements. Includes 3 regression tests.

Fixes #2936.