### PR TITLE
check_file_listing= argument for fixed_regex_linter() to check list.dir(pattern=) [and dir()]

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -10,7 +10,7 @@
 
 * `class_equals_linter()` blocks checking class membership with `is.element(cls, class(obj))` or `is.element(class(obj), cls)`, matching existing behavior for `class(obj) %in% cls` (#2849, @MichaelChirico).
 * `sprintf_linter()` lints `sprintf()` and `gettextf()` calls with zero or one argument (#2980, @MichaelChirico).
-* `fixed_regex_linter()` encourages using the recent (R 4.6.0) `fixed = TRUE` arguments to `list.files()` and `dir()` (#3003, @MichaelChirico).
+* `fixed_regex_linter()` encourages using the recent (R 4.6.0) `fixed = TRUE` arguments to `list.files()` and `dir()` (#3003, @MichaelChirico). To avoid depending on a recent R version, the rule for `list.files()` and `dir()` can be disabled by setting `check_file_listing = FALSE`.
 
 ### Lint accuracy fixes: removing false positives
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -10,6 +10,7 @@
 
 * `class_equals_linter()` blocks checking class membership with `is.element(cls, class(obj))` or `is.element(class(obj), cls)`, matching existing behavior for `class(obj) %in% cls` (#2849, @MichaelChirico).
 * `sprintf_linter()` lints `sprintf()` and `gettextf()` calls with zero or one argument (#2980, @MichaelChirico).
+* `fixed_regex_linter()` encourages using the recent (R 4.6.0) `fixed = TRUE` arguments to `list.files()` and `dir()` (#3003, @MichaelChirico).
 
 ### Lint accuracy fixes: removing false positives
 

--- a/R/fixed_regex_linter.R
+++ b/R/fixed_regex_linter.R
@@ -132,15 +132,13 @@ fixed_regex_linter <- function(allow_unescaped = FALSE) {
     ])
   ]
     /following-sibling::expr[
-      (
-        position() = 2 - count({ in_pipe_cond })
-        and STR_CONST
-        and not(EQ_SUB)
-      ) or (
-        STR_CONST
-        and preceding-sibling::*[not(self::COMMENT)][2][
+      STR_CONST and (
+        preceding-sibling::*[not(self::COMMENT)][2][
           self::SYMBOL_SUB[text() = 'pattern' or text() = 'split']
-        ]
+        ] or (
+          position() = 2 - count({ in_pipe_cond })
+          and not(EQ_SUB)
+        )
       )
     ]
   ")

--- a/R/fixed_regex_linter.R
+++ b/R/fixed_regex_linter.R
@@ -83,7 +83,7 @@ fixed_regex_linter <- function(allow_unescaped = FALSE) {
   # regular expression pattern is the second argument
   pos_2_regex_funs <- c(
     # base functions.
-    "strsplit",
+    "dir", "list.files", "strsplit",
     # data.table functions.
     "tstrsplit",
     # stringr functions.
@@ -127,14 +127,21 @@ fixed_regex_linter <- function(allow_unescaped = FALSE) {
   pos_2_xpath <- glue("
   self::*[
     not(following-sibling::SYMBOL_SUB[
-      text() = 'fixed'
+      (text() = 'fixed' or text() = 'ignore.case')
       and following-sibling::expr[1][NUM_CONST[text() = 'TRUE'] or SYMBOL[text() = 'T']]
     ])
   ]
     /following-sibling::expr[
-      position() = 2 - count({ in_pipe_cond })
-      and STR_CONST
-      and not(EQ_SUB)
+      (
+        position() = 2 - count({ in_pipe_cond })
+        and STR_CONST
+        and not(EQ_SUB)
+      ) or (
+        STR_CONST
+        and preceding-sibling::*[not(self::COMMENT)][2][
+          self::SYMBOL_SUB[text() = 'pattern' or text() = 'split']
+        ]
+      )
     ]
   ")
 

--- a/R/fixed_regex_linter.R
+++ b/R/fixed_regex_linter.R
@@ -12,10 +12,9 @@
 #'
 #' @param allow_unescaped Logical, default `FALSE`. If `TRUE`, only patterns that
 #'   require regex escapes (e.g. `"\\$"` or `"[$]"`) will be linted. See examples.
-#' @param check_file_listing Logical, default `TRUE`. If `TRUE`, [list.files()] and [dir()]
-#'   are checked for static patterns. Since `fixed = TRUE` for file listing functions
-#'   was introduced in R 4.6.0, packages requiring compatibility with earlier R versions
-#'   can set this to `FALSE`.
+#' @param check_file_listing Logical, default `TRUE`, governing whether to require
+#'   [list.files()] and [dir()] to use `fixed = TRUE` for non-regex `pattern=`. Note
+#'   that `fixed = TRUE` is only available from R 4.6.0.
 #' @examples
 #' # will produce lints
 #' code_lines <- 'gsub("\\\\.", "", x)'
@@ -49,7 +48,7 @@
 #'
 #' lint(
 #'   text = 'list.files(pattern = "RDS")',
-#'   linters = fixed_regex_linter()
+#'   linters = fixed_regex_linter(check_file_listing = TRUE)
 #' )
 #'
 #' # okay
@@ -82,12 +81,7 @@
 #'
 #' lint(
 #'   text = 'list.files(pattern = "RDS", fixed = TRUE)',
-#'   linters = fixed_regex_linter()
-#' )
-#'
-#' lint(
-#'   text = 'list.files(pattern = "RDS")',
-#'   linters = fixed_regex_linter(check_file_listing = FALSE)
+#'   linters = fixed_regex_linter(check_file_listing = TRUE)
 #' )
 #'
 #' @evalRd rd_tags("fixed_regex_linter")
@@ -100,12 +94,10 @@ fixed_regex_linter <- function(allow_unescaped = FALSE, check_file_listing = TRU
     "grep", "grepv", "gsub", "sub", "regexec", "grepl", "regexpr", "gregexpr"
   )
 
-  file_listing_funs <- if (check_file_listing) c("dir", "list.files")
-
   # regular expression pattern is the second argument
   pos_2_regex_funs <- c(
     # base functions.
-    file_listing_funs, "strsplit",
+    "strsplit", if (check_file_listing) c("dir", "list.files"),
     # data.table functions.
     "tstrsplit",
     # stringr functions.

--- a/R/fixed_regex_linter.R
+++ b/R/fixed_regex_linter.R
@@ -127,14 +127,14 @@ fixed_regex_linter <- function(allow_unescaped = FALSE, check_file_listing = TRU
     ])
   ]
     /following-sibling::expr[
-      (
-        position() = 1
-        and STR_CONST
-        and not(EQ_SUB)
-        and not({ in_pipe_cond })
-      ) or (
-        STR_CONST
-        and preceding-sibling::*[not(self::COMMENT)][2][self::SYMBOL_SUB/text() = 'pattern']
+      STR_CONST and (
+        preceding-sibling::*[not(self::COMMENT)][2][
+          self::SYMBOL_SUB[text() = 'pattern']
+        ] or (
+          position() = 1
+          and not(preceding-sibling::*[not(self::COMMENT)][1][self::EQ_SUB])
+          and not({ in_pipe_cond })
+        )
       )
     ]
   ")
@@ -151,7 +151,7 @@ fixed_regex_linter <- function(allow_unescaped = FALSE, check_file_listing = TRU
           self::SYMBOL_SUB[text() = 'pattern' or text() = 'split']
         ] or (
           position() = 2 - count({ in_pipe_cond })
-          and not(EQ_SUB)
+          and not(preceding-sibling::*[not(self::COMMENT)][1][self::EQ_SUB])
         )
       )
     ]

--- a/R/fixed_regex_linter.R
+++ b/R/fixed_regex_linter.R
@@ -12,6 +12,10 @@
 #'
 #' @param allow_unescaped Logical, default `FALSE`. If `TRUE`, only patterns that
 #'   require regex escapes (e.g. `"\\$"` or `"[$]"`) will be linted. See examples.
+#' @param check_file_listing Logical, default `TRUE`. If `TRUE`, [list.files()] and [dir()]
+#'   are checked for static patterns. Since `fixed = TRUE` for file listing functions
+#'   was introduced in R 4.6.0, packages requiring compatibility with earlier R versions
+#'   can set this to `FALSE`.
 #' @examples
 #' # will produce lints
 #' code_lines <- 'gsub("\\\\.", "", x)'
@@ -43,6 +47,11 @@
 #'   linters = fixed_regex_linter()
 #' )
 #'
+#' lint(
+#'   text = 'list.files(pattern = "RDS")',
+#'   linters = fixed_regex_linter()
+#' )
+#'
 #' # okay
 #' code_lines <- 'gsub("\\\\.", "", x, fixed = TRUE)'
 #' writeLines(code_lines)
@@ -71,19 +80,32 @@
 #'   linters = fixed_regex_linter(allow_unescaped = TRUE)
 #' )
 #'
+#' lint(
+#'   text = 'list.files(pattern = "RDS", fixed = TRUE)',
+#'   linters = fixed_regex_linter()
+#' )
+#'
+#' lint(
+#'   text = 'list.files(pattern = "RDS")',
+#'   linters = fixed_regex_linter(check_file_listing = FALSE)
+#' )
+#'
 #' @evalRd rd_tags("fixed_regex_linter")
 #' @seealso [linters] for a complete list of linters available in lintr.
 #' @export
-fixed_regex_linter <- function(allow_unescaped = FALSE) {
+# TODO(R>=4.6.0): Deprecate check_file_listing once R 4.6.0 is the minimum supported version.
+fixed_regex_linter <- function(allow_unescaped = FALSE, check_file_listing = TRUE) {
   # regular expression pattern is the first argument
   pos_1_regex_funs <- c(
     "grep", "grepv", "gsub", "sub", "regexec", "grepl", "regexpr", "gregexpr"
   )
 
+  file_listing_funs <- if (check_file_listing) c("dir", "list.files")
+
   # regular expression pattern is the second argument
   pos_2_regex_funs <- c(
     # base functions.
-    "dir", "list.files", "strsplit",
+    file_listing_funs, "strsplit",
     # data.table functions.
     "tstrsplit",
     # stringr functions.

--- a/R/fixed_regex_linter.R
+++ b/R/fixed_regex_linter.R
@@ -128,9 +128,8 @@ fixed_regex_linter <- function(allow_unescaped = FALSE, check_file_listing = TRU
   ]
     /following-sibling::expr[
       STR_CONST and (
-        preceding-sibling::*[not(self::COMMENT)][2][
-          self::SYMBOL_SUB[text() = 'pattern']
-        ] or (
+        preceding-sibling::*[not(self::COMMENT)][2][self::SYMBOL_SUB[text() = 'pattern']]
+        or (
           position() = 1
           and not(preceding-sibling::*[not(self::COMMENT)][1][self::EQ_SUB])
           and not({ in_pipe_cond })

--- a/R/fixed_regex_linter.R
+++ b/R/fixed_regex_linter.R
@@ -128,7 +128,7 @@ fixed_regex_linter <- function(allow_unescaped = FALSE, check_file_listing = TRU
   ]
     /following-sibling::expr[
       STR_CONST and (
-        preceding-sibling::*[not(self::COMMENT)][2][self::SYMBOL_SUB[text() = 'pattern']]
+        preceding-sibling::*[not(self::COMMENT)][2]/self::SYMBOL_SUB[text() = 'pattern']
         or (
           position() = 1
           and not(preceding-sibling::*[not(self::COMMENT)][1][self::EQ_SUB])
@@ -146,9 +146,8 @@ fixed_regex_linter <- function(allow_unescaped = FALSE, check_file_listing = TRU
   ]
     /following-sibling::expr[
       STR_CONST and (
-        preceding-sibling::*[not(self::COMMENT)][2][
-          self::SYMBOL_SUB[text() = 'pattern' or text() = 'split']
-        ] or (
+        preceding-sibling::*[not(self::COMMENT)][2]/self::SYMBOL_SUB[text() = 'pattern' or text() = 'split']
+        or (
           position() = 2 - count({ in_pipe_cond })
           and not(preceding-sibling::*[not(self::COMMENT)][1][self::EQ_SUB])
         )

--- a/man/fixed_regex_linter.Rd
+++ b/man/fixed_regex_linter.Rd
@@ -4,11 +4,16 @@
 \alias{fixed_regex_linter}
 \title{Require usage of \code{fixed=TRUE} in regular expressions where appropriate}
 \usage{
-fixed_regex_linter(allow_unescaped = FALSE)
+fixed_regex_linter(allow_unescaped = FALSE, check_file_listing = TRUE)
 }
 \arguments{
 \item{allow_unescaped}{Logical, default \code{FALSE}. If \code{TRUE}, only patterns that
 require regex escapes (e.g. \code{"\\\\$"} or \code{"[$]"}) will be linted. See examples.}
+
+\item{check_file_listing}{Logical, default \code{TRUE}. If \code{TRUE}, \code{\link[=list.files]{list.files()}} and \code{\link[=dir]{dir()}}
+are checked for static patterns. Since \code{fixed = TRUE} for file listing functions
+was introduced in R 4.6.0, packages requiring compatibility with earlier R versions
+can set this to \code{FALSE}.}
 }
 \description{
 Invoking a regular expression engine is overkill for cases when the search
@@ -53,6 +58,11 @@ lint(
   linters = fixed_regex_linter()
 )
 
+lint(
+  text = 'list.files(pattern = "RDS")',
+  linters = fixed_regex_linter()
+)
+
 # okay
 code_lines <- 'gsub("\\\\\\\\.", "", x, fixed = TRUE)'
 writeLines(code_lines)
@@ -79,6 +89,16 @@ lint(
 lint(
   text = 'grepl("Munich", address)',
   linters = fixed_regex_linter(allow_unescaped = TRUE)
+)
+
+lint(
+  text = 'list.files(pattern = "RDS", fixed = TRUE)',
+  linters = fixed_regex_linter()
+)
+
+lint(
+  text = 'list.files(pattern = "RDS")',
+  linters = fixed_regex_linter(check_file_listing = FALSE)
 )
 
 }

--- a/man/fixed_regex_linter.Rd
+++ b/man/fixed_regex_linter.Rd
@@ -10,10 +10,9 @@ fixed_regex_linter(allow_unescaped = FALSE, check_file_listing = TRUE)
 \item{allow_unescaped}{Logical, default \code{FALSE}. If \code{TRUE}, only patterns that
 require regex escapes (e.g. \code{"\\\\$"} or \code{"[$]"}) will be linted. See examples.}
 
-\item{check_file_listing}{Logical, default \code{TRUE}. If \code{TRUE}, \code{\link[=list.files]{list.files()}} and \code{\link[=dir]{dir()}}
-are checked for static patterns. Since \code{fixed = TRUE} for file listing functions
-was introduced in R 4.6.0, packages requiring compatibility with earlier R versions
-can set this to \code{FALSE}.}
+\item{check_file_listing}{Logical, default \code{TRUE}, governing whether to require
+\code{\link[=list.files]{list.files()}} and \code{\link[=dir]{dir()}} to use \code{fixed = TRUE} for non-regex \verb{pattern=}. Note
+that \code{fixed = TRUE} is only available from R 4.6.0.}
 }
 \description{
 Invoking a regular expression engine is overkill for cases when the search
@@ -60,7 +59,7 @@ lint(
 
 lint(
   text = 'list.files(pattern = "RDS")',
-  linters = fixed_regex_linter()
+  linters = fixed_regex_linter(check_file_listing = TRUE)
 )
 
 # okay
@@ -93,12 +92,7 @@ lint(
 
 lint(
   text = 'list.files(pattern = "RDS", fixed = TRUE)',
-  linters = fixed_regex_linter()
-)
-
-lint(
-  text = 'list.files(pattern = "RDS")',
-  linters = fixed_regex_linter(check_file_listing = FALSE)
+  linters = fixed_regex_linter(check_file_listing = TRUE)
 )
 
 }

--- a/tests/testthat/test-fixed_regex_linter.R
+++ b/tests/testthat/test-fixed_regex_linter.R
@@ -410,10 +410,6 @@ test_that("fixed_regex_linter checks realistic list.files and dir usages", {
   expect_no_lint('dir("data", pattern = "abc", fixed = TRUE, full.names = TRUE)', linter)
   expect_no_lint('dir("data", pattern = "abc", ignore.case = TRUE, recursive = TRUE)', linter)
 
-  # allowed positional pattern usages
-  expect_no_lint('list.files("data", "^test$")', linter)
-  expect_no_lint(R'{dir("data", "\\.R$")}', linter)
-
   # disallowed usages where static or escaped literal patterns are passed with typical configuration arguments
   expect_lint('list.files(pattern = "_analysis", full.names = TRUE)', lint_msg, linter)
   expect_lint('list.files(pattern = "prepare_", full.names = TRUE)', lint_msg, linter)
@@ -422,6 +418,15 @@ test_that("fixed_regex_linter checks realistic list.files and dir usages", {
   expect_lint('dir(recursive = TRUE, full.names = TRUE, pattern = "solved")', lint_msg, linter)
   expect_lint(R'{"data" |> list.files(pattern = "_bmarks\\.csv", full.names = TRUE)}', lint_msg, linter)
   expect_lint('"data" |> list.files(pattern = "_bmarks[.]csv", full.names = TRUE)', lint_msg, linter)
+})
+
+test_that("pattern= inferred positionally is handled correctly", {
+  linter <- fixed_regex_linter()
+  lint_msg <- "This regular expression is static"
+
+  # position= inferred positionally
+  expect_no_lint('list.files("data", "^test$")', linter)
+  expect_no_lint(R'{dir("data", "\\.R$")}', linter)
 
   # disallowed positional pattern usages (including pipelines)
   expect_lint('list.files("data", "RDS")', lint_msg, linter)
@@ -443,16 +448,13 @@ test_that("check_file_listing allows disabling file listing checks while retaini
   expect_no_lint('dir(recursive = TRUE, full.names = TRUE, pattern = "solved")', linter)
   expect_no_lint('dir("data", "pdf")', linter)
 
-  # pos_1_regex_funs still enforced
+  # other behavior of the linter continues WAI
   expect_lint("grepl('abcdefg', x)", lint_msg, linter)
   expect_lint("gsub('[.]', '', x)", lint_msg, linter)
   expect_lint("sub('a[*]b', 'c', x)", lint_msg, linter)
-
-  # other pos_2_regex_funs still strictly enforced when check_file_listing = FALSE
   expect_lint(R'{strsplit(x, "\\.")}', lint_msg, linter)
   expect_lint("tstrsplit(x, 'abcdefg')", lint_msg, linter)
   expect_lint("str_detect(x, 'abcdefg')", lint_msg, linter)
   expect_lint(R'{str_subset(x, "\\$")}', lint_msg, linter)
   expect_lint(R'{str_replace_all(x, "\\.", "")}', lint_msg, linter)
 })
-

--- a/tests/testthat/test-fixed_regex_linter.R
+++ b/tests/testthat/test-fixed_regex_linter.R
@@ -420,3 +420,11 @@ test_that("fixed_regex_linter checks realistic list.files and dir usages", {
   expect_lint(R'{"data" |> list.files(pattern = "_bmarks\\.csv", full.names = TRUE)}', lint_msg, linter)
   expect_lint('"data" |> list.files(pattern = "_bmarks[.]csv", full.names = TRUE)', lint_msg, linter)
 })
+
+test_that("check_file_listing allows disabling file listing checks", {
+  linter <- fixed_regex_linter(check_file_listing = FALSE)
+
+  expect_no_lint('list.files(pattern = "_analysis", full.names = TRUE)', linter)
+  expect_no_lint('dir(recursive = TRUE, full.names = TRUE, pattern = "solved")', linter)
+  expect_lint("grepl('abcdefg', x)", "This regular expression is static", linter)
+})

--- a/tests/testthat/test-fixed_regex_linter.R
+++ b/tests/testthat/test-fixed_regex_linter.R
@@ -410,21 +410,49 @@ test_that("fixed_regex_linter checks realistic list.files and dir usages", {
   expect_no_lint('dir("data", pattern = "abc", fixed = TRUE, full.names = TRUE)', linter)
   expect_no_lint('dir("data", pattern = "abc", ignore.case = TRUE, recursive = TRUE)', linter)
 
+  # allowed positional pattern usages
+  expect_no_lint('list.files("data", "^test$")', linter)
+  expect_no_lint(R'{dir("data", "\\.R$")}', linter)
+
   # disallowed usages where static or escaped literal patterns are passed with typical configuration arguments
   expect_lint('list.files(pattern = "_analysis", full.names = TRUE)', lint_msg, linter)
   expect_lint('list.files(pattern = "prepare_", full.names = TRUE)', lint_msg, linter)
   expect_lint('list.files("data/raw", pattern = "RDS", full.names = TRUE, recursive = TRUE)', lint_msg, linter)
-  expect_lint('list.files("data", "RDS", full.names = TRUE, recursive = TRUE)', lint_msg, linter)
   expect_lint('dir("data", pattern = "pdf", recursive = TRUE)', lint_msg, linter)
   expect_lint('dir(recursive = TRUE, full.names = TRUE, pattern = "solved")', lint_msg, linter)
   expect_lint(R'{"data" |> list.files(pattern = "_bmarks\\.csv", full.names = TRUE)}', lint_msg, linter)
   expect_lint('"data" |> list.files(pattern = "_bmarks[.]csv", full.names = TRUE)', lint_msg, linter)
+
+  # disallowed positional pattern usages (including pipelines)
+  expect_lint('list.files("data", "RDS")', lint_msg, linter)
+  expect_lint('list.files("data", "RDS", full.names = TRUE, recursive = TRUE)', lint_msg, linter)
+  expect_lint('list.files("src", "prepare_")', lint_msg, linter)
+  expect_lint('dir("data", "pdf")', lint_msg, linter)
+  expect_lint('dir("source", "_analysis")', lint_msg, linter)
+  expect_lint('"data" |> list.files("RDS")', lint_msg, linter)
+  expect_lint('"data" %>% dir("RDS")', lint_msg, linter)
 })
 
-test_that("check_file_listing allows disabling file listing checks", {
+test_that("check_file_listing allows disabling file listing checks while retaining standard behavior", {
   linter <- fixed_regex_linter(check_file_listing = FALSE)
+  lint_msg <- "This regular expression is static"
 
+  # file listing functions skipped when option is disabled
   expect_no_lint('list.files(pattern = "_analysis", full.names = TRUE)', linter)
+  expect_no_lint('list.files("data", "RDS")', linter)
   expect_no_lint('dir(recursive = TRUE, full.names = TRUE, pattern = "solved")', linter)
-  expect_lint("grepl('abcdefg', x)", "This regular expression is static", linter)
+  expect_no_lint('dir("data", "pdf")', linter)
+
+  # pos_1_regex_funs still enforced
+  expect_lint("grepl('abcdefg', x)", lint_msg, linter)
+  expect_lint("gsub('[.]', '', x)", lint_msg, linter)
+  expect_lint("sub('a[*]b', 'c', x)", lint_msg, linter)
+
+  # other pos_2_regex_funs still strictly enforced when check_file_listing = FALSE
+  expect_lint(R'{strsplit(x, "\\.")}', lint_msg, linter)
+  expect_lint("tstrsplit(x, 'abcdefg')", lint_msg, linter)
+  expect_lint("str_detect(x, 'abcdefg')", lint_msg, linter)
+  expect_lint(R'{str_subset(x, "\\$")}', lint_msg, linter)
+  expect_lint(R'{str_replace_all(x, "\\.", "")}', lint_msg, linter)
 })
+

--- a/tests/testthat/test-fixed_regex_linter.R
+++ b/tests/testthat/test-fixed_regex_linter.R
@@ -248,6 +248,13 @@ test_that("fixed replacements vectorize and recognize str_detect", {
     rex::rex('Use stringr::fixed("abc") as the pattern'),
     linter
   )
+
+  # list.files hint works
+  expect_lint(
+    'list.files(pattern = "RDS")',
+    rex::rex('Use "RDS" with fixed = TRUE here'),
+    linter
+  )
 })
 
 test_that("fixed replacement is correct with UTF-8", {
@@ -342,7 +349,9 @@ test_that("'unescaped' regex can optionally be skipped", {
 
   expect_no_lint("grepl('a', x)", linter)
   expect_no_lint("str_detect(x, 'a')", linter)
+  expect_no_lint('list.files(pattern = "RDS")', linter)
   expect_lint("grepl('[$]', x)", rex::rex('Use "$" with fixed = TRUE'), linter)
+  expect_lint(R'{list.files(pattern = "RDS\\.csv")}', rex::rex('Use "RDS.csv" with fixed = TRUE'), linter)
 })
 
 local({
@@ -410,6 +419,15 @@ test_that("fixed_regex_linter checks realistic list.files and dir usages", {
   expect_no_lint('dir("data", pattern = "abc", fixed = TRUE, full.names = TRUE)', linter)
   expect_no_lint('dir("data", pattern = "abc", ignore.case = TRUE, recursive = TRUE)', linter)
 
+  # non-pattern named arguments at position 1 or 2 are not falsely flagged
+  expect_no_lint('list.files("data", full.names = "foo")', linter)
+  expect_no_lint('dir("data", recursive = "solved")', linter)
+  expect_no_lint('gsub(x = "abc", replacement = "def")', linter)
+
+  # explicit fixed = FALSE or ignore.case = FALSE does not suppress lint
+  expect_lint('list.files(pattern = "RDS", fixed = FALSE)', lint_msg, linter)
+  expect_lint('dir("data", pattern = "pdf", ignore.case = FALSE)', lint_msg, linter)
+
   # disallowed usages where static or escaped literal patterns are passed with typical configuration arguments
   expect_lint('list.files(pattern = "_analysis", full.names = TRUE)', lint_msg, linter)
   expect_lint('list.files(pattern = "prepare_", full.names = TRUE)', lint_msg, linter)
@@ -424,7 +442,7 @@ test_that("pattern= inferred positionally is handled correctly", {
   linter <- fixed_regex_linter()
   lint_msg <- "This regular expression is static"
 
-  # position= inferred positionally
+  # pattern= inferred positionally
   expect_no_lint('list.files("data", "^test$")', linter)
   expect_no_lint(R'{dir("data", "\\.R$")}', linter)
 

--- a/tests/testthat/test-fixed_regex_linter.R
+++ b/tests/testthat/test-fixed_regex_linter.R
@@ -397,18 +397,18 @@ test_that("fixed_regex_linter checks realistic list.files and dir usages", {
 
   # allowed usages with realistic regex patterns, flags, and paths
   expect_no_lint(R'{list.files("src", pattern = ".*\\.o$", full.names = TRUE)}', linter)
-  expect_no_lint(R'{list.files(pattern = "csv$", full.names = TRUE)}', linter)
+  expect_no_lint('list.files(pattern = "csv$", full.names = TRUE)', linter)
   expect_no_lint(R'{list.files("./source/", pattern = "^\\d{2}-.*\\.md$", full.names = TRUE)}', linter)
-  expect_no_lint(R'{list.files(pattern = paste0(prefix, "[[:alnum:]_]+_result.rds"), recursive = TRUE)}', linter)
+  expect_no_lint('list.files(pattern = paste0(prefix, "[[:alnum:]_]+_result.rds"), recursive = TRUE)', linter)
   expect_no_lint(R'{list.files("data", pattern = "\\.rds$", ignore.case = TRUE, recursive = TRUE)}', linter)
-  expect_no_lint(R'{list.files(pattern = "_analysis", fixed = TRUE, recursive = TRUE)}', linter)
-  expect_no_lint(R'{list.files("foo", full.names = TRUE, recursive = TRUE)}', linter)
+  expect_no_lint('list.files(pattern = "_analysis", fixed = TRUE, recursive = TRUE)', linter)
+  expect_no_lint('list.files("foo", full.names = TRUE, recursive = TRUE)', linter)
   expect_no_lint(R'{getwd() |> list.files(pattern = ".*\\.RData$")}', linter)
 
   expect_no_lint(R'{dir("data", pattern = "\\.(wav|png)$", full.names = TRUE)}', linter)
-  expect_no_lint(R'{dir("data", pattern = "^abc", recursive = TRUE)}', linter)
-  expect_no_lint(R'{dir("data", pattern = "abc", fixed = TRUE, full.names = TRUE)}', linter)
-  expect_no_lint(R'{dir("data", pattern = "abc", ignore.case = TRUE, recursive = TRUE)}', linter)
+  expect_no_lint('dir("data", pattern = "^abc", recursive = TRUE)', linter)
+  expect_no_lint('dir("data", pattern = "abc", fixed = TRUE, full.names = TRUE)', linter)
+  expect_no_lint('dir("data", pattern = "abc", ignore.case = TRUE, recursive = TRUE)', linter)
 
   # disallowed usages where static or escaped literal patterns are passed with typical configuration arguments
   expect_lint('list.files(pattern = "_analysis", full.names = TRUE)', lint_msg, linter)
@@ -418,7 +418,5 @@ test_that("fixed_regex_linter checks realistic list.files and dir usages", {
   expect_lint('dir("data", pattern = "pdf", recursive = TRUE)', lint_msg, linter)
   expect_lint('dir(recursive = TRUE, full.names = TRUE, pattern = "solved")', lint_msg, linter)
   expect_lint(R'{"data" |> list.files(pattern = "_bmarks\\.csv", full.names = TRUE)}', lint_msg, linter)
-  expect_lint(R'{"data" |> list.files(pattern = "_bmarks[.]csv", full.names = TRUE)}', lint_msg, linter)
+  expect_lint('"data" |> list.files(pattern = "_bmarks[.]csv", full.names = TRUE)', lint_msg, linter)
 })
-
-

--- a/tests/testthat/test-fixed_regex_linter.R
+++ b/tests/testthat/test-fixed_regex_linter.R
@@ -390,3 +390,35 @@ test_that("fixed_regex_linter properly simplifies escaped character groups and c
   expect_lint(R'[grep("\u0020", x)]', lint_message, linter)
   expect_lint(R'[grep("\\u0020", x)]', lint_message, linter)
 })
+
+test_that("fixed_regex_linter checks realistic list.files and dir usages", {
+  linter <- fixed_regex_linter()
+  lint_msg <- "This regular expression is static"
+
+  # allowed usages with realistic regex patterns, flags, and paths
+  expect_no_lint(R'{list.files("src", pattern = ".*\\.o$", full.names = TRUE)}', linter)
+  expect_no_lint(R'{list.files(pattern = "csv$", full.names = TRUE)}', linter)
+  expect_no_lint(R'{list.files("./source/", pattern = "^\\d{2}-.*\\.md$", full.names = TRUE)}', linter)
+  expect_no_lint(R'{list.files(pattern = paste0(prefix, "[[:alnum:]_]+_result.rds"), recursive = TRUE)}', linter)
+  expect_no_lint(R'{list.files("data", pattern = "\\.rds$", ignore.case = TRUE, recursive = TRUE)}', linter)
+  expect_no_lint(R'{list.files(pattern = "_analysis", fixed = TRUE, recursive = TRUE)}', linter)
+  expect_no_lint(R'{list.files("foo", full.names = TRUE, recursive = TRUE)}', linter)
+  expect_no_lint(R'{getwd() |> list.files(pattern = ".*\\.RData$")}', linter)
+
+  expect_no_lint(R'{dir("data", pattern = "\\.(wav|png)$", full.names = TRUE)}', linter)
+  expect_no_lint(R'{dir("data", pattern = "^abc", recursive = TRUE)}', linter)
+  expect_no_lint(R'{dir("data", pattern = "abc", fixed = TRUE, full.names = TRUE)}', linter)
+  expect_no_lint(R'{dir("data", pattern = "abc", ignore.case = TRUE, recursive = TRUE)}', linter)
+
+  # disallowed usages where static or escaped literal patterns are passed with typical configuration arguments
+  expect_lint('list.files(pattern = "_analysis", full.names = TRUE)', lint_msg, linter)
+  expect_lint('list.files(pattern = "prepare_", full.names = TRUE)', lint_msg, linter)
+  expect_lint('list.files("data/raw", pattern = "RDS", full.names = TRUE, recursive = TRUE)', lint_msg, linter)
+  expect_lint('list.files("data", "RDS", full.names = TRUE, recursive = TRUE)', lint_msg, linter)
+  expect_lint('dir("data", pattern = "pdf", recursive = TRUE)', lint_msg, linter)
+  expect_lint('dir(recursive = TRUE, full.names = TRUE, pattern = "solved")', lint_msg, linter)
+  expect_lint(R'{"data" |> list.files(pattern = "_bmarks\\.csv", full.names = TRUE)}', lint_msg, linter)
+  expect_lint(R'{"data" |> list.files(pattern = "_bmarks[.]csv", full.names = TRUE)}', lint_msg, linter)
+})
+
+


### PR DESCRIPTION
Closes #3003.

 - Not super married to the argument name `check_file_listing`, any other suggestions?
 - I _think_ `TRUE` is a good default, but maybe we should only do that once X% of CRAN packages are requiring 4.6.0?