### PR TITLE
string_boundary_linter: recognize zero start offsets

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -22,6 +22,7 @@
 
 * `vector_logic_linter()` again finds `&&`/`||` usage in filtering expressions in function bodies like `\() filter(x, A && B)` (#3082, @MichaelChirico).
 * `seq_linter()` now flags `seq(1, n)` and `seq(from = 1, to = n)` calls, recommending `seq_len()` or `seq_along()` (#2661, @MichaelChirico).
+* `string_boundary_linter()` now recommends `startsWith()` for `substr()` and `substring()` comparisons whose start position is `0` (#3029, @fly1d).
 
 # lintr (3.4.0)
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -22,7 +22,7 @@
 
 * `vector_logic_linter()` again finds `&&`/`||` usage in filtering expressions in function bodies like `\() filter(x, A && B)` (#3082, @MichaelChirico).
 * `seq_linter()` now flags `seq(1, n)` and `seq(from = 1, to = n)` calls, recommending `seq_len()` or `seq_along()` (#2661, @MichaelChirico).
-* `string_boundary_linter()` now recommends `startsWith()` for `substr()` and `substring()` comparisons whose start position is `0` (#3029, @fly1d).
+* `string_boundary_linter()` also recommends `startsWith()` for `substr(s, 0, n)` and `substring(s, 0, n)` (#3029, @fly1d).
 
 # lintr (3.4.0)
 

--- a/R/string_boundary_linter.R
+++ b/R/string_boundary_linter.R
@@ -121,7 +121,7 @@ string_boundary_linter <- function(allow_grepl = FALSE) {
   self::*[expr/expr[
     (
       position() = 3
-      and NUM_CONST[text() = '1' or text() = '1L']
+      and NUM_CONST[text() = '0' or text() = '0L' or text() = '1' or text() = '1L']
     ) or (
       position() = 4
       and expr[1][SYMBOL_FUNCTION_CALL[text() = 'nchar']]
@@ -166,10 +166,10 @@ string_boundary_linter <- function(allow_grepl = FALSE) {
     is_str_comparison <- !is.na(xml_find_first_(substr_calls, string_comparison_xpath))
     substr_calls <- strip_comments_from_subtree(substr_calls[is_str_comparison])
     substr_expr <- xml_find_all_(substr_calls, substr_xpath)
-    substr_one <- xml_find_chr_(substr_expr, substr_arg2_xpath) %in% c("1", "1L")
+    substr_initial <- xml_find_chr_(substr_expr, substr_arg2_xpath) %in% c("0", "0L", "1", "1L")
     substr_lint_message <- paste(
       ifelse(
-        substr_one,
+        substr_initial,
         "Use startsWith() to detect an initial substring.",
         "Use endsWith() to detect a terminal substring."
       ),

--- a/tests/testthat/test-string_boundary_linter.R
+++ b/tests/testthat/test-string_boundary_linter.R
@@ -171,7 +171,7 @@ test_that("vectorization + metadata work as intended", {
 
   expect_lint(
     trim_some("{
-      substring(a, 0, 3) == 'abc'
+      substring(a, 1, 3) == 'abc'
       substring(b, nchar(b) - 3, nchar(b)) == 'defg'
       substr(c, 1, 3) == 'hij'
       substr(d, nchar(d) - 3, nchar(d)) == 'klmn'

--- a/tests/testthat/test-string_boundary_linter.R
+++ b/tests/testthat/test-string_boundary_linter.R
@@ -94,6 +94,8 @@ test_that("string_boundary_linter blocks disallowed substr()/substring() usage",
   starts_message <- rex::rex("Use startsWith() to detect an initial substring.")
   ends_message <- rex::rex("Use endsWith() to detect a terminal substring.")
 
+  expect_lint("substr(x, 0, 1) == 'a'", starts_message, linter)
+  expect_lint("substring(x, 0L, 1L) == 'a'", starts_message, linter)
   expect_lint("substr(x, 1L, 2L) == 'ab'", starts_message, linter)
   # end doesn't matter, just anchoring to 1L
   expect_lint("substr(x, 1L, end) == 'ab'", starts_message, linter)
@@ -169,7 +171,7 @@ test_that("vectorization + metadata work as intended", {
 
   expect_lint(
     trim_some("{
-      substring(a, 1, 3) == 'abc'
+      substring(a, 0, 3) == 'abc'
       substring(b, nchar(b) - 3, nchar(b)) == 'defg'
       substr(c, 1, 3) == 'hij'
       substr(d, nchar(d) - 3, nchar(d)) == 'klmn'


### PR DESCRIPTION
## Summary

- recognize `0` and `0L` as initial boundaries in `substr()` and `substring()` comparisons
- classify those matches as `startsWith()` recommendations
- add focused and vectorized regression coverage plus a NEWS entry

Fixes #3029.

## Verification

- `options(warn = 2); testthat::test_file("tests/testthat/test-string_boundary_linter.R")` - 53 passed, 0 failures, 0 warnings, 0 skips
- `lint_package(".")` using the installed working-tree package and all Suggests - 0 lints
- `testthat::test_local(reporter = "summary")` - full test suite passed
- `R CMD build --no-manual` followed by `R CMD check --no-manual` on the source tarball - `Status: OK`

## AI assistance

OpenAI Codex (GPT-5) assisted with implementation, tests, and verification.