### PR TITLE
Correctly exclude print-only lints under implicit_assignment_linter(allow_paren_print=TRUE)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,7 @@
 ## Bug fixes
 
 * `unnecessary_lambda_linter()` doesn't error when encountering multiple comparison-only lambdas like `\(x) x == 1` (#3116, @MichaelChirico).
+* `implicit_assignment_linter(allow_paren_print = TRUE)` correctly excludes lints for `(a <- 1)` when other true positives are _also_ present (#3117, @MichaelChirico).
 
 ## New and improved features
 

--- a/R/implicit_assignment_linter.R
+++ b/R/implicit_assignment_linter.R
@@ -134,12 +134,15 @@ implicit_assignment_linter <- function(except = c("bquote", "expression", "expr"
     print_only <- !is.na(xml_find_first_(bad_expr, "parent::expr[parent::exprlist and *[1][self::OP-LEFT-PAREN]]"))
     if (allow_paren_print) {
       bad_expr <- bad_expr[!print_only]
+      lint_message <- implicit_message
+    } else {
+      lint_message <- ifelse(print_only, print_message, implicit_message)
     }
 
     xml_nodes_to_lints(
       bad_expr,
       source_expression = source_expression,
-      lint_message = ifelse(print_only, print_message, implicit_message),
+      lint_message = lint_message,
       type = "warning"
     )
   })

--- a/tests/testthat/test-implicit_assignment_linter.R
+++ b/tests/testthat/test-implicit_assignment_linter.R
@@ -508,11 +508,10 @@ test_that("call-less '(' mentions avoiding implicit printing", {
 })
 
 test_that("allow_paren_print allows `(` for auto printing", {
-  lint_message <- rex::rex("Avoid implicit assignments in function calls.")
   linter <- implicit_assignment_linter(allow_paren_print = TRUE)
   expect_no_lint("(a <- foo())", linter)
 
-  # Doesn't effect other cases
+  # Doesn't affect other cases
   lint_message <- rex::rex("Avoid implicit assignments in function calls.")
   expect_lint("if (x <- 1L) TRUE", lint_message, linter)
   expect_lint("while (x <- 0L) FALSE", lint_message, linter)

--- a/tests/testthat/test-implicit_assignment_linter.R
+++ b/tests/testthat/test-implicit_assignment_linter.R
@@ -522,5 +522,15 @@ test_that("allow_paren_print allows `(` for auto printing", {
   # default remains as is
   print_msg <- rex::rex("Call print() explicitly instead of relying on implicit printing behavior via '('.")
   expect_lint("(a <- foo())", print_msg, implicit_assignment_linter())
+
+  # vectorizes correctly
+  expect_lint(
+    trim_some("
+      (a <- 1L)
+      mean(b <- 2L)
+    "),
+    list(list(lint_message, line_number = 2L)),
+    linter
+  )
 })
 # fuzzer enable: assignment


### PR DESCRIPTION
Closes #3117 