### PR TITLE
is_numeric_linter works under adversarial commenting

### DIFF
--- a/R/is_numeric_linter.R
+++ b/R/is_numeric_linter.R
@@ -111,6 +111,7 @@ is_numeric_linter <- function() {
     if (has_both_calls) {
       all_or <- xml_find_all_(xml, "//OR2/parent::expr")
       or_expr <- all_or[vapply(all_or, is_or_root, logical(1L))] |>
+        strip_comments_from_subtree() |>
         lapply(\(root) check_or_tree(root)$lints) |>
         unlist(recursive = FALSE)
       or_lints <- xml_nodes_to_lints(

--- a/tests/testthat/test-is_numeric_linter.R
+++ b/tests/testthat/test-is_numeric_linter.R
@@ -58,7 +58,7 @@ test_that("is_numeric_linter blocks disallowed usages involving ||", {
   expect_lint("is.numeric(a) || is.integer(x = a)", lint_msg, linter)
   expect_lint("base::is.numeric(x) || base::is.integer(x)", lint_msg, linter)
 
-  # line breaks don't matter
+  # line breaks and comments don't matter
   lines <- trim_some("
     if (
       is.integer(x)
@@ -66,6 +66,19 @@ test_that("is_numeric_linter blocks disallowed usages involving ||", {
     ) TRUE
   ")
   expect_lint(lines, lint_msg, linter)
+  expect_lint(
+    trim_some("
+      is.numeric( # comment
+        foo(x)
+      ) || is.integer( # comment
+        foo( # comment
+          x # comment
+        ) # comment
+      )
+    "),
+    lint_msg,
+    linter
+  )
 
   # caught when nesting
   expect_lint("all(y > 5) && (is.integer(x) || is.numeric(x))", lint_msg, linter)


### PR DESCRIPTION
Follow-up to #3105.

My spidey-sense was tingling about this during the re-work process of review but it wasn't originally caught by `ast-fuzz` so I let it slide, of course it started firing the moment it reached `main` :)