### PR TITLE
Vectorize get_fixed_string

### DIFF
--- a/R/fixed_regex_linter.R
+++ b/R/fixed_regex_linter.R
@@ -168,7 +168,7 @@ fixed_regex_linter <- function(allow_unescaped = FALSE, check_file_listing = TRU
     patterns <- patterns[is_static]
     pattern_strings <- pattern_strings[is_static]
 
-    fixed_equivalent <- encodeString(get_fixed_string(pattern_strings), quote = '"', justify = "none")
+    fixed_equivalent <- get_fixed_string(pattern_strings)
     call_name <- xml_find_chr_(patterns, "string(preceding-sibling::expr[last()]/SYMBOL_FUNCTION_CALL)")
 
     is_stringr <- startsWith(call_name, "str_")

--- a/R/shared_constants.R
+++ b/R/shared_constants.R
@@ -117,9 +117,9 @@ get_fixed_string <- function(static_regex) {
     return(character())
   }
   static_regex <- static_regex |>
-    gsub(rx_trivial_char_group, "\\1", x = _, perl = TRUE) |>
+    gsub(pattern = rx_trivial_char_group, replacement = "\\1", perl = TRUE) |>
     decode_escapes() |>
-    gsub(rx_escapable_regex, "\\1", x = _, perl = TRUE) |>
+    gsub(pattern = rx_escapable_regex, replacement = "\\1", perl = TRUE) |>
     encodeString(quote = '"', justify = "none")
 
   static_regex

--- a/R/shared_constants.R
+++ b/R/shared_constants.R
@@ -19,8 +19,8 @@ rx_static_escape <- local({
     "]"
   )
   rex(or(
-    capture(rx_char_escape, name = "char_escape"),
-    capture(rx_trivial_char_group, name = "trivial_char_group")
+    rx_char_escape,
+    rx_trivial_char_group
   ))
 })
 
@@ -35,8 +35,7 @@ rx_unescaped_regex <- paste0("(?s)", rex(start, zero_or_more(rx_non_active_char)
 rx_static_regex <- paste0("(?s)", rex(start, zero_or_more(rx_static_token), end))
 rx_escapable_tokens <- "^${}().*+?|[]\\<>=:;/_-!@#%&,~"
 rx_escapable_regex <- rex("\\", capture(one_of(rx_escapable_tokens)))
-rx_trivial_char_group <- paste0("(?s)", rex(
-  "[",
+rx_trivial_char_group <- paste0("(?s)(?<!\\\\)(?:\\\\\\\\)*\\K\\[", rex(
   capture(or(
     group("\\", or(
       group("x", between(xdigit, 1L, 2L)),
@@ -48,9 +47,55 @@ rx_trivial_char_group <- paste0("(?s)", rex(
       none_of("dswDSW")
     )),
     any
-  )),
-  "]"
-))
+  ))
+), "\\]")
+
+rx_esc_num <- paste0(
+  "(?s)(?<!\\\\)(?:\\\\\\\\)*\\K\\\\",
+  rex(or(
+    group("x", between(xdigit, 1L, 2L)),
+    group("u{", between(xdigit, 1L, 4L), "}"),
+    group("u", between(xdigit, 1L, 4L)),
+    group("U{", between(xdigit, 1L, 8L), "}"),
+    group("U", between(xdigit, 1L, 8L)),
+    between("0":"7", 1L, 3L)
+  ))
+)
+
+decode_escape_token <- function(esc) {
+  code <- if (startsWith(esc, "x")) {
+    strtoi(substr(esc, 2L, nchar(esc)), 16L)
+  } else if (startsWith(esc, "u{") || startsWith(esc, "U{")) {
+    strtoi(substr(esc, 3L, nchar(esc) - 1L), 16L)
+  } else if (startsWith(esc, "u") || startsWith(esc, "U")) {
+    strtoi(substr(esc, 2L, nchar(esc)), 16L)
+  } else {
+    strtoi(esc, 8L)
+  }
+  if (is.na(code) || code == 0L) {
+    ""
+  } else {
+    intToUtf8(code)
+  }
+}
+
+decode_escapes <- function(s) {
+  m <- gregexpr(rx_esc_num, s, perl = TRUE)
+  has_esc <- vapply(m, \(pos) any(pos != -1L), logical(1L))
+  if (!any(has_esc)) {
+    return(s)
+  }
+  matches <- regmatches(s, m)
+  decoded <- lapply(matches, \(vec) {
+    if (length(vec) == 0L) {
+      return(character(0L))
+    }
+    raw_esc <- substr(vec, 2L, nchar(vec))
+    vapply(raw_esc, decode_escape_token, character(1L), USE.NAMES = FALSE)
+  })
+  regmatches(s, m) <- decoded
+  s
+}
 
 #' Determine whether a regex pattern actually uses regex patterns
 #'
@@ -76,9 +121,9 @@ is_not_regex <- function(str, allow_unescaped = FALSE) {
 
 #' Compute a fixed string equivalent to a static regular expression
 #'
-#' @param static_regex A character vector of regex patterns for which `is_not_regex()` returns `TRUE`
-#' @return A quoted string such that `grepl(static_regex, x)` is equivalent to
-#'   `eval(parse(text = sprintf("grepl(%s, x, fixed = TRUE)", get_fixed_string(static_regex))))`
+#' @param static_regex A character vector of regex patterns for which `is_not_regex()` returns `TRUE`.
+#' @return A character vector of quoted strings such that `grepl(static_regex, x)` is equivalent to
+#'   `eval(parse(text = sprintf("grepl(%s, x, fixed = TRUE)", get_fixed_string(static_regex))))`.
 #'
 #' @noRd
 get_fixed_string <- function(static_regex) {
@@ -86,17 +131,9 @@ get_fixed_string <- function(static_regex) {
     return(character())
   }
   static_regex <- gsub(rx_trivial_char_group, "\\1", static_regex, perl = TRUE)
+  static_regex <- decode_escapes(static_regex)
   static_regex <- gsub(rx_escapable_regex, "\\1", static_regex, perl = TRUE)
 
-  has_esc <- grepl("\\\\[0-9a-fA-FxuUabefnrtv]", static_regex)
-  if (any(has_esc)) {
-    static_regex[has_esc] <- vapply(
-      static_regex[has_esc],
-      function(s) eval(parse(text = paste0('"', s, '"'))),
-      character(1L),
-      USE.NAMES = FALSE
-    )
-  }
   encodeString(static_regex, quote = '"', justify = "none")
 }
 

--- a/R/shared_constants.R
+++ b/R/shared_constants.R
@@ -116,11 +116,13 @@ get_fixed_string <- function(static_regex) {
   if (length(static_regex) == 0L) {
     return(character())
   }
-  static_regex <- gsub(rx_trivial_char_group, "\\1", static_regex, perl = TRUE)
-  static_regex <- decode_escapes(static_regex)
-  static_regex <- gsub(rx_escapable_regex, "\\1", static_regex, perl = TRUE)
+  static_regex <- static_regex |>
+    gsub(rx_trivial_char_group, "\\1", x = _, perl = TRUE) |>
+    decode_escapes() |>
+    gsub(rx_escapable_regex, "\\1", x = _, perl = TRUE) |>
+    encodeString(quote = '"', justify = "none")
 
-  encodeString(static_regex, quote = '"', justify = "none")
+  static_regex
 }
 
 # some metadata about infix operators on the R parse tree.

--- a/R/shared_constants.R
+++ b/R/shared_constants.R
@@ -74,7 +74,7 @@ decode_escapes <- function(s) {
   if (any(is_hex)) {
     codes[is_hex] <- strtoi(gsub("[^0-9a-fA-F]", "", all_vec[is_hex]), base = 16L)
   }
-  if (any(!is_hex)) {
+  if (!all(is_hex)) {
     codes[!is_hex] <- strtoi(substr(all_vec[!is_hex], 2L, 4L), base = 8L)
   }
   codes[is.na(codes)] <- 0L

--- a/R/shared_constants.R
+++ b/R/shared_constants.R
@@ -62,38 +62,24 @@ rx_esc_num <- paste0(
   ))
 )
 
-decode_escape_token <- function(esc) {
-  code <- if (startsWith(esc, "x")) {
-    strtoi(substr(esc, 2L, nchar(esc)), 16L)
-  } else if (startsWith(esc, "u{") || startsWith(esc, "U{")) {
-    strtoi(substr(esc, 3L, nchar(esc) - 1L), 16L)
-  } else if (startsWith(esc, "u") || startsWith(esc, "U")) {
-    strtoi(substr(esc, 2L, nchar(esc)), 16L)
-  } else {
-    strtoi(esc, 8L)
-  }
-  if (is.na(code) || code == 0L) {
-    ""
-  } else {
-    intToUtf8(code)
-  }
-}
-
 decode_escapes <- function(s) {
   m <- gregexpr(rx_esc_num, s, perl = TRUE)
-  has_esc <- vapply(m, \(pos) any(pos != -1L), logical(1L))
-  if (!any(has_esc)) {
+  matches <- regmatches(s, m)
+  all_vec <- unlist(matches, use.names = FALSE)
+  if (length(all_vec) == 0L) {
     return(s)
   }
-  matches <- regmatches(s, m)
-  decoded <- lapply(matches, \(vec) {
-    if (length(vec) == 0L) {
-      return(character(0L))
-    }
-    raw_esc <- substr(vec, 2L, nchar(vec))
-    vapply(raw_esc, decode_escape_token, character(1L), USE.NAMES = FALSE)
-  })
-  regmatches(s, m) <- decoded
+  is_hex <- grepl("^\\\\[xuU]", all_vec)
+  codes <- integer(length(all_vec))
+  if (any(is_hex)) {
+    codes[is_hex] <- strtoi(gsub("[^0-9a-fA-F]", "", all_vec[is_hex]), base = 16L)
+  }
+  if (any(!is_hex)) {
+    codes[!is_hex] <- strtoi(substr(all_vec[!is_hex], 2L, 4L), base = 8L)
+  }
+  codes[is.na(codes)] <- 0L
+  all_chars <- intToUtf8(codes, multiple = TRUE)
+  regmatches(s, m) <- relist(all_chars, matches)
   s
 }
 

--- a/R/shared_constants.R
+++ b/R/shared_constants.R
@@ -33,8 +33,24 @@ rx_static_token <- local({
 
 rx_unescaped_regex <- paste0("(?s)", rex(start, zero_or_more(rx_non_active_char), end))
 rx_static_regex <- paste0("(?s)", rex(start, zero_or_more(rx_static_token), end))
-rx_first_static_token <- paste0("(?s)", rex(start, zero_or_more(rx_non_active_char), rx_static_escape))
 rx_escapable_tokens <- "^${}().*+?|[]\\<>=:;/_-!@#%&,~"
+rx_escapable_regex <- rex("\\", capture(one_of(rx_escapable_tokens)))
+rx_trivial_char_group <- paste0("(?s)", rex(
+  "[",
+  capture(or(
+    group("\\", or(
+      group("x", between(xdigit, 1L, 2L)),
+      between("0":"7", 1L, 3L),
+      group("u{", between(xdigit, 1L, 4L), "}"),
+      group("u", between(xdigit, 1L, 4L)),
+      group("U{", between(xdigit, 1L, 8L), "}"),
+      group("U", between(xdigit, 1L, 8L)),
+      none_of("dswDSW")
+    )),
+    any
+  )),
+  "]"
+))
 
 #' Determine whether a regex pattern actually uses regex patterns
 #'
@@ -60,54 +76,28 @@ is_not_regex <- function(str, allow_unescaped = FALSE) {
 
 #' Compute a fixed string equivalent to a static regular expression
 #'
-#' @param static_regex A regex for which `is_not_regex()` returns `TRUE`
-#' @return A string such that `grepl(static_regex, x)` is equivalent to
-#' `grepl(get_fixed_string(static_regex), x, fixed = TRUE)`
+#' @param static_regex A character vector of regex patterns for which `is_not_regex()` returns `TRUE`
+#' @return A quoted string such that `grepl(static_regex, x)` is equivalent to
+#'   `eval(parse(text = sprintf("grepl(%s, x, fixed = TRUE)", get_fixed_string(static_regex))))`
 #'
 #' @noRd
 get_fixed_string <- function(static_regex) {
   if (length(static_regex) == 0L) {
     return(character())
-  } else if (length(static_regex) > 1L) {
-    return(vapply(static_regex, get_fixed_string, character(1L)))
   }
-  fixed_string <- ""
-  current_match <- regexpr(rx_first_static_token, static_regex, perl = TRUE)
-  while (current_match != -1L) {
-    token_type <- attr(current_match, "capture.names")[attr(current_match, "capture.start") > 0L]
-    token_start <- max(attr(current_match, "capture.start"))
-    if (token_start > 1L) {
-      fixed_string <- paste0(fixed_string, substr(static_regex, 1L, token_start - 1L))
-    }
-    consume_to <- attr(current_match, "match.length")
-    token_content <- substr(static_regex, token_start, consume_to)
-    fixed_string <- paste0(fixed_string, get_token_replacement(token_content, token_type))
-    static_regex <- substr(static_regex, start = consume_to + 1L, stop = nchar(static_regex))
-    current_match <- regexpr(rx_first_static_token, static_regex, perl = TRUE)
-  }
-  paste0(fixed_string, static_regex)
-}
+  static_regex <- gsub(rx_trivial_char_group, "\\1", static_regex, perl = TRUE)
+  static_regex <- gsub(rx_escapable_regex, "\\1", static_regex, perl = TRUE)
 
-#' Get a fixed string equivalent to a regular expression token
-#'
-#' This handles two cases: converting a "trivial" character group like `[$]` to `$`,
-#'   and converting an escaped character like `"\\$"` to `$`. Splitting a full expression
-#'   into tokens is handled by `get_fixed_string()`.
-#'
-#' @noRd
-get_token_replacement <- function(token_content, token_type) {
-  if (token_type == "trivial_char_group") { # otherwise, char_escape
-    token_content <- substr(token_content, start = 2L, stop = nchar(token_content) - 1L)
-    if (startsWith(token_content, "\\")) { # escape within trivial char group
-      get_token_replacement(token_content, "char_escape")
-    } else {
-      token_content
-    }
-  } else if (re_matches(token_content, rex("\\", one_of(rx_escapable_tokens)))) {
-    substr(token_content, start = 2L, stop = nchar(token_content))
-  } else {
-    eval(parse(text = paste0('"', token_content, '"')))
+  has_esc <- grepl("\\\\[0-9a-fA-FxuUabefnrtv]", static_regex)
+  if (any(has_esc)) {
+    static_regex[has_esc] <- vapply(
+      static_regex[has_esc],
+      function(s) eval(parse(text = paste0('"', s, '"'))),
+      character(1L),
+      USE.NAMES = FALSE
+    )
   }
+  encodeString(static_regex, quote = '"', justify = "none")
 }
 
 # some metadata about infix operators on the R parse tree.

--- a/R/shared_constants.R
+++ b/R/shared_constants.R
@@ -35,7 +35,7 @@ rx_unescaped_regex <- paste0("(?s)", rex(start, zero_or_more(rx_non_active_char)
 rx_static_regex <- paste0("(?s)", rex(start, zero_or_more(rx_static_token), end))
 rx_escapable_tokens <- "^${}().*+?|[]\\<>=:;/_-!@#%&,~"
 rx_escapable_regex <- rex("\\", capture(one_of(rx_escapable_tokens)))
-rx_trivial_char_group <- paste0("(?s)(?<!\\\\)(?:\\\\\\\\)*\\K\\[", rex(
+rx_trivial_char_group <- paste0(R"{(?s)(?<!\\)(?:\\\\)*\K\[}", rex(
   capture(or(
     group("\\", or(
       group("x", between(xdigit, 1L, 2L)),
@@ -51,7 +51,7 @@ rx_trivial_char_group <- paste0("(?s)(?<!\\\\)(?:\\\\\\\\)*\\K\\[", rex(
 ), "\\]")
 
 rx_esc_num <- paste0(
-  "(?s)(?<!\\\\)(?:\\\\\\\\)*\\K\\\\",
+  R"{(?s)(?<!\\)(?:\\\\)*\K\\}",
   rex(or(
     group("x", between(xdigit, 1L, 2L)),
     group("u{", between(xdigit, 1L, 4L), "}"),

--- a/R/string_boundary_linter.R
+++ b/R/string_boundary_linter.R
@@ -93,7 +93,7 @@ string_boundary_linter <- function(allow_grepl = FALSE) {
     terminal_anchor <- terminal_anchor[should_lint]
     sub_patterns <- sub_patterns[should_lint]
 
-    fixed_strings <- encodeString(get_fixed_string(sub_patterns), quote = '"', justify = "none")
+    fixed_strings <- get_fixed_string(sub_patterns)
 
     lint_type <- character(length(initial_anchor))
 

--- a/tests/testthat/test-fixed_regex_linter.R
+++ b/tests/testthat/test-fixed_regex_linter.R
@@ -264,6 +264,7 @@ test_that("fixed replacements vectorize across mixed escapes, quotes, and litera
       grepl('abc"def', x)
       grepl(r"(\\n)", x)
       grepl(r"(\x41)", x)
+      grepl(r"(\123)", x)
       grepl('a[.]b', x)
       grepl(r"(\[a\])", x)
     })-"),
@@ -271,8 +272,9 @@ test_that("fixed replacements vectorize across mixed escapes, quotes, and litera
       list(rex::rex('Use "abc\\"def" with fixed = TRUE'), line_number = 2L),
       list(rex::rex('Use "\\\\n" with fixed = TRUE'), line_number = 3L),
       list(rex::rex('Use "A" with fixed = TRUE'), line_number = 4L),
-      list(rex::rex('Use "a.b" with fixed = TRUE'), line_number = 5L),
-      list(rex::rex('Use "[a]" with fixed = TRUE'), line_number = 6L)
+      list(rex::rex('Use "S" with fixed = TRUE'), line_number = 5L),
+      list(rex::rex('Use "a.b" with fixed = TRUE'), line_number = 6L),
+      list(rex::rex('Use "[a]" with fixed = TRUE'), line_number = 7L)
     ),
     linter
   )
@@ -297,13 +299,16 @@ test_that("fixed_regex_linter handles quotes, literal backslashes, and escaped b
   expect_lint(R'{grepl(r"(\\[a]\\)", x)}', rex::rex('Use "\\\\a\\\\" with fixed = TRUE'), linter)
   expect_lint(R'{grepl(r"(\\\x41)", x)}', rex::rex('Use "\\\\A" with fixed = TRUE'), linter)
 
-  # character groups with escaped delimiters
+  # character groups and escape codes
   expect_lint("grepl('[\"]', x)", rex::rex('Use "\\"" with fixed = TRUE'), linter)
   expect_lint(R'{grepl(r"([\]])", x)}', rex::rex('Use "]" with fixed = TRUE'), linter)
   expect_lint(R'{grepl(r"([\[])", x)}', rex::rex('Use "[" with fixed = TRUE'), linter)
   expect_lint(R'{grepl(r"([\\])", x)}', rex::rex('Use "\\\\" with fixed = TRUE'), linter)
   expect_lint(R'{grepl(r"([\$])", x)}', rex::rex('Use "$" with fixed = TRUE'), linter)
   expect_lint(R'{grepl(r"([\x41])", x)}', rex::rex('Use "A" with fixed = TRUE'), linter)
+  expect_lint(R'{grepl(r"(\123)", x)}', rex::rex('Use "S" with fixed = TRUE'), linter)
+  expect_lint(R'{grepl(r"([\101])", x)}', rex::rex('Use "A" with fixed = TRUE'), linter)
+  expect_lint(R'{grepl(r"([\041])", x)}', rex::rex('Use "!" with fixed = TRUE'), linter)
 
   # potential code injection payload is safely parsed as string literal without execution
   expect_lint(

--- a/tests/testthat/test-fixed_regex_linter.R
+++ b/tests/testthat/test-fixed_regex_linter.R
@@ -257,6 +257,62 @@ test_that("fixed replacements vectorize and recognize str_detect", {
   )
 })
 
+test_that("fixed replacements vectorize across mixed escapes, quotes, and literal backslashes", {
+  linter <- fixed_regex_linter()
+  expect_lint(
+    trim_some(R"-({
+      grepl('abc"def', x)
+      grepl(r"(\\n)", x)
+      grepl(r"(\x41)", x)
+      grepl('a[.]b', x)
+      grepl(r"(\[a\])", x)
+    })-"),
+    list(
+      list(rex::rex('Use "abc\\"def" with fixed = TRUE'), line_number = 2L),
+      list(rex::rex('Use "\\\\n" with fixed = TRUE'), line_number = 3L),
+      list(rex::rex('Use "A" with fixed = TRUE'), line_number = 4L),
+      list(rex::rex('Use "a.b" with fixed = TRUE'), line_number = 5L),
+      list(rex::rex('Use "[a]" with fixed = TRUE'), line_number = 6L)
+    ),
+    linter
+  )
+})
+
+test_that("fixed_regex_linter handles quotes, literal backslashes, and escaped brackets safely", {
+  linter <- fixed_regex_linter()
+
+  # quotes in regex are safely escaped without syntax errors
+  expect_lint("grepl('foo\"bar', x)", rex::rex('Use "foo\\"bar" with fixed = TRUE'), linter)
+  expect_lint('grepl(r"(a"b)", x)', rex::rex('Use "a\\"b" with fixed = TRUE'), linter)
+  expect_lint("grepl('a\"\\\\x41', x)", rex::rex('Use "a\\"A" with fixed = TRUE'), linter)
+
+  # literal backslashes are preserved and not conflated with active escape codes
+  expect_lint(R'{grepl(r"(\\n)", x)}', rex::rex('Use "\\\\n" with fixed = TRUE'), linter)
+  expect_lint(R'{grepl(r"(\\t)", x)}', rex::rex('Use "\\\\t" with fixed = TRUE'), linter)
+  expect_lint(R'{grepl(r"(\\u0020)", x)}', rex::rex('Use "\\\\u0020" with fixed = TRUE'), linter)
+  expect_lint(R'{grepl(r"(\\123)", x)}', rex::rex('Use "\\\\123" with fixed = TRUE'), linter)
+
+  # escaped brackets and backslashes preceding escapes
+  expect_lint(R'{grepl(r"(\[a\])", x)}', rex::rex('Use "[a]" with fixed = TRUE'), linter)
+  expect_lint(R'{grepl(r"(\\[a]\\)", x)}', rex::rex('Use "\\\\a\\\\" with fixed = TRUE'), linter)
+  expect_lint(R'{grepl(r"(\\\x41)", x)}', rex::rex('Use "\\\\A" with fixed = TRUE'), linter)
+
+  # character groups with escaped delimiters
+  expect_lint("grepl('[\"]', x)", rex::rex('Use "\\"" with fixed = TRUE'), linter)
+  expect_lint(R'{grepl(r"([\]])", x)}', rex::rex('Use "]" with fixed = TRUE'), linter)
+  expect_lint(R'{grepl(r"([\[])", x)}', rex::rex('Use "[" with fixed = TRUE'), linter)
+  expect_lint(R'{grepl(r"([\\])", x)}', rex::rex('Use "\\\\" with fixed = TRUE'), linter)
+  expect_lint(R'{grepl(r"([\$])", x)}', rex::rex('Use "$" with fixed = TRUE'), linter)
+  expect_lint(R'{grepl(r"([\x41])", x)}', rex::rex('Use "A" with fixed = TRUE'), linter)
+
+  # potential code injection payload is safely parsed as string literal without execution
+  expect_lint(
+    'grepl(r"-(; system\\("id"\\); a <- "\\x41)-", x)',
+    rex::rex('Use "; system(\\"id\\"); a <- \\"A" with fixed = TRUE'),
+    linter
+  )
+})
+
 test_that("fixed replacement is correct with UTF-8", {
   skip_if(
     .Platform$OS.type == "windows" && !hasName(R.Version(), "crt"),


### PR DESCRIPTION
#3102 re-uses this, and in both sites, `encodeString()` wraps the output.

I wanted to absorb this `encodeString()` call to the helper, and found the natural way to do so to vectorize the loop (an alternative is to split into two helpers, one to get a fixed regex from a single string, the other wrapping that).