### PR TITLE
Fix: False positive lints with Library call nested args

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -23,6 +23,7 @@
 ### Lint accuracy fixes: removing false positives
 
 * `unreachable_code_linter()` no longer flags cases like `switch(x, a = stop("invalid value"))` where `stop()` is in a nested call (#3084, @MichaelChirico).
+* `library_call_linter()` no longer flags later `library()` calls when an earlier attach call uses a function in its arguments, e.g. `library(pkg, exclude = c("foo"))` (#3097, @fabiandistler).
 
 ### Lint accuracy fixes: removing false negatives
 

--- a/R/library_call_linter.R
+++ b/R/library_call_linter.R
@@ -86,7 +86,10 @@ library_call_linter <- function(allow_preamble = TRUE) {
   attach_call_cond <- xp_text_in_table(attach_calls)
   suppress_call_cond <- xp_text_in_table(c("suppressMessages", "suppressPackageStartupMessages"))
 
-  unsuppressed_call_cond <- glue("not( {xp_or(attach_call_cond, suppress_call_cond)} )")
+  unsuppressed_call_cond <- xp_and(
+    glue("not( {xp_or(attach_call_cond, suppress_call_cond)} )"),
+    glue("not(ancestor::expr[expr/SYMBOL_FUNCTION_CALL[{ attach_call_cond }]])")
+  )
   if (allow_preamble) {
     unsuppressed_call_cond <- xp_and(
       unsuppressed_call_cond,


### PR DESCRIPTION
 > Analysis and draft assisted by an AI tool; I reproduced, reviewed and tested the change myself.

Fixes #3097 