### PR TITLE
Handle #line directives in get_source_expressions() (#3106)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,7 @@
 ## New and improved features
 
 * `lint()` gains support for passing both `filename` and `text` simultaneously. The `filename` is used for file identity (settings discovery, exclusion handling, knitr detection, and display) while `text` provides the content, so the file need not exist on disk. This is useful for IDE/LSP integrations where the editor has unsaved changes (#3017, @atusy).
+* `get_source_expressions()` no longer errors with "subscript out of bounds" on code containing a `#line` directive; such directives are now treated as comments, matching the behavior of `getParseData()` in R >= 4.7.0 (#3106, @youdie006).
 * Non-R code chunks in R Markdown and Quarto documents (such as `{extendr}` or `{ojs}`) are no longer parsed and linted as R code (#1896, @MichaelChirico).
 
 ### New linters

--- a/R/get_source_expressions.R
+++ b/R/get_source_expressions.R
@@ -577,7 +577,7 @@ get_source_expression <- function(source_expression, error = identity) {
   }
 
   source_expression$parsed_content <- parsed_content
-  fix_octal_escapes(fix_tab_indentations(source_expression), source_expression$lines)
+  fix_line_directives(fix_octal_escapes(fix_tab_indentations(source_expression), source_expression$lines))
 }
 
 maybe_append_expression_xml <- function(expressions, xml_parsed_content) {
@@ -682,6 +682,47 @@ top_level_expressions <- function(pc) {
     return(integer(0L))
   }
   which(pc$parent <= 0L)
+}
+
+# `#line` directives are parser directives, not expressions; {lintr} has no reason to treat one as
+#   anything other than a comment, and leaving it labelled LINE_DIRECTIVE means the rare file that
+#   really uses the construct can produce subtly wrong lints.
+# Relabelling alone is not enough. R also declines to treat LINE_DIRECTIVE as comment-like when it
+#   assigns parents, with two consequences: the directive itself is left an orphan (parent 0), and a
+#   neighbouring COMMENT can be attached to the directive instead of skipping over it (parent
+#   -<directive id>). Either way a positionally nested node is reported with parent <= 0, so
+#   top_level_expressions() counts it while xmlparsedata::xml_parse_data() -- which nests purely by
+#   source position -- does not emit a matching /exprlist/* node, and zipping the two errors (#3106).
+#   Fixed in r-devel (PR#19137, https://bugs.r-project.org/show_bug.cgi?id=19137) by making
+#   finalizeData() treat LINE_DIRECTIVE as comment-like:
+#   https://github.com/r-devel/r-svn/commit/5a482292547659cf25163d96ff1ef15b22dc82e8
+# TODO(R>=4.7.0): remove the re-parenting below; the COMMENT relabelling is ours to keep.
+fix_line_directives <- function(pc) {
+  is_directive <- pc$token == "LINE_DIRECTIVE"
+  if (!any(is_directive)) {
+    return(pc)
+  }
+  pc$token[is_directive] <- "COMMENT"
+
+  # Only files using the directive reach here, so plain comments elsewhere keep R's parents.
+  orphans <- which(pc$token == "COMMENT" & pc$parent <= 0L)
+  if (length(orphans) == 0L) {
+    return(pc)
+  }
+  # Encode positions exactly as xml_parse_data() does, so the parent assigned here always agrees
+  #   with where the node actually lands in the XML.
+  max_col <- max(pc$col1, pc$col2) + 1L
+  node_start <- pc$line1 * max_col + pc$col1
+  node_end <- pc$line2 * max_col + pc$col2
+  for (ii in orphans) {
+    encloses <- !pc$terminal & node_start <= node_start[ii] & node_end >= node_end[ii]
+    if (!any(encloses)) {
+      next
+    }
+    # innermost enclosing node, i.e. the one spanning the fewest characters
+    pc$parent[ii] <- pc$id[which(encloses)[which.min((node_end - node_start)[encloses])]]
+  }
+  pc
 }
 
 # workaround for bad parse data bug for octal escapes

--- a/tests/testthat/test-get_source_expressions.R
+++ b/tests/testthat/test-get_source_expressions.R
@@ -584,3 +584,116 @@ test_that("get_source_expressions() handles unmarked UTF-8 lines correctly", {
   expect_identical(str_const$col1, 6L)
   expect_identical(str_const$col2, 8L)
 })
+
+# `#line` directives, #3106. NB R < 4.4.0 discards the parse data for any file containing one --
+# getParseData() returns NULL there, so lintr only ever sees the whole-file expression and the
+# directive has no representation left to test. The structural expectations are gated on that; the
+# "doesn't error" and "doesn't lint" guards are not, since erroring is what regressed.
+line_directive_cases <- list(
+  "inside braces" = c("{", '#line 1 "foo.R"', "1 + 1", "}"),
+  "at top level" = c('#line 10 "x.R"', "1 + 1", "2 + 2"),
+  "nested two deep" = c(
+    "x <- function() {",
+    '#line 2 "b.R"',
+    "  identity({",
+    '#line 3 "c.R"',
+    "    1",
+    "  })",
+    "}"
+  ),
+  "next to comments" = c('#line 1 "a.R"', "# hi", "1", "{", "# there", '#line 2 "b.R"', "2", "}")
+)
+
+patrick::with_parameters_test_that(
+  "get_source_expressions() survives a #line directive",
+  {
+    tmp <- withr::local_tempfile(lines = lines)
+    src_exprs <- expect_silent(get_source_expressions(tmp))
+    expect_null(src_exprs$error)
+  },
+  .test_name = names(line_directive_cases),
+  lines = unname(line_directive_cases)
+)
+
+test_that("a #line directive on its own attracts no lints (#3106)", {
+  expect_no_lint(paste(line_directive_cases[["at top level"]], collapse = "\n"), linters = default_linters)
+})
+
+test_that("get_source_expressions() treats #line directives as comments (#3106)", {
+  skip_unless_r(">= 4.4.0")
+
+  # R leaves a LINE_DIRECTIVE orphaned at the top level instead of attaching it to the enclosing
+  # expression the way it attaches a comment, so the expression list used to be one entry longer
+  # than the list of /exprlist/* nodes, and zipping the two errored.
+  tmp <- withr::local_tempfile(lines = line_directive_cases[["inside braces"]])
+
+  src_exprs <- get_source_expressions(tmp)
+
+  # the braced expression, plus the appended full-file expression
+  expect_length(src_exprs$expressions, 2L)
+
+  expr <- src_exprs$expressions[[1L]]
+  expect_false("LINE_DIRECTIVE" %in% expr$parsed_content$token)
+  expect_length(xml2::xml_find_all(expr$xml_parsed_content, "//LINE_DIRECTIVE"), 0L)
+  expect_identical(
+    xml2::xml_text(xml2::xml_find_all(expr$xml_parsed_content, "//COMMENT")),
+    '#line 1 "foo.R"'
+  )
+})
+
+test_that("#line directives at the top level stay top-level comments (#3106)", {
+  skip_unless_r(">= 4.4.0")
+
+  tmp <- withr::local_tempfile(lines = line_directive_cases[["at top level"]])
+
+  src_exprs <- get_source_expressions(tmp)
+
+  # the directive (like any top-level comment), both expressions, plus the full-file expression
+  expect_length(src_exprs$expressions, 4L)
+  expect_identical(
+    xml2::xml_text(
+      xml2::xml_find_all(src_exprs$expressions[[4L]]$full_xml_parsed_content, "/exprlist/COMMENT")
+    ),
+    '#line 10 "x.R"'
+  )
+})
+
+test_that("get_source_expressions() handles #line directives nested several levels deep (#3106)", {
+  skip_unless_r(">= 4.4.0")
+
+  tmp <- withr::local_tempfile(lines = line_directive_cases[["nested two deep"]])
+
+  src_exprs <- get_source_expressions(tmp)
+
+  # the assignment, plus the appended full-file expression
+  expect_length(src_exprs$expressions, 2L)
+  expect_identical(
+    xml2::xml_text(xml2::xml_find_all(src_exprs$expressions[[1L]]$xml_parsed_content, "//COMMENT")),
+    c('#line 2 "b.R"', '#line 3 "c.R"')
+  )
+})
+
+test_that("a comment neighbouring a #line directive keeps its own parent (#3106)", {
+  skip_unless_r(">= 4.4.0")
+
+  # R attaches a comment to the following token, and before 4.7.0 it does not skip a LINE_DIRECTIVE
+  # while doing so, so '# there' below is recorded as a child of the directive rather than of the
+  # braced expression that positionally contains it.
+  tmp <- withr::local_tempfile(lines = line_directive_cases[["next to comments"]])
+
+  src_exprs <- get_source_expressions(tmp)
+
+  # both top-level comments, both top-level expressions, plus the appended full-file expression
+  expect_length(src_exprs$expressions, 5L)
+
+  global_xml <- src_exprs$expressions[[5L]]$full_xml_parsed_content
+  # the two comments inside the braces are nested, not top-level
+  expect_identical(
+    xml2::xml_text(xml2::xml_find_all(global_xml, "/exprlist/COMMENT")),
+    c('#line 1 "a.R"', "# hi")
+  )
+  expect_identical(
+    xml2::xml_text(xml2::xml_find_all(global_xml, "/exprlist/expr/COMMENT")),
+    c("# there", '#line 2 "b.R"')
+  )
+})


### PR DESCRIPTION
Fixes #3106.

### Root cause

A `#line` directive resets the R parser's line numbering. Because of that, `getParseData()` can report the `LINE_DIRECTIVE` row with `parent == 0`, so `top_level_expressions()` (which is `which(pc$parent <= 0L)`) counts it as a top-level expression. But `xmlparsedata` does not always surface the directive as a top-level `/exprlist/*` node. The two lists then have different lengths, and `maybe_append_expression_xml()` zips them positionally:

```r
for (i in seq_along(expressions)) {
  expressions[[i]]$xml_parsed_content <- expression_xmls[[i]]  # subscript out of bounds
```

Repro from the issue:

```r
writeLines(con = tmp <- tempfile(), c("{", '#line 1 "foo.R"', "1+1", "}"))
lintr::get_source_expressions(tmp)
#> Error in expression_xmls[[i]] : subscript out of bounds
```

I confirmed the desync directly: for that input `top_level_expressions()` returns 2 rows (`expr` + `LINE_DIRECTIVE`) while `/exprlist/*` returns 1 (`expr`).

### Fix

`LINE_DIRECTIVE` is a parser directive, not an expression, so it should never be paired with an XML expression node. I exclude it on **both** sides so the two lists stay aligned in every configuration:

- `top_level_expressions()`: `which(pc$parent <= 0L & pc$token != "LINE_DIRECTIVE")`
- the XML selection: `/exprlist/*[not(self::LINE_DIRECTIVE)]`

Excluding it on only one side would re-introduce a desync in the plain top-level `#line` case (where `xmlparsedata` *does* list the directive), so both are needed. I verified alignment (and that linting still works and reports physical line numbers) across: a `#line` inside a block, a `#line` at top level, multiple `#line` directives, plain comments, and no directive.

This follows your suggestion in the issue to "add it to the set of things that we fix up coming from the R parser." Happy to adjust if you'd prefer neutralizing the directive earlier in the pipeline instead.

### Test

Added a regression test in `test-get_source_expressions.R`. Red-green verified with `devtools::test(filter = "get_source_expressions")`: before the change the new test errors with `subscript out of bounds`; after, the whole file passes. `lintr::lint()` on the changed files is clean; `NEWS.md` updated.

---
Disclosure: I used AI assistance (Claude) while preparing this change. I root-caused the desync, ran the tests (red-green), and take responsibility for the contribution.
